### PR TITLE
BPTL Dashboard: Added BPTL landing page & Kit Assembly placeholder

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ import { shippingDashboard } from "./src/pages/shipping.js"
 import {reportsQuery } from "./src/pages/reportsQuery.js"
 import { signIn, signOut } from "./src/pages/signIn.js";
 import { welcomeScreen } from "./src/pages/welcome.js";
-
+import { bptlScreen } from "./src/pages/bptl.js";
+import { kitAssemblyScreen } from "./src/pages/homeCollection/kitAssembly.js";
 let auth = '';
 
 window.onload = () => {
@@ -30,10 +31,11 @@ window.onhashchange = () => {
 const manageRoutes = async () => {
     const route =  window.location.hash || '#';
     if(await userLoggedIn()){
-        console.log('route: ' + route)
         if (route === '#dashboard') userDashboard(auth, route);
         else if(route === "#shipping") shippingDashboard(auth,route);
         else if (route === '#welcome') welcomeScreen(auth, route);
+        else if (route === '#bptl') bptlScreen(auth, route);
+        else if (route === '#kitassembly') kitAssemblyScreen(auth, route);
         else if (route === '#manage_users') manageUsers(auth, route);
         else if (route === '#sign_out') signOut();
         else if (route === '#reports') reportsQuery(auth, route);

--- a/src/navbar.js
+++ b/src/navbar.js
@@ -82,6 +82,11 @@ export const nonUserNavBar = (name) => {
                 <a class="nav-link" href="#welcome" id="welcome" title="Home"><i class="fas fa-home"></i> Home</a>
             </li>
         </div>
+        <div class="navbar-nav">
+            <li class="nav-item">
+                <a class="nav-link" href="#bptl" id="bptl" title="Home"><i class="fa fa-id-badge"></i> BPTL</a>
+            </li>
+        </div>
         <div class="navbar-nav ml-auto">
             <div class="grid-elements dropdown">
                 <button class="nav-link nav-menu-links dropdown-toggle dropdown-btn"  title="Welcome, ${name}!" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/src/pages/bptl.js
+++ b/src/pages/bptl.js
@@ -1,0 +1,68 @@
+import { validateUser, siteFullNames, showAnimation, hideAnimation, errorMessage, removeAllErrors } from "./../shared.js";
+import { kitAssemblyScreen } from "./homeCollection/kitAssembly.js";
+import { nonUserNavBar, unAuthorizedUser } from './../navbar.js'
+
+export const bptlScreen = async (auth, route) => {
+    const user = auth.currentUser;
+    if(!user) return;
+    const name = user.displayName ? user.displayName : user.email;
+    showAnimation();
+    const response = await validateUser();
+    hideAnimation();
+    if(response.code !== 200) {
+        document.getElementById('contentBody').innerHTML = 'Authorization failed you lack permissions to use this dashboard!';
+        document.getElementById('navbarNavAltMarkup').innerHTML = unAuthorizedUser();
+        return;
+    }
+    bptlScreenTemplate(name, response.data, auth, route);
+    redirectPageToLocation(name, auth, route);
+}
+
+const bptlScreenTemplate = (name, data, auth, route) => {
+    let template = '';
+    template += `
+        <div class="row align-center welcome-screen-div">
+            <div class="col"><h3>BPTL Dashboard</h3></div>
+        </div>
+        <div class="container overflow-hidden">
+            <div class="row gx-5">
+                <div class="col">
+                    <h4>Home Collection</h4>
+                    <div class="p-3 border bg-light"><button type="button" href="#kitassembly" class="btn btn-primary btn-lg" id="kitAssembly">Kit Assembly</button></div>
+                    <div class="p-3 border bg-light"><button type="button" class="btn btn-primary btn-lg">Print Adresses</button></div>
+                    <div class="p-3 border bg-light"><button type="button" class="btn btn-primary btn-lg">Participant Selection</button></div>
+                    <div class="p-3 border bg-light"><button type="button" class="btn btn-primary btn-lg">Participant Assignment</button></div>
+                    <div class="p-3 border bg-light"><button type="button" class="btn btn-primary btn-lg">Kit Shipment</button></div>
+                </div>
+                <div class="col">
+                    <h4>Supplies</h4>
+                    <div class="p-3 border bg-light"><button type="button" class="btn btn-primary btn-lg">Pending Requests</button></div>
+                    <div class="p-3 border bg-light"><button type="button" class="btn btn-primary btn-lg">Supply Packing</button></div>
+                    <div class="p-3 border bg-light"><button type="button" class="btn btn-primary btn-lg">Supply Shipment</button></div>
+                </div>
+                <div class="col">
+                    <h4>Receipts</h4>
+                    <div class="p-3 border bg-light"><button type="button" class="btn btn-primary btn-lg">Packages in Transit from Sites</button></div>
+                    <div class="p-3 border bg-light"><button type="button" class="btn btn-primary btn-lg">Package Receipt</button></div>
+                    <div class="p-3 border bg-light"><button type="button" class="btn btn-primary btn-lg">Home Collection Data Entry</button></div>
+                    <div class="p-3 border bg-light"><button type="button" class="btn btn-primary btn-lg">Create .csv File</button></div>
+                </div>
+                <div class="col">
+                    <h4>Reports</h4>
+                    <div class="p-3 border bg-light"><button type="button" class="btn btn-primary btn-lg">Reports</button></div>
+                </div>
+            </div>
+        </div>
+        `
+       // document.getElementById('navbarNavAltMarkup').innerHTML = nonUserNavBar(name);
+        document.getElementById('contentBody').innerHTML = template;
+}
+
+
+
+const redirectPageToLocation = (name, auth, route) => {
+    const a = document.getElementById('kitAssembly');
+    a && a.addEventListener('click',  async () => {
+        location.hash = '#kitassembly';
+    })
+}

--- a/src/pages/homeCollection/homeCollectionNavbar.js
+++ b/src/pages/homeCollection/homeCollectionNavbar.js
@@ -1,0 +1,22 @@
+export const homeCollectionNavbar = () => {
+    let template = ``;
+    template += `
+                <ul class="nav nav-tabs">
+                    <li class="nav-item">
+                    <a class="nav-link active" aria-current="page" href="#kitassembly" id="kitAssembly">Kit Assembly</a>
+                    </li>
+                    <li class="nav-item">
+                    <a class="nav-link active" aria-current="page" href="#printadresses" id="printAdresses">Print Adresses</a>
+                    </li>
+                    <li class="nav-item">
+                    <a class="nav-link active" aria-current="page" href="#participantselection" id="participantSelection">Participant Selection</a>
+                    </li>
+                    <li class="nav-item">
+                    <a class="nav-link active" aria-current="page" href="#participantassignmen" id="participantAssignment">Participant Assignment</a>
+                    </li>
+                    <li class="nav-item">
+                    <a class="nav-link active" aria-current="page" href="#kitshipment" id="kitShipment">Kit Shipment</a>
+                    </li>
+                </ul>`
+    return template;
+}

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -1,0 +1,21 @@
+import { homeCollectionNavbar } from "./homeCollectionNavbar.js";
+import { userDashboard } from "../dashboard.js";
+
+export const kitAssemblyScreen = async (auth, route) => {
+    const user = auth.currentUser;
+    if(!user) return;
+    const username = user.displayName ? user.displayName : user.email;
+    //showAnimation();
+    kitAssemblyTemplate(auth, route);
+}             
+
+
+const kitAssemblyTemplate = (auth, route) => {
+    let template = ``;
+    template += homeCollectionNavbar();
+    template += `
+                <div class="row align-center welcome-screen-div">
+                        <div class="col"><h3>Kit Assembly</h3></div>
+                </div>  `
+    document.getElementById('contentBody').innerHTML = template;
+}


### PR DESCRIPTION
This PR addresses the following features:
-> Added BPTL landing page & setup internal navigation
-> Created KIT ASSEMBLY PAGE placeholder

Checklist:
- [x] Code cleanup
- [x] Check for ES Lint warnings
- [ ] Verify test cases
- [x] Check for GIT conflicts
- [ ] Verified unit tests pass with current changes
- [ ] Any dependencies or modules added 
- [x] Attach PoC
- [ ] Notes added

Notes: 
BPTL dashboard is currently available on navigation bar, in the future would be available only for BPTL users

PoC:

Landing Page:
<img width="1790" alt="Screen Shot 2021-07-13 at 1 32 58 AM" src="https://user-images.githubusercontent.com/30497847/125396223-42bb0480-e37a-11eb-8143-0434328ccae8.png">

Kit Assembly Placeholder & internal navigation on tab:
<img width="1792" alt="Screen Shot 2021-07-13 at 1 33 32 AM" src="https://user-images.githubusercontent.com/30497847/125396290-57979800-e37a-11eb-965b-18cb7da237e3.png">


