### PR TITLE
BPTL Dashboard: Added Kit Assembly Table to Render Kits & Add Save Kit Functionality

### DIFF
--- a/kitAssembly.json
+++ b/kitAssembly.json
@@ -1,8 +1,8 @@
 {
-    "lineItem": "d",
-    "uspsTrackingNumber":"9400 1234 5678 9999 8765 00",
-    "supplyKitId":"JKL123422",
-    "specimenKitId":"GHI123422",
-    "collectionCupId":"DEF123422",
-    "collectionCardId":"ABC123422"
+  "lineItem": "1",
+  "uspsTrackingNumber": "9400 1234 5678 9999 8765 00",
+  "supplyKitId": "JKL123422",
+  "specimenKitId": "GHI123422",
+  "collectionCupId": "DEF123422",
+  "collectionCardId": "ABC123422"
 }

--- a/kitAssembly.json
+++ b/kitAssembly.json
@@ -1,8 +1,0 @@
-{
-  "lineItem": "1",
-  "uspsTrackingNumber": "9400 1234 5678 9999 8765 00",
-  "supplyKitId": "JKL123422",
-  "specimenKitId": "GHI123422",
-  "collectionCupId": "DEF123422",
-  "collectionCardId": "ABC123422"
-}

--- a/kitAssembly.json
+++ b/kitAssembly.json
@@ -1,0 +1,8 @@
+{
+    "lineItem": "d",
+    "uspsTrackingNumber":"9400 1234 5678 9999 8765 00",
+    "supplyKitId":"JKL123422",
+    "specimenKitId":"GHI123422",
+    "collectionCupId":"DEF123422",
+    "collectionCardId":"ABC123422"
+}

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -198,7 +198,7 @@ const populateKitTable = (tableBody, kitData) => {
       `;
       tableRow += extraRow;
     }
-
+    
     tableBody.innerHTML = tableRow;
   }
 };
@@ -228,7 +228,9 @@ const saveItem = async (
   inputCollectionCard
 ) => {
   const saveButton = document.getElementById("kit-assembly-save-button");
+  let tableNumRows = tableBody.rows.length
   saveButton.addEventListener("click", (e) => {
+    tableNumRows++
     console.log("save button clicked");
     // console.log(tableBody);
     e.preventDefault();
@@ -265,43 +267,46 @@ const saveItem = async (
     //   // return addKitData(jsonSaveBody).then(res => console.log(res))
     //   // return addKitData(jsonSaveBody);
     // };
-
+    
     // addRow(tableBody);
-    addEndRow();
-    function addEndRow() {
+    addEndRow(jsonSaveBody);
+    function addEndRow(jsonSaveBody) {
       let newRowEl = document.querySelector(".new-row");
+      console.log(newRowEl.firstChild)
+      // console.log(newRowEl.firstChild)
       // let rowCount = 0;
       // rowCount += tableBody.rows.length + 1;
-      let rowCount = tableBody.rows.length;
-      rowCount+=1
+      // let rowCount = tableBody.rows.length;
+      // rowCount+=1
+      console.log(jsonSaveBody)
       newRowEl.insertAdjacentHTML(
-        "afterend",
+        "beforebegin",
         `<tr>
-    <th scope="row">${rowCount}</th>
+    <th scope="row">${tableNumRows}</th>
     <td>
       
-        <input id="input-usps" type="string" autocomplete="off" style="width:80%"/>
-      
+        
+        ${jsonSaveBody.uspsTrackingNumber}
     </td>
     <td>
       
-        <input id="input-supply-kit" type="string" autocomplete="off" style="width:80%"/>
-      
+        
+        ${jsonSaveBody.supplyKitId}
     </td>
     <td>
       
-        <input id="input-specimen-kit" type="string" autocomplete="off" style="width:80%"/>
-      
+        
+        ${jsonSaveBody.specimenKitId}
     </td>
     <td>
       
-        <input id="input-collection-cup" type="string" autocomplete="off" style="width:80%"/>
-      
+        
+        ${jsonSaveBody.collectionCupId}
     </td>
     <td>
       
-        <input id="input-collection-card" type="string" autocomplete="off" style="width:80%"/>
-      
+        
+        ${jsonSaveBody.collectionCardId}
     </td>
 </tr>`
       );

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -79,18 +79,18 @@ const getKitData = async () => {
 // POST METHOD REQUEST
 const addKitData = async (jsonSaveBody) => {
   const idToken = await getIdToken();
-  const response = await fetch(`${api}api=addKitData`, {
+  const response = await (await fetch(`${api}api=addKitData`, {
     method: "POST",
-    headers: {
-      Authorization: "Bearer" + idToken,
-    },
     body: JSON.stringify(jsonSaveBody),
-  });
-  const addKit = await response.json();
-  console.log(jsonSaveBody);
-  console.log(addKit);
-  debugger;
-  return addKit;
+    headers: {
+      Authorization: "Bearer " + idToken,
+      "Content-Type": "application/json"
+    },
+    
+  }));
+  if (response.status === 200) {
+    console.log('hello')
+  }
   
 };
 

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -17,6 +17,7 @@ export const kitAssemblyScreen = async (auth, route) => {
   const kitData = await getKitData().then(res => res.data)
   const tableBody = document.getElementById("kit-assembly-table-body")
   populateKitTable(tableBody,kitData)
+  kitAssemblyPageButtons()
 };
 
 // REMOVE & REFACTOR FOR LATER, ADD TO SHARED.JS FILE?***
@@ -31,7 +32,7 @@ const getKitData = async () => {
 
     const kitData = await response.json()
 
-    // TODO - ERROR HANDLING, MAYBE TRY/CATCH BLOCK?
+    // TODO: ERROR HANDLING, MAYBE TRY/CATCH BLOCK?
     // if(kitData.data.length < 1) {
     //     return console.log('No data')
     // }
@@ -55,7 +56,7 @@ const kitAssemblyTemplate = async (auth, route) => {
                 </div>  `;
 
   template += `
-        <table id="kit-assembly-table" class="table   table-bordered">
+        <table id="kit-assembly-table" class="table table-bordered">
                 <thead>
                     <tr>
                         <th scope="col">Line Item</th>
@@ -76,20 +77,11 @@ const kitAssemblyTemplate = async (auth, route) => {
 
 
 const populateKitTable = (tableBody, kitData) => {
-    // tableBody - targetstable body element, use when inserting an element when looping
+    // tableBody - targetable body element, use when inserting an element when looping
     let tableRow = ''
 
     // TODO = Make the number dynamic and editable
-    let extraRow = `
-        <tr>
-            <th scope="row">.</th>
-            <td>.</td>
-            <td>.</td>
-            <td>.</td>
-            <td>.</td>
-            <td>.</td>
-        </tr>
-        `
+    let extraRow = ''
     console.log(kitData)
     // Create loop 
     for(let i = 0; i < kitData.length; i++) {
@@ -106,12 +98,44 @@ const populateKitTable = (tableBody, kitData) => {
         
         // If the current iteration is the last item, add an extra row
         if(i === kitData.length-1){
+            // Add two to current i value to displayy correct line item number
+            extraRow = `        
+            <tr>
+                <th scope="row">${i+2}</th>
+                <td contenteditable="true"></td>
+                <td contenteditable="true"></td>
+                <td contenteditable="true"></td>
+                <td contenteditable="true"></td>
+                <td contenteditable="true"></td>
+            </tr>
+            `
             tableRow += extraRow
         }
         tableBody.innerHTML = tableRow
     }
 }
 
+const kitAssemblyPageButtons = () => {
+    const contentBody = document.getElementById("contentBody")
+    let buttonContainerTemplate = ""
+
+    console.log(contentBody)
+    
+    buttonContainerTemplate += `
+        <div class="kit-assembly-button-container">
+            <button type="button" class="btn btn-outline-primary">Add</button>
+            <button type="button" class="btn btn-outline-success">Save</button>
+            <button type="button" class="btn btn-outline-info">Print Address</button>
+        </div> 
+    `
+    contentBody.innerHTML += buttonContainerTemplate
+}
+
+// ADD finished button template
+// contentBody.innerHTML += `
+    //     <h1>Testing</h1>
+
+    // `
 
 /*
 TODO STEPS:
@@ -121,6 +145,10 @@ TODO STEPS:
 3. Create a function to create a new row and iterate through list of items
     NOTE: Insert an extra row
 4. Make extra row editable
-
+    TODO: Fix resizing issue - make content fit within container and not change width
+5. Create Buttons (Add, Save, Link to another page)
+    - Add: Create a new editable row for table
+    - Save: Makes a POST request to add a new item to the dataset
+    - Link: To another Web page
 
 */

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -15,9 +15,11 @@ export const kitAssemblyScreen = async (auth, route) => {
   //showAnimation();
   await kitAssemblyTemplate(auth, route);
 
+  // Fetch data using GET request
   const kitData = await getKitData().then((res) => res.data);
   const tableBody = document.getElementById("kit-assembly-table-body");
 
+  // Render Table Data
   populateKitTable(tableBody, kitData);
   // Render Page Buttons
   kitAssemblyPageButtons();
@@ -48,7 +50,7 @@ export const kitAssemblyScreen = async (auth, route) => {
   // Remove all current input fields on row
   clearAllInputs(inputElements);
 
-  // Invoke function to add event listener when clicked
+  // Invoke function to add item to table and send a POST request
   await saveItem(
     tableBody,
     inputUsps,
@@ -60,7 +62,11 @@ export const kitAssemblyScreen = async (auth, route) => {
   );
 };
 
-// GET METHOD REQUEST
+/*
+==================================================
+GET METHOD REQUEST - Retrieve all Kits
+==================================================
+*/
 const getKitData = async () => {
   const idToken = await getIdToken();
   const response = await fetch(`${api}api=getKitData`, {
@@ -74,10 +80,9 @@ const getKitData = async () => {
     if (response.status === 200) {
       const kitData = await response.json();
       if (kitData.data.length) {
-        // debugger;
         return kitData;
       }
-      // TODO: ADD a row where a user is able to enter into specfic table cells
+      // TODO: ADD a row where a user can enter data, handle when there is no data from GET request
       throw new Error("No Kit Assembly data!");
     } else {
       throw new Error("Status Code is not 200!");
@@ -87,7 +92,11 @@ const getKitData = async () => {
   }
 };
 
-// POST METHOD REQUEST
+/*
+==================================================
+POST METHOD REQUEST - Add a Kit
+==================================================
+*/
 const addKitData = async (jsonSaveBody) => {
   const idToken = await getIdToken();
   const response = await await fetch(`${api}api=addKitData`, {
@@ -98,19 +107,31 @@ const addKitData = async (jsonSaveBody) => {
       "Content-Type": "application/json",
     },
   });
+
+  // TODO: Make into separate Function call
+  let contentBody = document.getElementById("contentBody");
+  let alert = "";
+
   if (response.status === 200) {
-    console.log("Successfully saved!");
-    window.alert("Successfully saved!");
+    alert += `
+    <div class="alert alert-success alert-dismissible fade show" role="alert" position="relative" style="top:50%">
+      <strong>Kit was saved successfully!</strong>
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </div>`;
+    contentBody.insertAdjacentHTML("afterbegin", alert);
   } else {
-    console.log("Error did not save!");
-    window.alert("Error on Save!");
+    alert += `<div class="alert alert-danger alert-dismissible fade show" role="alert">
+      <strong>Kit was not saved successfully!</strong>
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </div>`;
   }
 };
 
 const kitAssemblyTemplate = async (auth, route) => {
-  //   const kitData = await getKitData().then(res => res.data)
-
-  //   console.log(kitData)
   let template = ``;
   template += homeCollectionNavbar();
   template += `
@@ -147,7 +168,6 @@ const populateKitTable = (tableBody, kitData) => {
 
   // TODO = Make the number dynamic and editable
   let extraRow = "";
-  console.log(kitData);
   // Create loop and iterate all array items
   for (let i = 0; i < kitData.length; i++) {
     // Append a row with data cells and corresponding data from fetch
@@ -163,43 +183,31 @@ const populateKitTable = (tableBody, kitData) => {
 
     // Update the last row number
     lastRowNumber = i + 1;
-    console.log(lastRowNumber);
     // // If the current iteration is the last item and matches length of last row variable, add an extra row
     if (lastRowNumber === kitData.length) {
-      console.log(lastRowNumber, kitData.length);
       extraRow = `
         <tr class="new-row">      
           <th scope="row">${lastRowNumber + 1}</th>
           <td>
-            
               <input id="input-usps" type="string" autocomplete="off" style="width:80%"/>
-            
           </td>
           <td>
-            
               <input id="input-supply-kit" type="string" autocomplete="off" style="width:80%"/>
-            
           </td>
           <td>
-            
               <input id="input-specimen-kit" type="string" autocomplete="off" style="width:80%"/>
-            
           </td>
           <td>
-            
               <input id="input-collection-cup" type="string" autocomplete="off" style="width:80%"/>
-            
           </td>
           <td>
-            
               <input id="input-collection-card" type="string" autocomplete="off" style="width:80%"/>
-            
           </td>
       </tr>
       `;
       tableRow += extraRow;
     }
-    
+
     tableBody.innerHTML = tableRow;
   }
 };
@@ -207,8 +215,6 @@ const populateKitTable = (tableBody, kitData) => {
 const kitAssemblyPageButtons = () => {
   const contentBody = document.getElementById("contentBody");
   let buttonContainerTemplate = "";
-
-  console.log(contentBody);
 
   buttonContainerTemplate += `
         <div class="kit-assembly-button-container d-flex justify-content-around" style="margin:8rem 0;">
@@ -230,96 +236,63 @@ const saveItem = async (
   inputElements
 ) => {
   const saveButton = document.getElementById("kit-assembly-save-button");
-  let tableNumRows = tableBody.rows.length
+  let tableNumRows = tableBody.rows.length;
   saveButton.addEventListener("click", (e) => {
-    tableNumRows++
-    console.log("save button clicked");
-    // console.log(tableBody);
+    tableNumRows++;
+
     e.preventDefault();
+
     // Target Last row and the last row's children elements
+    // Remove whitespace if any on input fields
+    jsonSaveBody.collectionCardId = inputCollectionCard.value.trim();
+    jsonSaveBody.supplyKitId = inputSupplyKit.value.trim();
+    jsonSaveBody.collectionCupId = inputCollectionCup.value.trim();
+    jsonSaveBody.specimenKitId = inputSpecimenKit.value.trim();
+    jsonSaveBody.uspsTrackingNumber = inputUsps.value.trim();
 
-    // console.log(tableBody.lastElementChild.children);
-    // const lastRowElements = tableBody.lastElementChild.children;
-    // for (let i = 1; i < lastRowElements.length; i++) {}
-    jsonSaveBody.collectionCardId = inputCollectionCard.value;
-    jsonSaveBody.supplyKitId = inputSupplyKit.value;
-    jsonSaveBody.collectionCupId = inputCollectionCup.value;
-    jsonSaveBody.specimenKitId = inputSpecimenKit.value;
-    jsonSaveBody.uspsTrackingNumber = inputUsps.value;
+    // PREVENTS USER FROM SUBMITTING INCOMPLETE INPUT FIELD ROW
+    for (const key in jsonSaveBody) {
+      if (!jsonSaveBody[key]) {
+        alert("One or more inputs are empty!");
+        return;
+      }
+    }
 
-    // // ADD DATA to TABLE
-    // function addRow(tableId) {
-    //   let rowCount = tableBody.rows.length;
-    //   // console.log(rowCount)
-
-    //   let row = tableBody.insertRow(rowCount);
-    //   let colCount = tableBody.rows[0].cells.length;
-
-    //   console.log(rowCount, row, colCount);
-
-    //   // loop using row columns
-    //   for( let i =0; i<colCount;i++){
-    //     // add new cell
-    //     let newcell = row.insertCell(i)
-    //     newcell.innerHTML = tableBody.rows[i].cells[i].innerHTML;
-    //     console.log(newcell)
-    //     if(newCell.childNodes[0].type){}
-    //   }
-
-    //   // return addKitData(jsonSaveBody).then(res => console.log(res))
-    //   // return addKitData(jsonSaveBody);
-    // };
-    
-    // addRow(tableBody);
-    addEndRow(jsonSaveBody);
-    function addEndRow(jsonSaveBody) {
-      let newRowEl = document.querySelector(".new-row");
-      console.log(newRowEl.firstChild)
+    // ADD DATA to TABLE
+    addRow(jsonSaveBody);
+    function addRow(jsonSaveBody) {
       // Target Line Item Number
-      newRowEl.firstChild.nextSibling.innerHTML = tableNumRows
-      // let rowCount = 0;
-      // rowCount += tableBody.rows.length + 1;
-      // let rowCount = tableBody.rows.length;
-      // rowCount+=1
-      console.log(jsonSaveBody)
+      let newRowEl = document.querySelector(".new-row");
+      newRowEl.firstChild.nextSibling.innerHTML = tableNumRows;
       newRowEl.insertAdjacentHTML(
         "beforebegin",
         `<tr>
-    <th scope="row">${tableNumRows-1}</th>
+    <th scope="row">${tableNumRows - 1}</th>
     <td>
-      
-        
         ${jsonSaveBody.uspsTrackingNumber}
     </td>
     <td>
-      
-        
         ${jsonSaveBody.supplyKitId}
     </td>
     <td>
-      
-        
         ${jsonSaveBody.specimenKitId}
     </td>
     <td>
-      
-        
         ${jsonSaveBody.collectionCupId}
     </td>
     <td>
-      
-        
         ${jsonSaveBody.collectionCardId}
     </td>
 </tr>`
       );
-      console.log(inputElements)
     }
-    clearRowInputs()
-    function clearRowInputs(){for (let property in inputElements) {
-      inputElements[property].value = "";
-    }}
-    // return addKitData(jsonSaveBody);
+    clearRowInputs();
+    function clearRowInputs() {
+      for (let property in inputElements) {
+        inputElements[property].value = "";
+      }
+    }
+    return addKitData(jsonSaveBody);
   });
 };
 
@@ -334,32 +307,23 @@ const userInputHandler = async (
 ) => {
   // Event Handlers for input fields
   await inputUsps.addEventListener("input", (e) => {
-    // console.log(e.target)
     inputUsps.value = e.target.value;
-    console.log(inputUsps.value);
   });
 
   await inputSupplyKit.addEventListener("input", (e) => {
     inputSupplyKit.value = e.target.value;
-    console.log(inputSupplyKit.value);
   });
 
   await inputSpecimenKit.addEventListener("input", (e) => {
     inputSpecimenKit.value = e.target.value;
-    console.log(inputSpecimenKit);
-    console.log(inputSpecimenKit.value);
   });
 
   await inputCollectionCup.addEventListener("input", (e) => {
     inputCollectionCup.value = e.target.value;
-    console.log(inputCollectionCup);
   });
 
   await inputCollectionCard.addEventListener("input", (e) => {
     inputCollectionCard.value = e.target.value;
-    console.log(inputCollectionCard);
-    console.log(e.target.value);
-
     // debugger;
   });
 };
@@ -378,7 +342,6 @@ const jsonSaveBody = {
 const clearAllInputs = (inputElements) => {
   const cancelButton = document.getElementById("kit-assembly-cancel-button");
 
-  console.log(inputElements);
   cancelButton.addEventListener("click", (e) => {
     e.preventDefault();
     // for in to loop over all property keys
@@ -387,15 +350,6 @@ const clearAllInputs = (inputElements) => {
     }
   });
 };
-
-const renderSaveRowItems = () => {};
-// Create extra table row
-
-// const addTableRow = () => {
-//   // Take all inputs from current row and create a new row with blank inputs
-//   // - Note: Make Sure to toggle id off and add back on later
-//   // - Note: Increment row correctly
-// };
 
 /*
 TODO STEPS:
@@ -406,10 +360,10 @@ TODO STEPS:
     NOTE: Insert an extra row
 4. Make extra row editable
     TODO: Fix resizing issue - make content fit within container and not change width
-5. Create Buttons (Add, Save, Link to another page)
-    - Add: Create a new editable row for table
+5. Create Buttons (Add, Cancel)
+    - Cancel: Clear inputs on last table row 
     - Save: Makes a POST request to add a new item to the dataset
-    - Link: To another Web page
+  
 6. Prioritize Save button POST request 
     - TEST POST Request first on POSTMAN *
     - Create a Modal for Save Button with Two Buttons (IGNORE FOR MVP)
@@ -420,7 +374,18 @@ TODO STEPS:
 8. Handle acceptable POST request on the client side
 
 
-BONUS:
+UPCOMING FEATURES
 
-SORT Kits from Oldest to Newest
+1. USER VALIDATION CHECKS - 
+    - Input checks for Column 2 and 3 (Match) / Modals? 
+    - Input checks for Column 4 and 5 (Match) / Modals?
+    - USPS unique numeric check / Modals?
+    - Modal Warning when user is moving away from page or accidentally hit close button
+
+2. ALERT FADE OUT
+    - HAVE ALERT FADE OUT WHEN CERTAIN TIME PASSES
+
+
+BONUS:
+SORT FUNCTION Kits from Oldest to Newest
 */

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -140,9 +140,8 @@ const kitAssemblyPageButtons = () => {
     
     buttonContainerTemplate += `
         <div class="kit-assembly-button-container d-flex justify-content-around" style="margin: 8rem;">
-            <button id="kit-assembly-add-button" type="button" class="btn btn-outline-primary">Add</button>
-            <button id="kit-assembly-save-button" type="button" class="btn btn-outline-success" data-toggle="modal" data-target="#saveModal">Save</button>
-            <button type="button" class="btn btn-outline-info">Continue to Print Addresses</button>
+            <button id="kit-assembly-save-button" type="button" class="btn btn-outline-primary" data-toggle="modal" data-target="#saveModal">Save</button>
+            <button type="button" class="btn btn-success">Continue to Print Addresses</button>
         </div> 
     `
     contentBody.innerHTML += buttonContainerTemplate

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -55,7 +55,8 @@ export const kitAssemblyScreen = async (auth, route) => {
     inputSupplyKit,
     inputSpecimenKit,
     inputCollectionCup,
-    inputCollectionCard
+    inputCollectionCard,
+    inputElements
   );
 };
 
@@ -225,7 +226,8 @@ const saveItem = async (
   inputSupplyKit,
   inputSpecimenKit,
   inputCollectionCup,
-  inputCollectionCard
+  inputCollectionCard,
+  inputElements
 ) => {
   const saveButton = document.getElementById("kit-assembly-save-button");
   let tableNumRows = tableBody.rows.length
@@ -273,7 +275,8 @@ const saveItem = async (
     function addEndRow(jsonSaveBody) {
       let newRowEl = document.querySelector(".new-row");
       console.log(newRowEl.firstChild)
-      // console.log(newRowEl.firstChild)
+      // Target Line Item Number
+      newRowEl.firstChild.nextSibling.innerHTML = tableNumRows
       // let rowCount = 0;
       // rowCount += tableBody.rows.length + 1;
       // let rowCount = tableBody.rows.length;
@@ -282,7 +285,7 @@ const saveItem = async (
       newRowEl.insertAdjacentHTML(
         "beforebegin",
         `<tr>
-    <th scope="row">${tableNumRows}</th>
+    <th scope="row">${tableNumRows-1}</th>
     <td>
       
         
@@ -310,7 +313,13 @@ const saveItem = async (
     </td>
 </tr>`
       );
+      console.log(inputElements)
     }
+    clearRowInputs()
+    function clearRowInputs(){for (let property in inputElements) {
+      inputElements[property].value = "";
+    }}
+    // return addKitData(jsonSaveBody);
   });
 };
 

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -17,31 +17,45 @@ export const kitAssemblyScreen = async (auth, route) => {
   const kitData = await getKitData().then(res => res.data)
   const tableBody = document.getElementById("kit-assembly-table-body")
   populateKitTable(tableBody,kitData)
+
+  // Render Page Buttons
   kitAssemblyPageButtons()
+
+  // Invoke function to add event listener when clicked
+  // saveItemModal()
 };
 
 // REMOVE & REFACTOR FOR LATER, ADD TO SHARED.JS FILE?***
+// GET METHOD REQUEST
 const getKitData = async () => {
-    const idToken = await getIdToken();
-    const response = await fetch(`${api}api=getKitData`,{
-        method:"GET",
-        headers: {
-            Authorization:"Bearer"+idToken
-        }
-    })
+  const idToken = await getIdToken();
+  const response = await fetch(`${api}api=getKitData`, {
+    method: "GET",
+    headers: {
+      Authorization: "Bearer" + idToken,
+    },
+  });
 
-    const kitData = await response.json()
+  try {
+    if (response.status === 200) {
+      const kitData = await response.json();
+      if (kitData.data.length) {
+        // debugger;
+        return kitData;
+      }
+      throw new Error("No Kit Assembly data!");
+    } else {
+      throw new Error("Status Code is not 200!");
+    }
+  } catch (e) {
+    console.log(e);
+  }
+};
 
-    // TODO: ERROR HANDLING, MAYBE TRY/CATCH BLOCK?
-    // if(kitData.data.length < 1) {
-    //     return console.log('No data')
-    // }
-    // else {
-    //     console.log(kitData)
-    //     return kitData
-    // }
-    
-    return kitData
+// REMOVE & REFACTOR FOR LATER, ADD TO SHARED.JS FILE?***
+// POST METHOD REQUEST
+const addKitData = () => {
+
 }
 
 const kitAssemblyTemplate = async (auth, route) => {
@@ -56,21 +70,24 @@ const kitAssemblyTemplate = async (auth, route) => {
                 </div>  `;
 
   template += `
-        <table id="kit-assembly-table" class="table table-bordered">
+        <div style="overflow:auto; height:400px">
+            <table id="kit-assembly-table" class="table table-bordered" style="margin-bottom:0; position: relative;border-collapse:collapse; box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.4);">
                 <thead>
-                    <tr>
-                        <th scope="col">Line Item</th>
-                        <th scope="col">Specify Kit USPS Tracking Number</th>
-                        <th scope="col">Supply Kit ID</th>
-                        <th scope="col">Specimen Kit ID</th>
-                        <th scope="col">Collection Cup ID</th>
-                        <th scope="col">Collection Card ID</th>
+                    <tr style="top: 0;
+                    position: sticky;">
+                        <th scope="col" style="background-color: #f7f7f7;">Line Item</th>
+                        <th scope="col" style="background-color: #f7f7f7;">Specify Kit USPS Tracking Number</th>
+                        <th scope="col" style="background-color: #f7f7f7;">Supply Kit ID</th>
+                        <th scope="col" style="background-color: #f7f7f7;">Specimen Kit ID</th>
+                        <th scope="col" style="background-color: #f7f7f7;">Collection Cup ID</th>
+                        <th scope="col" style="background-color: #f7f7f7;">Collection Card ID</th>
                     </tr>
                 </thead>
                 
                 <tbody id="kit-assembly-table-body">
                 </tbody>
-            </table>`;
+            </table>
+        </div>`;
 
   document.getElementById("contentBody").innerHTML = template;
 };
@@ -98,9 +115,9 @@ const populateKitTable = (tableBody, kitData) => {
         
         // If the current iteration is the last item, add an extra row
         if(i === kitData.length-1){
-            // Add two to current i value to displayy correct line item number
+            // Add two to current i value to display correct line item number
             extraRow = `        
-            <tr>
+            <tr class="new-row">
                 <th scope="row">${i+2}</th>
                 <td contenteditable="true"></td>
                 <td contenteditable="true"></td>
@@ -122,20 +139,15 @@ const kitAssemblyPageButtons = () => {
     console.log(contentBody)
     
     buttonContainerTemplate += `
-        <div class="kit-assembly-button-container">
-            <button type="button" class="btn btn-outline-primary">Add</button>
-            <button type="button" class="btn btn-outline-success">Save</button>
-            <button type="button" class="btn btn-outline-info">Print Address</button>
+        <div class="kit-assembly-button-container d-flex justify-content-around" style="margin: 8rem;">
+            <button id="kit-assembly-add-button" type="button" class="btn btn-outline-primary">Add</button>
+            <button id="kit-assembly-save-button" type="button" class="btn btn-outline-success" data-toggle="modal" data-target="#saveModal">Save</button>
+            <button type="button" class="btn btn-outline-info">Continue to Print Addresses</button>
         </div> 
     `
     contentBody.innerHTML += buttonContainerTemplate
 }
 
-// ADD finished button template
-// contentBody.innerHTML += `
-    //     <h1>Testing</h1>
-
-    // `
 
 /*
 TODO STEPS:
@@ -150,5 +162,12 @@ TODO STEPS:
     - Add: Create a new editable row for table
     - Save: Makes a POST request to add a new item to the dataset
     - Link: To another Web page
-
+6. Prioritize Save button POST request 
+    - TEST POST Request first on POSTMAN *
+    - Create a Modal for Save Button with Two Buttons (IGNORE FOR MVP)
+        - Confirm
+        - Cancel
+    - Make save button make a post request and have a popup saying success
+7. Have an Add button create a new line to table
+8. Handle acceptable POST request on the client side
 */

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -25,6 +25,8 @@ export const kitAssemblyScreen = async (auth, route) => {
   let inputCollectionCup = document.getElementById("input-collection-cup");
   let inputCollectionCard = document.getElementById("input-collection-card");
 
+  const inputElements = {inputUsps,inputSupplyKit,inputSpecimenKit,inputCollectionCard,inputCollectionCup}
+
   //Event Listener for Table Inputs
   await userInputHandler(
     inputUsps,
@@ -34,9 +36,7 @@ export const kitAssemblyScreen = async (auth, route) => {
     inputCollectionCard
   );
 
-  const inputElements = {inputUsps,inputSupplyKit,inputSpecimenKit,inputCollectionCard,inputCollectionCup}
-
-  await clearAllInputs(inputElements) 
+  clearAllInputs(inputElements) 
 
   // Invoke function to add event listener when clicked
   await saveItem(
@@ -192,10 +192,10 @@ const kitAssemblyPageButtons = () => {
   console.log(contentBody);
 
   buttonContainerTemplate += `
-        <div class="kit-assembly-button-container d-flex justify-content-center" style="margin: 8rem;">
-          <button id="kit-assembly-cancel-button" type="button" class="btn btn-outline-secondary btn-lg" style="margin-right:10%">Cancel</button>
+        <div class="kit-assembly-button-container d-flex justify-content-around" style="margin:8rem 0;">
+          <button id="kit-assembly-cancel-button" type="button" class="btn btn-outline-secondary" style=" width:13rem; height:3rem; border-radius:15px">Cancel</button>
 
-          <button id="kit-assembly-save-button" type="submit" class="btn btn-primary btn-lg">Save</button>
+          <button id="kit-assembly-save-button" type="submit" class="btn btn-success" style="width:13rem;height:3rem; border-radius:15px">Save</button>
         </div> 
     `;
   contentBody.innerHTML += buttonContainerTemplate;

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -6,7 +6,7 @@ const api =
   "https://us-central1-nih-nci-dceg-connect-dev.cloudfunctions.net/biospecimen?";
 
 // Track the last row number
-let lastRowNumber = ""
+let lastRowNumber = "";
 
 export const kitAssemblyScreen = async (auth, route) => {
   const user = auth.currentUser;
@@ -28,7 +28,13 @@ export const kitAssemblyScreen = async (auth, route) => {
   let inputCollectionCup = document.getElementById("input-collection-cup");
   let inputCollectionCard = document.getElementById("input-collection-card");
 
-  const inputElements = {inputUsps,inputSupplyKit,inputSpecimenKit,inputCollectionCard,inputCollectionCup}
+  const inputElements = {
+    inputUsps,
+    inputSupplyKit,
+    inputSpecimenKit,
+    inputCollectionCard,
+    inputCollectionCup,
+  };
 
   //Event Listener for Table Inputs
   await userInputHandler(
@@ -38,9 +44,9 @@ export const kitAssemblyScreen = async (auth, route) => {
     inputCollectionCup,
     inputCollectionCard
   );
-  
+
   // Remove all current input fields on row
-  clearAllInputs(inputElements) 
+  clearAllInputs(inputElements);
 
   // Invoke function to add event listener when clicked
   await saveItem(
@@ -83,19 +89,21 @@ const getKitData = async () => {
 // POST METHOD REQUEST
 const addKitData = async (jsonSaveBody) => {
   const idToken = await getIdToken();
-  const response = await (await fetch(`${api}api=addKitData`, {
+  const response = await await fetch(`${api}api=addKitData`, {
     method: "POST",
     body: JSON.stringify(jsonSaveBody),
     headers: {
       Authorization: "Bearer " + idToken,
-      "Content-Type": "application/json"
+      "Content-Type": "application/json",
     },
-    
-  }));
+  });
   if (response.status === 200) {
-    console.log('hello')
+    console.log("Successfully saved!");
+    window.alert("Successfully saved!");
+  } else {
+    console.log("Error did not save!");
+    window.alert("Error on Save!");
   }
-  
 };
 
 const kitAssemblyTemplate = async (auth, route) => {
@@ -151,16 +159,16 @@ const populateKitTable = (tableBody, kitData) => {
             <td>${kitData[i].collectionCupId}</td>
             <td>${kitData[i].collectionCardId}</td>
         </tr>`;
-    
+
     // Update the last row number
-    lastRowNumber = i+1
-    console.log(lastRowNumber)
+    lastRowNumber = i + 1;
+    console.log(lastRowNumber);
     // // If the current iteration is the last item and matches length of last row variable, add an extra row
-    if(lastRowNumber === kitData.length) {
-      console.log(lastRowNumber,kitData.length)
-      extraRow =`        
-      <tr class="new-row">
-          <th scope="row">${i + 2}</th>
+    if (lastRowNumber === kitData.length) {
+      console.log(lastRowNumber, kitData.length);
+      extraRow = `
+        <tr class="new-row">      
+          <th scope="row">${lastRowNumber + 1}</th>
           <td>
             
               <input id="input-usps" type="string" autocomplete="off" style="width:80%"/>
@@ -188,7 +196,7 @@ const populateKitTable = (tableBody, kitData) => {
           </td>
       </tr>
       `;
-      tableRow += extraRow
+      tableRow += extraRow;
     }
 
     tableBody.innerHTML = tableRow;
@@ -222,8 +230,8 @@ const saveItem = async (
   const saveButton = document.getElementById("kit-assembly-save-button");
   saveButton.addEventListener("click", (e) => {
     console.log("save button clicked");
-    console.log(tableBody);
-    e.preventDefault()
+    // console.log(tableBody);
+    e.preventDefault();
     // Target Last row and the last row's children elements
 
     // console.log(tableBody.lastElementChild.children);
@@ -235,8 +243,69 @@ const saveItem = async (
     jsonSaveBody.specimenKitId = inputSpecimenKit.value;
     jsonSaveBody.uspsTrackingNumber = inputUsps.value;
 
-    // return addKitData(jsonSaveBody).then(res => console.log(res))
-    return addKitData(jsonSaveBody);
+    // // ADD DATA to TABLE
+    // function addRow(tableId) {
+    //   let rowCount = tableBody.rows.length;
+    //   // console.log(rowCount)
+
+    //   let row = tableBody.insertRow(rowCount);
+    //   let colCount = tableBody.rows[0].cells.length;
+
+    //   console.log(rowCount, row, colCount);
+
+    //   // loop using row columns
+    //   for( let i =0; i<colCount;i++){
+    //     // add new cell
+    //     let newcell = row.insertCell(i)
+    //     newcell.innerHTML = tableBody.rows[i].cells[i].innerHTML;
+    //     console.log(newcell)
+    //     if(newCell.childNodes[0].type){}
+    //   }
+
+    //   // return addKitData(jsonSaveBody).then(res => console.log(res))
+    //   // return addKitData(jsonSaveBody);
+    // };
+
+    // addRow(tableBody);
+    addEndRow();
+    function addEndRow() {
+      let newRowEl = document.querySelector(".new-row");
+      // let rowCount = 0;
+      // rowCount += tableBody.rows.length + 1;
+      let rowCount = tableBody.rows.length;
+      rowCount+=1
+      newRowEl.insertAdjacentHTML(
+        "afterend",
+        `<tr>
+    <th scope="row">${rowCount}</th>
+    <td>
+      
+        <input id="input-usps" type="string" autocomplete="off" style="width:80%"/>
+      
+    </td>
+    <td>
+      
+        <input id="input-supply-kit" type="string" autocomplete="off" style="width:80%"/>
+      
+    </td>
+    <td>
+      
+        <input id="input-specimen-kit" type="string" autocomplete="off" style="width:80%"/>
+      
+    </td>
+    <td>
+      
+        <input id="input-collection-cup" type="string" autocomplete="off" style="width:80%"/>
+      
+    </td>
+    <td>
+      
+        <input id="input-collection-card" type="string" autocomplete="off" style="width:80%"/>
+      
+    </td>
+</tr>`
+      );
+    }
   });
 };
 
@@ -290,29 +359,29 @@ const jsonSaveBody = {
   uspsTrackingNumber: "",
 };
 
-
 // Cancel Button Clear Inputs Function
 
 const clearAllInputs = (inputElements) => {
-  const cancelButton = document.getElementById("kit-assembly-cancel-button")
-  
-  console.log(inputElements)
-  cancelButton.addEventListener("click",(e)=> {
-    e.preventDefault() 
-    // for in to loop over all property keys
-    for(let property in inputElements) {
-      inputElements[property].value = ""
-    }
-  })
-}
+  const cancelButton = document.getElementById("kit-assembly-cancel-button");
 
+  console.log(inputElements);
+  cancelButton.addEventListener("click", (e) => {
+    e.preventDefault();
+    // for in to loop over all property keys
+    for (let property in inputElements) {
+      inputElements[property].value = "";
+    }
+  });
+};
+
+const renderSaveRowItems = () => {};
 // Create extra table row
 
-const addTableRow = () => {
-  // Take all inputs from current row and create a new row with blank inputs
-  // - Note: Make Sure to toggle id off and add back on later
-  // - Note: Increment row correctly
-};
+// const addTableRow = () => {
+//   // Take all inputs from current row and create a new row with blank inputs
+//   // - Note: Make Sure to toggle id off and add back on later
+//   // - Note: Increment row correctly
+// };
 
 /*
 TODO STEPS:

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -15,6 +15,7 @@ export const kitAssemblyScreen = async (auth, route) => {
 
   const kitData = await getKitData().then((res) => res.data);
   const tableBody = document.getElementById("kit-assembly-table-body");
+
   populateKitTable(tableBody, kitData);
   // Render Page Buttons
   kitAssemblyPageButtons();
@@ -24,45 +25,27 @@ export const kitAssemblyScreen = async (auth, route) => {
   let inputSpecimenKit = document.getElementById("input-specimen-kit");
   let inputCollectionCup = document.getElementById("input-collection-cup");
   let inputCollectionCard = document.getElementById("input-collection-card");
-  
-  inputUsps.addEventListener("input", (e) => {
-    
-    // console.log(e.target)
-    inputUsps.value = e.target.value
-    console.log(inputUsps.value)
-  })
 
-  inputSupplyKit.addEventListener("input", (e) => {
-    inputSupplyKit.value = e.target.value
-    console.log(inputSupplyKit.value)
-  })
-
-  inputSpecimenKit.addEventListener("input", (e) => {
-    inputSpecimenKit.value = e.target.value
-    console.log(inputSpecimenKit)
-    console.log(inputSpecimenKit.value)
-  })
-
-  inputCollectionCup.addEventListener("input", (e)=> {
-    inputCollectionCup.value = e.target.value
-    console.log(inputCollectionCup)
-  })
-
-  inputCollectionCard.addEventListener("input", (e) => {
-    inputCollectionCard.value = e.target.value
-    console.log(inputCollectionCard)
-    console.log(e.target.value)
-
-    // debugger;
-  })
+  //Event Listener for Table Inputs
+  await userInputHandler(
+    inputUsps,
+    inputSupplyKit,
+    inputSpecimenKit,
+    inputCollectionCup,
+    inputCollectionCard
+  );
 
   // Invoke function to add event listener when clicked
-  saveItem(tableBody,inputUsps,inputSupplyKit,inputSpecimenKit,inputCollectionCup,inputCollectionCard);
+  await saveItem(
+    tableBody,
+    inputUsps,
+    inputSupplyKit,
+    inputSpecimenKit,
+    inputCollectionCup,
+    inputCollectionCard
+  );
 };
 
-
-
-// TODO: REMOVE & REFACTOR FOR LATER, ADD TO SHARED.JS FILE?***
 // GET METHOD REQUEST
 const getKitData = async () => {
   const idToken = await getIdToken();
@@ -80,7 +63,7 @@ const getKitData = async () => {
         // debugger;
         return kitData;
       }
-      // TODO: ADD a row where a user is able to enter into speecfic table cells
+      // TODO: ADD a row where a user is able to enter into specfic table cells
       throw new Error("No Kit Assembly data!");
     } else {
       throw new Error("Status Code is not 200!");
@@ -90,21 +73,20 @@ const getKitData = async () => {
   }
 };
 
-// TODO: REMOVE & REFACTOR FOR LATER, ADD TO SHARED.JS FILE?***
 // POST METHOD REQUEST
 const addKitData = async (jsonSaveBody) => {
   const idToken = await getIdToken();
-  const response = await fetch(`${api}api=addKitData`,{
-    method:"POST",
+  const response = await fetch(`${api}api=addKitData`, {
+    method: "POST",
     headers: {
       Authorization: "Bearer" + idToken,
     },
-    body: JSON.stringify(jsonSaveBody)
-  })
-  const addKit = await response.clone().json()
-  console.log(addKit)
-  return addKit
-  debugger;
+    body: JSON.stringify(jsonSaveBody),
+  });
+  const addKit = await response.json();
+  // console.log(addKit);
+  return addKit;
+  // debugger;
 };
 
 const kitAssemblyTemplate = async (auth, route) => {
@@ -163,34 +145,33 @@ const populateKitTable = (tableBody, kitData) => {
 
     // If the current iteration is the last item, add an extra row
     if (i === kitData.length - 1) {
-      // Add two to current i value to display correct line item number
-      // Note: cannot add event listeners to td elements
+      // Add two to current i value to display correct line item number increment
       extraRow = `        
             <tr class="new-row">
                 <th scope="row">${i + 2}</th>
                 <td>
                   
-                    <input id="input-usps" type="string" value="" style="width:80%"/>
+                    <input id="input-usps" type="string" autocomplete="off" style="width:80%"/>
                   
                 </td>
                 <td>
                   
-                    <input id="input-supply-kit" type="string" value="" style="width:80%"/>
+                    <input id="input-supply-kit" type="string" autocomplete="off" style="width:80%"/>
                   
                 </td>
                 <td>
                   
-                    <input id="input-specimen-kit" type="string" value="" style="width:80%"/>
+                    <input id="input-specimen-kit" type="string" autocomplete="off" style="width:80%"/>
                   
                 </td>
                 <td>
                   
-                    <input id="input-collection-cup" type="string" value="" style="width:80%"/>
+                    <input id="input-collection-cup" type="string" autocomplete="off" style="width:80%"/>
                   
                 </td>
                 <td>
                   
-                    <input id="input-collection-card" type="string" value="" style="width:80%"/>
+                    <input id="input-collection-card" type="string" autocomplete="off" style="width:80%"/>
                   
                 </td>
             </tr>
@@ -209,14 +190,21 @@ const kitAssemblyPageButtons = () => {
 
   buttonContainerTemplate += `
         <div class="kit-assembly-button-container d-flex justify-content-center" style="margin: 8rem;">
-          <button id="kit-assembly-cancel-button" type="button" class="btn btn-outline-secondary" style="margin-right:10%">Cancel</button>
-          <button id="kit-assembly-save-button" type="button" class="btn btn-outline-primary" data-toggle="modal" data-target="#saveModal">Save</button>
+          <button id="kit-assembly-cancel-button " type="button" class="btn btn-outline-secondary btn-lg" style="margin-right:10%">Cancel</button>
+          <button id="kit-assembly-save-button" type="submit" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#saveModal">Save</button>
         </div> 
     `;
   contentBody.innerHTML += buttonContainerTemplate;
 };
 
-const saveItem = async (tableBody,inputUsps,inputSupplyKit,inputSpecimenKit,inputCollectionCup,inputCollectionCard) => {
+const saveItem = async (
+  tableBody,
+  inputUsps,
+  inputSupplyKit,
+  inputSpecimenKit,
+  inputCollectionCup,
+  inputCollectionCard
+) => {
   const saveButton = document.getElementById("kit-assembly-save-button");
   saveButton.addEventListener("click", (e) => {
     console.log("save button clicked");
@@ -226,13 +214,55 @@ const saveItem = async (tableBody,inputUsps,inputSupplyKit,inputSpecimenKit,inpu
     // console.log(tableBody.lastElementChild.children);
     // const lastRowElements = tableBody.lastElementChild.children;
     // for (let i = 1; i < lastRowElements.length; i++) {}
-    jsonSaveBody.collectionCardId = inputCollectionCard.value
-    jsonSaveBody.supplyKitId = inputSupplyKit.value
-    jsonSaveBody.collectionCupId = inputCollectionCup.value
-    jsonSaveBody.specimenKitId = inputSpecimenKit.value
-    jsonSaveBody.uspsTrackingNumber = inputUsps.value
-    
-    return addKitData(jsonSaveBody).then(res => console.log(res))
+    jsonSaveBody.collectionCardId = inputCollectionCard.value;
+    jsonSaveBody.supplyKitId = inputSupplyKit.value;
+    jsonSaveBody.collectionCupId = inputCollectionCup.value;
+    jsonSaveBody.specimenKitId = inputSpecimenKit.value;
+    jsonSaveBody.uspsTrackingNumber = inputUsps.value;
+
+    // return addKitData(jsonSaveBody).then(res => console.log(res))
+    return addKitData(jsonSaveBody);
+  });
+};
+
+// User input handler
+
+const userInputHandler = async (
+  inputUsps,
+  inputSupplyKit,
+  inputSpecimenKit,
+  inputCollectionCup,
+  inputCollectionCard
+) => {
+  // Event Handlers for input fields
+  await inputUsps.addEventListener("input", (e) => {
+    // console.log(e.target)
+    inputUsps.value = e.target.value;
+    console.log(inputUsps.value);
+  });
+
+  await inputSupplyKit.addEventListener("input", (e) => {
+    inputSupplyKit.value = e.target.value;
+    console.log(inputSupplyKit.value);
+  });
+
+  await inputSpecimenKit.addEventListener("input", (e) => {
+    inputSpecimenKit.value = e.target.value;
+    console.log(inputSpecimenKit);
+    console.log(inputSpecimenKit.value);
+  });
+
+  await inputCollectionCup.addEventListener("input", (e) => {
+    inputCollectionCup.value = e.target.value;
+    console.log(inputCollectionCup);
+  });
+
+  await inputCollectionCard.addEventListener("input", (e) => {
+    inputCollectionCard.value = e.target.value;
+    console.log(inputCollectionCard);
+    console.log(e.target.value);
+
+    // debugger;
   });
 };
 
@@ -244,6 +274,10 @@ const jsonSaveBody = {
   specimenKitId: "",
   uspsTrackingNumber: "",
 };
+
+// Create extra table row
+
+const addTableRow = () => {};
 
 /*
 TODO STEPS:

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -1,6 +1,6 @@
 import { homeCollectionNavbar } from "./homeCollectionNavbar.js";
 import { userDashboard } from "../dashboard.js";
-import { biospecimenUsers,getIdToken } from "../../shared.js";
+import { getIdToken } from "../../shared.js";
 
 
 // REMOVE & REFACTOR FOR LATER***
@@ -12,7 +12,11 @@ export const kitAssemblyScreen = async (auth, route) => {
   if (!user) return;
   const username = user.displayName ? user.displayName : user.email;
   //showAnimation();
-  kitAssemblyTemplate(auth, route);
+  await kitAssemblyTemplate(auth, route);
+
+  const kitData = await getKitData().then(res => res.data)
+  const tableBody = document.getElementById("kit-assembly-table-body")
+  populateKitTable(tableBody,kitData)
 };
 
 // REMOVE & REFACTOR FOR LATER, ADD TO SHARED.JS FILE?***
@@ -40,9 +44,9 @@ const getKitData = async () => {
 }
 
 const kitAssemblyTemplate = async (auth, route) => {
-  const kitData = await getKitData().then(res => res.data)
+//   const kitData = await getKitData().then(res => res.data)
 
-  await console.log(kitData)
+//   console.log(kitData)
   let template = ``;
   template += homeCollectionNavbar();
   template += `
@@ -51,7 +55,7 @@ const kitAssemblyTemplate = async (auth, route) => {
                 </div>  `;
 
   template += `
-            <table id="kit-assembly-table" class="table   table-bordered">
+        <table id="kit-assembly-table" class="table   table-bordered">
                 <thead>
                     <tr>
                         <th scope="col">Line Item</th>
@@ -63,16 +67,60 @@ const kitAssemblyTemplate = async (auth, route) => {
                     </tr>
                 </thead>
                 
-                <tbody>
-                    <tr>
-                        <th scope="row">1</th>
-                        <td>9400 1234 5678 9999 8765 00</td>
-                        <td>JKL123422</td>
-                        <td>GHI123422</td>
-                        <td>DEF123422</td>
-                        <td>ABC123422</td>
-                    </tr>
+                <tbody id="kit-assembly-table-body">
                 </tbody>
             </table>`;
+
   document.getElementById("contentBody").innerHTML = template;
 };
+
+
+const populateKitTable = (tableBody, kitData) => {
+    // tableBody - targetstable body element, use when inserting an element when looping
+    let tableRow = ''
+
+    // TODO = Make the number dynamic and editable
+    let extraRow = `
+        <tr>
+            <th scope="row">.</th>
+            <td>.</td>
+            <td>.</td>
+            <td>.</td>
+            <td>.</td>
+            <td>.</td>
+        </tr>
+        `
+    console.log(kitData)
+    // Create loop 
+    for(let i = 0; i < kitData.length; i++) {
+        // Append a row with data cells and corresponding data from fetch
+        tableRow += `
+        <tr>
+            <th scope="row">${i+1}</th>
+            <td>${kitData[i].uspsTrackingNumber}</td>
+            <td>${kitData[i].supplyKitId}</td>
+            <td>${kitData[i].specimenKitId}</td>
+            <td>${kitData[i].collectionCupId}</td>
+            <td>${kitData[i].collectionCardId}</td>
+        </tr>`
+        
+        // If the current iteration is the last item, add an extra row
+        if(i === kitData.length-1){
+            tableRow += extraRow
+        }
+        tableBody.innerHTML = tableRow
+    }
+}
+
+
+/*
+TODO STEPS:
+
+1. Fetch data using GET request
+2. Target table body
+3. Create a function to create a new row and iterate through list of items
+    NOTE: Insert an extra row
+4. Make extra row editable
+
+
+*/

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -5,6 +5,9 @@ import { getIdToken } from "../../shared.js";
 const api =
   "https://us-central1-nih-nci-dceg-connect-dev.cloudfunctions.net/biospecimen?";
 
+// Track the last row number
+let lastRowNumber = ""
+
 export const kitAssemblyScreen = async (auth, route) => {
   const user = auth.currentUser;
   if (!user) return;
@@ -35,7 +38,8 @@ export const kitAssemblyScreen = async (auth, route) => {
     inputCollectionCup,
     inputCollectionCard
   );
-
+  
+  // Remove all current input fields on row
   clearAllInputs(inputElements) 
 
   // Invoke function to add event listener when clicked
@@ -135,7 +139,7 @@ const populateKitTable = (tableBody, kitData) => {
   // TODO = Make the number dynamic and editable
   let extraRow = "";
   console.log(kitData);
-  // Create loop
+  // Create loop and iterate all array items
   for (let i = 0; i < kitData.length; i++) {
     // Append a row with data cells and corresponding data from fetch
     tableRow += `
@@ -147,42 +151,46 @@ const populateKitTable = (tableBody, kitData) => {
             <td>${kitData[i].collectionCupId}</td>
             <td>${kitData[i].collectionCardId}</td>
         </tr>`;
-
-    // If the current iteration is the last item, add an extra row
-    if (i === kitData.length - 1) {
-      // Add two to current i value to display correct line item number increment
-      extraRow = `        
-            <tr class="new-row">
-                <th scope="row">${i + 2}</th>
-                <td>
-                  
-                    <input id="input-usps" type="string" autocomplete="off" style="width:80%"/>
-                  
-                </td>
-                <td>
-                  
-                    <input id="input-supply-kit" type="string" autocomplete="off" style="width:80%"/>
-                  
-                </td>
-                <td>
-                  
-                    <input id="input-specimen-kit" type="string" autocomplete="off" style="width:80%"/>
-                  
-                </td>
-                <td>
-                  
-                    <input id="input-collection-cup" type="string" autocomplete="off" style="width:80%"/>
-                  
-                </td>
-                <td>
-                  
-                    <input id="input-collection-card" type="string" autocomplete="off" style="width:80%"/>
-                  
-                </td>
-            </tr>
-            `;
-      tableRow += extraRow;
+    
+    // Update the last row number
+    lastRowNumber = i+1
+    console.log(lastRowNumber)
+    // // If the current iteration is the last item and matches length of last row variable, add an extra row
+    if(lastRowNumber === kitData.length) {
+      console.log(lastRowNumber,kitData.length)
+      extraRow =`        
+      <tr class="new-row">
+          <th scope="row">${i + 2}</th>
+          <td>
+            
+              <input id="input-usps" type="string" autocomplete="off" style="width:80%"/>
+            
+          </td>
+          <td>
+            
+              <input id="input-supply-kit" type="string" autocomplete="off" style="width:80%"/>
+            
+          </td>
+          <td>
+            
+              <input id="input-specimen-kit" type="string" autocomplete="off" style="width:80%"/>
+            
+          </td>
+          <td>
+            
+              <input id="input-collection-cup" type="string" autocomplete="off" style="width:80%"/>
+            
+          </td>
+          <td>
+            
+              <input id="input-collection-card" type="string" autocomplete="off" style="width:80%"/>
+            
+          </td>
+      </tr>
+      `;
+      tableRow += extraRow
     }
+
     tableBody.innerHTML = tableRow;
   }
 };
@@ -301,7 +309,9 @@ const clearAllInputs = (inputElements) => {
 // Create extra table row
 
 const addTableRow = () => {
-  
+  // Take all inputs from current row and create a new row with blank inputs
+  // - Note: Make Sure to toggle id off and add back on later
+  // - Note: Increment row correctly
 };
 
 /*

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -259,11 +259,11 @@ const saveItem = async (
     tableNumRows++;
 
     // ADD DATA to TABLE
+    addKitData(jsonSaveBody);
+
     addRow(jsonSaveBody, tableNumRows);
 
     clearRowInputs(inputElements);
-
-    return addKitData(jsonSaveBody);
   });
 };
 

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -2,20 +2,63 @@ import { homeCollectionNavbar } from "./homeCollectionNavbar.js";
 import { userDashboard } from "../dashboard.js";
 
 export const kitAssemblyScreen = async (auth, route) => {
-    const user = auth.currentUser;
-    if(!user) return;
-    const username = user.displayName ? user.displayName : user.email;
-    //showAnimation();
-    kitAssemblyTemplate(auth, route);
-}             
-
+  const user = auth.currentUser;
+  if (!user) return;
+  const username = user.displayName ? user.displayName : user.email;
+  //showAnimation();
+  kitAssemblyTemplate(auth, route);
+};
 
 const kitAssemblyTemplate = (auth, route) => {
-    let template = ``;
-    template += homeCollectionNavbar();
-    template += `
+  let template = ``;
+  template += homeCollectionNavbar();
+  template += `
                 <div class="row align-center welcome-screen-div">
                         <div class="col"><h3>Kit Assembly</h3></div>
-                </div>  `
-    document.getElementById('contentBody').innerHTML = template;
-}
+                </div>  `;
+
+  template += `
+            <table id="kit-assembly-table" class="table   table-bordered">
+                <thead>
+                    <tr>
+                        <th scope="col">Line Item</th>
+                        <th scope="col">Specify Kit USPS Tracking Number</th>
+                        <th scope="col">Supply Kit ID</th>
+                        <th scope="col">Specimen Kit ID</th>
+                        <th scope="col">Collection Cup ID</th>
+                        <th scope="col">Collection Card ID</th>
+                    </tr>
+                </thead>
+                
+                <tbody>
+                    <tr>
+                        <th scope="row">1</th>
+                        <td>9400 1234 5678 9999 8765 00</td>
+                        <td>JKL123422</td>
+                        <td>GHI123422</td>
+                        <td>DEF123422</td>
+                        <td>ABC123422</td>
+                    </tr>
+                </tbody>
+            </table>`;
+  document.getElementById("contentBody").innerHTML = template;
+};
+
+
+/* 
+
+KIT ASSEMBLY TABLE HEADERS 
+
+1. Line Item - NUMERIC
+2. Specify Kit USPS Tracking Number - NUMBER
+NOTE: USPS has 22 numbers long and Arranged in groups of 4 digits
+EXAMPLE: 9400 1234 5678 9999 8765 00 
+3. Supply Kit ID - ALPHA NUMERIC
+EXAMPLE(?) - JKL123422
+4. Specimen Kit ID - ALPHA NUMERIC
+EXAMPLE(?) - GHI123422
+5. Collection Cup ID - ALPHA NUMERIC
+EXAMPLE(?) - DEF123422
+6. Collection Card ID - ALPHA NUMERIC
+EXAMPLE(?) - ABC123422 
+*/

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -87,9 +87,11 @@ const addKitData = async (jsonSaveBody) => {
     body: JSON.stringify(jsonSaveBody),
   });
   const addKit = await response.json();
-  // console.log(addKit);
+  console.log(jsonSaveBody);
+  console.log(addKit);
+  debugger;
   return addKit;
-  // debugger;
+  
 };
 
 const kitAssemblyTemplate = async (auth, route) => {

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -2,10 +2,9 @@ import { homeCollectionNavbar } from "./homeCollectionNavbar.js";
 import { userDashboard } from "../dashboard.js";
 import { getIdToken } from "../../shared.js";
 
-
-// REMOVE & REFACTOR FOR LATER***
-const api = 'https://us-central1-nih-nci-dceg-connect-dev.cloudfunctions.net/biospecimen?'; 
-
+// TODO: REMOVE & REFACTOR FOR LATER***
+const api =
+  "https://us-central1-nih-nci-dceg-connect-dev.cloudfunctions.net/biospecimen?";
 
 export const kitAssemblyScreen = async (auth, route) => {
   const user = auth.currentUser;
@@ -14,18 +13,56 @@ export const kitAssemblyScreen = async (auth, route) => {
   //showAnimation();
   await kitAssemblyTemplate(auth, route);
 
-  const kitData = await getKitData().then(res => res.data)
-  const tableBody = document.getElementById("kit-assembly-table-body")
-  populateKitTable(tableBody,kitData)
-
+  const kitData = await getKitData().then((res) => res.data);
+  const tableBody = document.getElementById("kit-assembly-table-body");
+  populateKitTable(tableBody, kitData);
   // Render Page Buttons
-  kitAssemblyPageButtons()
+  kitAssemblyPageButtons();
+
+  let inputUsps = document.getElementById("input-usps");
+  let inputSupplyKit = document.getElementById("input-supply-kit");
+  let inputSpecimenKit = document.getElementById("input-specimen-kit");
+  let inputCollectionCup = document.getElementById("input-collection-cup");
+  let inputCollectionCard = document.getElementById("input-collection-card");
+  
+  inputUsps.addEventListener("input", (e) => {
+    
+    // console.log(e.target)
+    inputUsps.value = e.target.value
+    console.log(inputUsps.value)
+  })
+
+  inputSupplyKit.addEventListener("input", (e) => {
+    inputSupplyKit.value = e.target.value
+    console.log(inputSupplyKit.value)
+  })
+
+  inputSpecimenKit.addEventListener("input", (e) => {
+    inputSpecimenKit.value = e.target.value
+    console.log(inputSpecimenKit)
+    console.log(inputSpecimenKit.value)
+  })
+
+  inputCollectionCup.addEventListener("input", (e)=> {
+    inputCollectionCup.value = e.target.value
+    console.log(inputCollectionCup)
+  })
+
+  inputCollectionCard.addEventListener("input", (e) => {
+    inputCollectionCard.value = e.target.value
+    console.log(inputCollectionCard)
+    console.log(e.target.value)
+
+    // debugger;
+  })
 
   // Invoke function to add event listener when clicked
-  // saveItemModal()
+  saveItem(tableBody,inputUsps,inputSupplyKit,inputSpecimenKit,inputCollectionCup,inputCollectionCard);
 };
 
-// REMOVE & REFACTOR FOR LATER, ADD TO SHARED.JS FILE?***
+
+
+// TODO: REMOVE & REFACTOR FOR LATER, ADD TO SHARED.JS FILE?***
 // GET METHOD REQUEST
 const getKitData = async () => {
   const idToken = await getIdToken();
@@ -43,6 +80,7 @@ const getKitData = async () => {
         // debugger;
         return kitData;
       }
+      // TODO: ADD a row where a user is able to enter into speecfic table cells
       throw new Error("No Kit Assembly data!");
     } else {
       throw new Error("Status Code is not 200!");
@@ -52,16 +90,27 @@ const getKitData = async () => {
   }
 };
 
-// REMOVE & REFACTOR FOR LATER, ADD TO SHARED.JS FILE?***
+// TODO: REMOVE & REFACTOR FOR LATER, ADD TO SHARED.JS FILE?***
 // POST METHOD REQUEST
-const addKitData = () => {
-
-}
+const addKitData = async (jsonSaveBody) => {
+  const idToken = await getIdToken();
+  const response = await fetch(`${api}api=addKitData`,{
+    method:"POST",
+    headers: {
+      Authorization: "Bearer" + idToken,
+    },
+    body: JSON.stringify(jsonSaveBody)
+  })
+  const addKit = await response.clone().json()
+  console.log(addKit)
+  return addKit
+  debugger;
+};
 
 const kitAssemblyTemplate = async (auth, route) => {
-//   const kitData = await getKitData().then(res => res.data)
+  //   const kitData = await getKitData().then(res => res.data)
 
-//   console.log(kitData)
+  //   console.log(kitData)
   let template = ``;
   template += homeCollectionNavbar();
   template += `
@@ -92,61 +141,109 @@ const kitAssemblyTemplate = async (auth, route) => {
   document.getElementById("contentBody").innerHTML = template;
 };
 
-
 const populateKitTable = (tableBody, kitData) => {
-    // tableBody - targetable body element, use when inserting an element when looping
-    let tableRow = ''
+  // tableBody - targetable body element, use when inserting an element when looping
+  let tableRow = "";
 
-    // TODO = Make the number dynamic and editable
-    let extraRow = ''
-    console.log(kitData)
-    // Create loop 
-    for(let i = 0; i < kitData.length; i++) {
-        // Append a row with data cells and corresponding data from fetch
-        tableRow += `
+  // TODO = Make the number dynamic and editable
+  let extraRow = "";
+  console.log(kitData);
+  // Create loop
+  for (let i = 0; i < kitData.length; i++) {
+    // Append a row with data cells and corresponding data from fetch
+    tableRow += `
         <tr>
-            <th scope="row">${i+1}</th>
+            <th scope="row">${i + 1}</th>
             <td>${kitData[i].uspsTrackingNumber}</td>
             <td>${kitData[i].supplyKitId}</td>
             <td>${kitData[i].specimenKitId}</td>
             <td>${kitData[i].collectionCupId}</td>
             <td>${kitData[i].collectionCardId}</td>
-        </tr>`
-        
-        // If the current iteration is the last item, add an extra row
-        if(i === kitData.length-1){
-            // Add two to current i value to display correct line item number
-            extraRow = `        
+        </tr>`;
+
+    // If the current iteration is the last item, add an extra row
+    if (i === kitData.length - 1) {
+      // Add two to current i value to display correct line item number
+      // Note: cannot add event listeners to td elements
+      extraRow = `        
             <tr class="new-row">
-                <th scope="row">${i+2}</th>
-                <td contenteditable="true"></td>
-                <td contenteditable="true"></td>
-                <td contenteditable="true"></td>
-                <td contenteditable="true"></td>
-                <td contenteditable="true"></td>
+                <th scope="row">${i + 2}</th>
+                <td>
+                  
+                    <input id="input-usps" type="string" value="" style="width:80%"/>
+                  
+                </td>
+                <td>
+                  
+                    <input id="input-supply-kit" type="string" value="" style="width:80%"/>
+                  
+                </td>
+                <td>
+                  
+                    <input id="input-specimen-kit" type="string" value="" style="width:80%"/>
+                  
+                </td>
+                <td>
+                  
+                    <input id="input-collection-cup" type="string" value="" style="width:80%"/>
+                  
+                </td>
+                <td>
+                  
+                    <input id="input-collection-card" type="string" value="" style="width:80%"/>
+                  
+                </td>
             </tr>
-            `
-            tableRow += extraRow
-        }
-        tableBody.innerHTML = tableRow
+            `;
+      tableRow += extraRow;
     }
-}
+    tableBody.innerHTML = tableRow;
+  }
+};
 
 const kitAssemblyPageButtons = () => {
-    const contentBody = document.getElementById("contentBody")
-    let buttonContainerTemplate = ""
+  const contentBody = document.getElementById("contentBody");
+  let buttonContainerTemplate = "";
 
-    console.log(contentBody)
-    
-    buttonContainerTemplate += `
-        <div class="kit-assembly-button-container d-flex justify-content-around" style="margin: 8rem;">
-            <button id="kit-assembly-save-button" type="button" class="btn btn-outline-primary" data-toggle="modal" data-target="#saveModal">Save</button>
-            <button type="button" class="btn btn-success">Continue to Print Addresses</button>
+  console.log(contentBody);
+
+  buttonContainerTemplate += `
+        <div class="kit-assembly-button-container d-flex justify-content-center" style="margin: 8rem;">
+          <button id="kit-assembly-cancel-button" type="button" class="btn btn-outline-secondary" style="margin-right:10%">Cancel</button>
+          <button id="kit-assembly-save-button" type="button" class="btn btn-outline-primary" data-toggle="modal" data-target="#saveModal">Save</button>
         </div> 
-    `
-    contentBody.innerHTML += buttonContainerTemplate
-}
+    `;
+  contentBody.innerHTML += buttonContainerTemplate;
+};
 
+const saveItem = async (tableBody,inputUsps,inputSupplyKit,inputSpecimenKit,inputCollectionCup,inputCollectionCard) => {
+  const saveButton = document.getElementById("kit-assembly-save-button");
+  saveButton.addEventListener("click", (e) => {
+    console.log("save button clicked");
+    console.log(tableBody);
+    // Target Last row and the last row's children elements
+
+    // console.log(tableBody.lastElementChild.children);
+    // const lastRowElements = tableBody.lastElementChild.children;
+    // for (let i = 1; i < lastRowElements.length; i++) {}
+    jsonSaveBody.collectionCardId = inputCollectionCard.value
+    jsonSaveBody.supplyKitId = inputSupplyKit.value
+    jsonSaveBody.collectionCupId = inputCollectionCup.value
+    jsonSaveBody.specimenKitId = inputSpecimenKit.value
+    jsonSaveBody.uspsTrackingNumber = inputUsps.value
+    
+    return addKitData(jsonSaveBody).then(res => console.log(res))
+  });
+};
+
+// Create JSON body object to be modified
+const jsonSaveBody = {
+  collectionCardId: "",
+  supplyKitId: "",
+  collectionCupId: "",
+  specimenKitId: "",
+  uspsTrackingNumber: "",
+};
 
 /*
 TODO STEPS:
@@ -169,4 +266,9 @@ TODO STEPS:
     - Make save button make a post request and have a popup saying success
 7. Have an Add button create a new line to table
 8. Handle acceptable POST request on the client side
+
+
+BONUS:
+
+SORT Kits from Oldest to Newest
 */

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -2,7 +2,6 @@ import { homeCollectionNavbar } from "./homeCollectionNavbar.js";
 import { userDashboard } from "../dashboard.js";
 import { getIdToken } from "../../shared.js";
 
-// TODO: REMOVE & REFACTOR FOR LATER***
 const api =
   "https://us-central1-nih-nci-dceg-connect-dev.cloudfunctions.net/biospecimen?";
 
@@ -34,6 +33,10 @@ export const kitAssemblyScreen = async (auth, route) => {
     inputCollectionCup,
     inputCollectionCard
   );
+
+  const inputElements = {inputUsps,inputSupplyKit,inputSpecimenKit,inputCollectionCard,inputCollectionCup}
+
+  await clearAllInputs(inputElements) 
 
   // Invoke function to add event listener when clicked
   await saveItem(
@@ -190,8 +193,9 @@ const kitAssemblyPageButtons = () => {
 
   buttonContainerTemplate += `
         <div class="kit-assembly-button-container d-flex justify-content-center" style="margin: 8rem;">
-          <button id="kit-assembly-cancel-button " type="button" class="btn btn-outline-secondary btn-lg" style="margin-right:10%">Cancel</button>
-          <button id="kit-assembly-save-button" type="submit" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#saveModal">Save</button>
+          <button id="kit-assembly-cancel-button" type="button" class="btn btn-outline-secondary btn-lg" style="margin-right:10%">Cancel</button>
+
+          <button id="kit-assembly-save-button" type="submit" class="btn btn-primary btn-lg">Save</button>
         </div> 
     `;
   contentBody.innerHTML += buttonContainerTemplate;
@@ -209,6 +213,7 @@ const saveItem = async (
   saveButton.addEventListener("click", (e) => {
     console.log("save button clicked");
     console.log(tableBody);
+    e.preventDefault()
     // Target Last row and the last row's children elements
 
     // console.log(tableBody.lastElementChild.children);
@@ -275,9 +280,27 @@ const jsonSaveBody = {
   uspsTrackingNumber: "",
 };
 
+
+// Cancel Button Clear Inputs Function
+
+const clearAllInputs = (inputElements) => {
+  const cancelButton = document.getElementById("kit-assembly-cancel-button")
+  
+  console.log(inputElements)
+  cancelButton.addEventListener("click",(e)=> {
+    e.preventDefault() 
+    // for in to loop over all property keys
+    for(let property in inputElements) {
+      inputElements[property].value = ""
+    }
+  })
+}
+
 // Create extra table row
 
-const addTableRow = () => {};
+const addTableRow = () => {
+  
+};
 
 /*
 TODO STEPS:

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -91,7 +91,6 @@ const getKitData = async () => {
     console.log(e);
   }
 };
-
 /*
 ==================================================
 POST METHOD REQUEST - Add a Kit
@@ -114,7 +113,7 @@ const addKitData = async (jsonSaveBody) => {
 
   if (response.status === 200) {
     alert += `
-    <div class="alert alert-success alert-dismissible fade show" role="alert" position="relative" style="top:50%">
+    <div class="alert alert-success alert-dismissible fade show" role="alert">
       <strong>Kit was saved successfully!</strong>
       <button type="button" class="close" data-dismiss="alert" aria-label="Close">
         <span aria-hidden="true">&times;</span>
@@ -238,8 +237,6 @@ const saveItem = async (
   const saveButton = document.getElementById("kit-assembly-save-button");
   let tableNumRows = tableBody.rows.length;
   saveButton.addEventListener("click", (e) => {
-    tableNumRows++;
-
     e.preventDefault();
 
     // Target Last row and the last row's children elements
@@ -258,40 +255,14 @@ const saveItem = async (
       }
     }
 
+    // Increment with all filled input fields
+    tableNumRows++;
+
     // ADD DATA to TABLE
-    addRow(jsonSaveBody);
-    function addRow(jsonSaveBody) {
-      // Target Line Item Number
-      let newRowEl = document.querySelector(".new-row");
-      newRowEl.firstChild.nextSibling.innerHTML = tableNumRows;
-      newRowEl.insertAdjacentHTML(
-        "beforebegin",
-        `<tr>
-    <th scope="row">${tableNumRows - 1}</th>
-    <td>
-        ${jsonSaveBody.uspsTrackingNumber}
-    </td>
-    <td>
-        ${jsonSaveBody.supplyKitId}
-    </td>
-    <td>
-        ${jsonSaveBody.specimenKitId}
-    </td>
-    <td>
-        ${jsonSaveBody.collectionCupId}
-    </td>
-    <td>
-        ${jsonSaveBody.collectionCardId}
-    </td>
-</tr>`
-      );
-    }
-    clearRowInputs();
-    function clearRowInputs() {
-      for (let property in inputElements) {
-        inputElements[property].value = "";
-      }
-    }
+    addRow(jsonSaveBody, tableNumRows);
+
+    clearRowInputs(inputElements);
+
     return addKitData(jsonSaveBody);
   });
 };
@@ -336,6 +307,41 @@ const jsonSaveBody = {
   specimenKitId: "",
   uspsTrackingNumber: "",
 };
+
+// Add New row with inputs
+function addRow(jsonSaveBody, tableNumRows) {
+  // Target Line Item Number
+  let newRowEl = document.querySelector(".new-row");
+  newRowEl.firstChild.nextSibling.innerHTML = tableNumRows;
+  newRowEl.insertAdjacentHTML(
+    "beforebegin",
+    `<tr>
+<th scope="row">${tableNumRows - 1}</th>
+<td>
+    ${jsonSaveBody.uspsTrackingNumber}
+</td>
+<td>
+    ${jsonSaveBody.supplyKitId}
+</td>
+<td>
+    ${jsonSaveBody.specimenKitId}
+</td>
+<td>
+    ${jsonSaveBody.collectionCupId}
+</td>
+<td>
+    ${jsonSaveBody.collectionCardId}
+</td>
+</tr>`
+  );
+}
+
+// Clear the row of existing user inputs
+function clearRowInputs(inputElements) {
+  for (let property in inputElements) {
+    inputElements[property].value = "";
+  }
+}
 
 // Cancel Button Clear Inputs Function
 

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -1,5 +1,11 @@
 import { homeCollectionNavbar } from "./homeCollectionNavbar.js";
 import { userDashboard } from "../dashboard.js";
+import { biospecimenUsers,getIdToken } from "../../shared.js";
+
+
+// REMOVE & REFACTOR FOR LATER***
+const api = 'https://us-central1-nih-nci-dceg-connect-dev.cloudfunctions.net/biospecimen?'; 
+
 
 export const kitAssemblyScreen = async (auth, route) => {
   const user = auth.currentUser;
@@ -9,7 +15,34 @@ export const kitAssemblyScreen = async (auth, route) => {
   kitAssemblyTemplate(auth, route);
 };
 
-const kitAssemblyTemplate = (auth, route) => {
+// REMOVE & REFACTOR FOR LATER, ADD TO SHARED.JS FILE?***
+const getKitData = async () => {
+    const idToken = await getIdToken();
+    const response = await fetch(`${api}api=getKitData`,{
+        method:"GET",
+        headers: {
+            Authorization:"Bearer"+idToken
+        }
+    })
+
+    const kitData = await response.json()
+
+    // TODO - ERROR HANDLING, MAYBE TRY/CATCH BLOCK?
+    // if(kitData.data.length < 1) {
+    //     return console.log('No data')
+    // }
+    // else {
+    //     console.log(kitData)
+    //     return kitData
+    // }
+    
+    return kitData
+}
+
+const kitAssemblyTemplate = async (auth, route) => {
+  const kitData = await getKitData().then(res => res.data)
+
+  await console.log(kitData)
   let template = ``;
   template += homeCollectionNavbar();
   template += `
@@ -43,22 +76,3 @@ const kitAssemblyTemplate = (auth, route) => {
             </table>`;
   document.getElementById("contentBody").innerHTML = template;
 };
-
-
-/* 
-
-KIT ASSEMBLY TABLE HEADERS 
-
-1. Line Item - NUMERIC
-2. Specify Kit USPS Tracking Number - NUMBER
-NOTE: USPS has 22 numbers long and Arranged in groups of 4 digits
-EXAMPLE: 9400 1234 5678 9999 8765 00 
-3. Supply Kit ID - ALPHA NUMERIC
-EXAMPLE(?) - JKL123422
-4. Specimen Kit ID - ALPHA NUMERIC
-EXAMPLE(?) - GHI123422
-5. Collection Cup ID - ALPHA NUMERIC
-EXAMPLE(?) - DEF123422
-6. Collection Card ID - ALPHA NUMERIC
-EXAMPLE(?) - ABC123422 
-*/


### PR DESCRIPTION
This PR addresses the following features:
-> Added table for KIT ASSEMBLY PAGE 
-> Functionality to retrieve all kit resources and render resources to table
-> Correctly increment line item number after retrieving data from database and adding kit data
-> Added Submit button to save kit data and add kit data to database
-> Added Cancel Button to clear inputs from input Row


Checklist:
- [x] Code cleanup
- [x] Check for ES Lint warnings
- [ ] Verify test cases
- [x] Check for GIT conflicts
- [ ] Verified unit tests pass with current changes
- [ ] Any dependencies or modules added 
- [x] Attach PoC
- [x] Notes added

Notes: 
Error handling will be needed for future pull requests to the Kit Assembly Page. More refactors will also be included in future pull requests. The current pull request is a the mvp for the Kit Assembly Page.

PoC:

Kit Assembly Page:
<img width="1400" alt="Screen Shot 2021-07-28 at 5 57 53 PM" src="https://user-images.githubusercontent.com/33293205/127401857-4bec9008-2dfd-4882-a546-e210aae63345.png">

Kit Assembly Page - Alert on Empty Inputs:
<img width="1517" alt="Screen Shot 2021-07-28 at 5 58 16 PM" src="https://user-images.githubusercontent.com/33293205/127401912-86ff2079-9474-4adb-a17a-13990ee588d3.png">

Kit Assembly Page - On Successful Save:
<img width="1270" alt="Screen Shot 2021-07-28 at 5 58 42 PM" src="https://user-images.githubusercontent.com/33293205/127401957-b25bd3bb-f206-4b73-8473-f26797cf98d0.png">
 


