### PR TITLE
[Hotfix] BPTL Dashboard: Changed getParticipantSelection filter to all

### DIFF
--- a/src/pages/homeCollection/kitShipment.js
+++ b/src/pages/homeCollection/kitShipment.js
@@ -37,7 +37,7 @@ import { showAnimation, hideAnimation, getIdToken, getParticipantSelection } fro
   
  const verifyScannedCode = async (uspsHit) => {
      const a = document.getElementById('scannedCode');
-     const response = await getParticipantSelection("assigned");
+     const response = await getParticipantSelection("all");
      const assignedParticipants = response.data
 
      if (a) {


### PR DESCRIPTION
This PR address following fix:
Changed getParticipantSelection filter to all in Kit Shipment