### PR TITLE
BPTL Dashboard: Add Today's Date to Pickup Date Input Box

### DIFF
--- a/src/pages/homeCollection/kitShipment.js
+++ b/src/pages/homeCollection/kitShipment.js
@@ -60,7 +60,7 @@ const confirmPickupTemplate = (uspsHit) => {
   let template = ``;
   template += `        
                   <div class="card-body">
-                      <span id="pickupDate"> Pickup Date </span>  : <input required type="text" name="inputDate" id="inputDate" style="text-align:center" value = ${date} />
+                      <span id="pickupDate"> Pickup Date </span>  : <input required type="text" name="inputDate" id="inputDate" value = ${date} />
                         <br />
                         <div class="form-check" style="padding-top: 20px;">
                             <input class="form-check-input" name="options" type="checkbox" id="defaultCheck" checked>

--- a/src/pages/homeCollection/kitShipment.js
+++ b/src/pages/homeCollection/kitShipment.js
@@ -1,25 +1,28 @@
-import { nonUserNavBar, unAuthorizedUser } from './../../navbar.js';
+import { nonUserNavBar, unAuthorizedUser } from "./../../navbar.js";
 import { homeCollectionNavbar } from "./homeCollectionNavbar.js";
-import { showAnimation, hideAnimation, getIdToken, getParticipantSelection } from "../../shared.js";
+import {
+  showAnimation,
+  hideAnimation,
+  getIdToken,
+  getParticipantSelection,
+} from "../../shared.js";
 
-  
-  export const kitShipmentScreen = async (auth, route) => {
-    const user = auth.currentUser;
-    let uspsHit = ``;
-    if (!user) return;
-    const username = user.displayName ? user.displayName : user.email;
-    kitShipmentTemplate(username, auth, route);
-    verifyScannedCode(uspsHit);
-  };
-  
-  
-  const kitShipmentTemplate = async (name, auth, route) => {
-    let template = ``;
-    template += homeCollectionNavbar();
-    template += ` 
+export const kitShipmentScreen = async (auth, route) => {
+  const user = auth.currentUser;
+  let uspsHit = ``;
+  if (!user) return;
+  const username = user.displayName ? user.displayName : user.email;
+  kitShipmentTemplate(username, auth, route);
+  verifyScannedCode(uspsHit);
+};
+
+const kitShipmentTemplate = async (name, auth, route) => {
+  let template = ``;
+  template += homeCollectionNavbar();
+  template += ` 
                       <div id="root root-margin" style="padding-top: 25px;">
                       <div id="alert_placeholder"></div>
-                      <span> <h3 style="text-align: center; margin: 0 0 1rem;">Kit Shippment</h3> </span>
+                      <span> <h3 style="text-align: center; margin: 0 0 1rem;">Kit Shipment</h3> </span>
                       <div class="container-fluid" style="padding-top: 50px;">     
                           <div class="card">
                           <div class="card-body">
@@ -31,29 +34,33 @@ import { showAnimation, hideAnimation, getIdToken, getParticipantSelection } fro
                         </div>
                   </div>
              </div>`;
-    document.getElementById("contentBody").innerHTML = template;
-    document.getElementById('navbarNavAltMarkup').innerHTML = nonUserNavBar(name);
-  };
-  
- const verifyScannedCode = async (uspsHit) => {
-     const a = document.getElementById('scannedCode');
-     const response = await getParticipantSelection("all");
-     const assignedParticipants = response.data
+  document.getElementById("contentBody").innerHTML = template;
+  document.getElementById("navbarNavAltMarkup").innerHTML = nonUserNavBar(name);
+};
 
-     if (a) {
-         a.addEventListener('change', () => {
-          uspsHit = assignedParticipants.filter( el => (parseInt(el.usps_trackingNum) === parseInt(a.value)) )
-          uspsHit.length != 0 ? confirmPickupTemplate(uspsHit) : tryAgainTemplate();
-         })
-     }
- }
+const verifyScannedCode = async (uspsHit) => {
+  const a = document.getElementById("scannedCode");
+  const response = await getParticipantSelection("all");
+  const assignedParticipants = response.data;
 
-  const confirmPickupTemplate = (uspsHit) => {
-    const a = document.getElementById('cardBody');
-    let template = ``
-    template += `        
+  console.log(assignedParticipants);
+  if (a) {
+    a.addEventListener("change", () => {
+      uspsHit = assignedParticipants.filter(
+        (el) => parseInt(el.usps_trackingNum) === parseInt(a.value)
+      );
+      uspsHit.length != 0 ? confirmPickupTemplate(uspsHit) : tryAgainTemplate();
+    });
+  }
+};
+
+const confirmPickupTemplate = (uspsHit) => {
+  const a = document.getElementById("cardBody");
+  let date = currentDate();
+  let template = ``;
+  template += `        
                   <div class="card-body">
-                      <span id="pickupDate"> Pickup Date </span>  : <input required type="text" name="inputDate" id="inputDate"  />
+                      <span id="pickupDate"> Pickup Date </span>  : <input required type="text" name="inputDate" id="inputDate" style="text-align:center" value = ${date} />
                         <br />
                         <div class="form-check" style="padding-top: 20px;">
                             <input class="form-check-input" name="options" type="checkbox" id="defaultCheck" checked>
@@ -61,68 +68,83 @@ import { showAnimation, hideAnimation, getIdToken, getParticipantSelection } fro
                         </div>
                       </div>
                       <div style="display:inline-block; padding: 10px 10px;">
-                        <button type="submit" class="btn btn-danger">Cancel</button>
+                        <button type="submit" class="btn btn-danger" id="cancelResponse">Cancel</button>
                         <button type="submit" class="btn btn-primary" id="saveResponse">Save</button>
-                      </div>`
-    a.innerHTML = template;
-    saveResponse(uspsHit);
-  }
+                      </div>`;
+  a.innerHTML = template;
+  saveResponse(uspsHit);
+  cancelResponse(a);
+};
 
-  const tryAgainTemplate = () => {
-    const a = document.getElementById('cardBody');
-    let template = ``
-    template += `        
+const tryAgainTemplate = () => {
+  const a = document.getElementById("cardBody");
+  let template = ``;
+  template += `        
                 <div class="card-body">
                     <span> Couldn't find USPS Tracking Number </span>
                     <br />
-                </div>`
-    a.innerHTML = template;
+                </div>`;
+  a.innerHTML = template;
+};
+
+const saveResponse = (uspsHit) => {
+  const a = document.getElementById("saveResponse");
+  let data = {};
+  data.id = uspsHit && uspsHit[0].id;
+  if (a) {
+    a.addEventListener("click", (e) => {
+      data.pickup_date = document.getElementById("inputDate").value;
+      data.confirm_pickup = document.getElementById("defaultCheck").checked;
+      setShippedResponse(data);
+    });
   }
+};
 
+const cancelResponse = (cardBody) => {
+  const cancelButton = document.getElementById("cancelResponse");
+  let template = ``;
+  if (cancelButton) {
+    cancelButton.addEventListener("click", (e) => {
+      cardBody.innerHTML = template;
+    });
+  }
+};
 
-  const saveResponse = (uspsHit) => {
-    const a = document.getElementById('saveResponse');
-    let data = {} 
-    data.id = uspsHit && uspsHit[0].id
-    if(a){
-      a.addEventListener("click", (e) => {
-        data.pickup_date = document.getElementById('inputDate').value;
-        data.confirm_pickup = document.getElementById('defaultCheck').checked;
-        setShippedResponse(data);
-      })
+const setShippedResponse = async (data) => {
+  showAnimation();
+  const idToken = await getIdToken();
+  const response = await await fetch(
+    `https://us-central1-nih-nci-dceg-connect-dev.cloudfunctions.net/biospecimen?api=shipped`,
+    {
+      method: "POST",
+      body: JSON.stringify(data),
+      headers: {
+        Authorization: "Bearer " + idToken,
+        "Content-Type": "application/json",
+      },
     }
-  }
-
-  const setShippedResponse = async (data) => {
-    showAnimation();
-    const idToken = await getIdToken(); 
-    const response = await await fetch(
-      `https://us-central1-nih-nci-dceg-connect-dev.cloudfunctions.net/biospecimen?api=shipped`,
-      {
-        method: "POST",
-        body: JSON.stringify(data),
-        headers: {
-          Authorization: "Bearer " + idToken,
-          "Content-Type": "application/json",
-        },
-      }
-    );
-    hideAnimation();
-    if (response.status === 200) {
-      let alertList = document.getElementById('alert_placeholder');
-      let template = ``
-      template += `
+  );
+  hideAnimation();
+  if (response.status === 200) {
+    let alertList = document.getElementById("alert_placeholder");
+    let template = ``;
+    template += `
                 <div class="alert alert-success alert-dismissible fade show" role="alert">
                   Response saved!
                   <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                             <span aria-hidden="true">&times;</span>
                         </button>
-                </div>`
-      alertList.innerHTML = template;
-      document.getElementById('scannedCode').value = ``;
-      document.getElementById('cardBody').innerHTML = ``;
-      return true; // return success modal screen
-    } else {
-      alert("Error");
-    }
+                </div>`;
+    alertList.innerHTML = template;
+    document.getElementById("scannedCode").value = ``;
+    document.getElementById("cardBody").innerHTML = ``;
+    return true; // return success modal screen
+  } else {
+    alert("Error");
   }
+};
+
+const currentDate = () => {
+  let date = new Date().toLocaleDateString();
+  return date;
+};

--- a/src/pages/homeCollection/participantSelectionHeaders.js
+++ b/src/pages/homeCollection/participantSelectionHeaders.js
@@ -28,7 +28,6 @@ export const renderKitStatusList = () => {
                         <option id="select-address-printed" value="addressPrinted">Address Printed</option>
                         <option id="select-assigned" value="assigned">Assigned</option>
                         <option id="select-shipped" value="shipped">Shipped</option>
-                        <option id="select-received" value="received">Received</option>
                     </select>
                 </div>
                 </br>


### PR DESCRIPTION
This PR addresses the following features:

-> Render today's date on pickup date input field after a a successful scan opens a card body

-> Add event listener to close button to empty card body contents and to go back to scan

-> Remove Received option from Participant Dropdown 

Checklist:
- [x] Code cleanup
- [x] Check for ES Lint warnings
- [ ] Verify test cases
- [x] Check for GIT conflicts
- [ ] Verified unit tests pass with current changes
- [ ] Any dependencies or modules added 
- [ ] Attach PoC
- [ ] Notes added
