### PR TITLE
Kit Assembly Input Field UI Labels & Fixes

### DIFF
--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -220,19 +220,28 @@ const populateKitTable = (tableBody, kitData) => {
         <tr class="new-row">      
           <th scope="row">${lastRowNumber + 1}</th>
           <td>
-              <input id="input-usps" autocomplete="off" style="width:80%"/>
+            <input id="input-usps" autocomplete="off" name="input-usps" style="width:100%;text-overflow: ellipsis;" placeholder="21168034670515269250"/>
+            <label for ="input-usps" style="font-size:.8rem;">Ex. 21168034670515269250</label>
           </td>
           <td>
-              <input id="input-supply-kit" type="string" autocomplete="off" style="width:80%"/>
+              <input id="input-supply-kit" type="string" autocomplete="off" name="input-supply-kit" style="width:80%" placeholder="CXA261331"/>
+              <label for ="input-supply-kit" style="font-size:.8rem;">Ex. CXA261331</label>
           </td>
           <td>
-              <input id="input-specimen-kit" type="string" autocomplete="off" style="width:80%"/>
+              <input id="input-specimen-kit" type="string" autocomplete="off" name="input-specimen-kit" style="width:80%" name="input-specimen-kit" placeholder="CXA261331"/>
+              <label for ="input-specimen-kit" style="font-size:.8rem;">Ex. CXA261331</label>
           </td>
           <td>
-              <input id="input-collection-cup" type="string" autocomplete="off" style="width:80%"/>
+              <input id="input-collection-cup" type="string" autocomplete="off" style="width:80%; text-overflow: ellipsis;" placeholder="QBC436604 0002
+              " name"input-collection-cup"/>
+              <label for ="input-collection-cup" style="font-size:.8rem;">Ex. QBC436604 0002
+              </label>
           </td>
           <td>
-              <input id="input-collection-card" type="string" autocomplete="off" style="width:80%"/>
+              <input id="input-collection-card" type="string" autocomplete="off" style="width:80%" placeholder="QBC436604 0002
+              " name="input-collection-card"/>
+              <label for ="input-collection-card" style="font-size:.8rem;">Ex. QBC436604 0002
+              </label>
           </td>
       </tr>
       `;
@@ -296,6 +305,7 @@ const saveItem = async (
 
       return alert("uspsTrackingNumber length must be 20 characters");
     }
+
     if (jsonSaveBody.supplyKitId.length !== 9) {
       console.log(jsonSaveBody.supplyKitId.length);
 
@@ -324,19 +334,18 @@ const saveItem = async (
     tableNumRows++;
 
     // Check and change data type to number before sending POST request
-    if (isNumeric(jsonSaveBody.uspsTrackingNumber)) {
-      jsonSaveBody.uspsTrackingNumber = parseInt(inputUsps.value.trim());
-      console.log(jsonSaveBody);
-    }
+    // if (isNumeric(jsonSaveBody.uspsTrackingNumber)) {
+    //   jsonSaveBody.uspsTrackingNumber = parseInt(inputUsps.value.trim());
+    //   console.log(jsonSaveBody);
+    // }
 
     // Checks array if input usps tracking number exists in usps placeholder array
     // exits outer function if duplicate
-    if (checkDuplicate(uspsHolder, jsonSaveBody.uspsTrackingNumber)) {
-      debugger;
-      alert("Duplicate usps tracking number!");
-      clearRowInputs(inputElements);
-      return;
-    }
+    // if (checkDuplicate(uspsHolder, jsonSaveBody.uspsTrackingNumber)) {
+    //   debugger;
+    //   alert("Duplicate usps tracking number!");
+    //   return;
+    // }
 
     // ADD DATA to TABLE
     addKitData(jsonSaveBody);
@@ -403,14 +412,14 @@ function addRow(jsonSaveBody, tableNumRows) {
     console.log(typeof uspsTrackingNumber === "number");
     console.log(uspsTrackingNumber);
     // ADD UI MODAL
-    alert("Number Value");
+    // alert("Number Value");
   } else {
     alert("Invalid USPS number data type, Not a number value");
     debugger;
     return;
   }
 
-  uspsHolder.push(parseInt(uspsTrackingNumber));
+  uspsHolder.push(uspsTrackingNumber);
   newRowEl.firstChild.nextSibling.innerHTML = tableNumRows;
   newRowEl.insertAdjacentHTML(
     "beforebegin",

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -221,27 +221,27 @@ const populateKitTable = (tableBody, kitData) => {
         <tr class="new-row">      
           <th scope="row">${lastRowNumber + 1}</th>
           <td>
-            <input id="input-usps" autocomplete="off" name="input-usps" style="width:100%;text-overflow: ellipsis;" placeholder="21168034670515269250" />
-            <label for ="input-usps" style="font-size:.8rem;">Ex. 21168034670515269250</label>
+            <input id="input-usps" autocomplete="off" name="input-usps" style="width:100%;text-overflow: ellipsis;" placeholder="3374889321009425653720" />
+            <label for ="input-usps" style="font-size:.8rem;">Ex. 3374889321009425653720</label>
           </td>
           <td>
-              <input id="input-supply-kit" type="string" autocomplete="off" name="input-supply-kit" style="width:80%" placeholder="CXA261331"/>
-              <label for ="input-supply-kit" style="font-size:.8rem;">Ex. CXA261331</label>
+              <input id="input-supply-kit" type="string" autocomplete="off" name="input-supply-kit" style="width:80%" placeholder="CON000007"/>
+              <label for ="input-supply-kit" style="font-size:.8rem;">Ex. CON000007</label>
           </td>
           <td>
-              <input id="input-specimen-kit" type="string" autocomplete="off" name="input-specimen-kit" style="width:80%" name="input-specimen-kit" placeholder="CXA261331"/>
-              <label for ="input-specimen-kit" style="font-size:.8rem;">Ex. CXA261331</label>
+              <input id="input-specimen-kit" type="string" autocomplete="off" name="input-specimen-kit" style="width:80%" name="input-specimen-kit" placeholder="CON000007"/>
+              <label for ="input-specimen-kit" style="font-size:.8rem;">Ex. CON000007</label>
           </td>
           <td>
-              <input id="input-collection-cup" type="string" autocomplete="off" style="width:80%; text-overflow: ellipsis;" placeholder="QBC436604 0002
+              <input id="input-collection-cup" type="string" autocomplete="off" style="width:80%; text-overflow: ellipsis;" placeholder="CXA123460 0009
               " name"input-collection-cup"/>
-              <label for ="input-collection-cup" style="font-size:.8rem;">Ex. QBC436604 0002
+              <label for ="input-collection-cup" style="font-size:.8rem;">Ex. CXA123460 0009
               </label>
           </td>
           <td>
-              <input id="input-collection-card" type="string" autocomplete="off" style="width:80%" placeholder="QBC436604 0002
+              <input id="input-collection-card" type="string" autocomplete="off" style="width:80%" placeholder="CXA123460 0009
               " name="input-collection-card"/>
-              <label for ="input-collection-card" style="font-size:.8rem;">Ex. QBC436604 0002
+              <label for ="input-collection-card" style="font-size:.8rem;">Ex. CXA123460 0009
               </label>
           </td>
       </tr>
@@ -301,16 +301,22 @@ const saveItem = async (
     /* 
       INPUT CHARACTER LENGTH CHECK
     */
+    console.log(
+      jsonSaveBody.uspsTrackingNumber.length,
+      jsonSaveBody.uspsTrackingNumber.length < 20,
+      jsonSaveBody.uspsTrackingNumber > 22
+    );
     if (
-      jsonSaveBody.uspsTrackingNumber.length <= 20 &&
-      jsonSaveBody.uspsTrackingNumber.length >= 22
+      jsonSaveBody.uspsTrackingNumber.length < 20 ||
+      jsonSaveBody.uspsTrackingNumber.length > 22
     ) {
       return alert(
-        "uspsTrackingNumber length must be within the range of 20 to 22 characters"
+        "USPS tracking number length must be within the range of 20 to 22 characters"
       );
     }
 
     if (jsonSaveBody.supplyKitId.length !== 9) {
+      debugger;
       return alert("supply kit id must be 9 characters");
     }
 

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -301,11 +301,7 @@ const saveItem = async (
     /* 
       INPUT CHARACTER LENGTH CHECK
     */
-    console.log(
-      jsonSaveBody.uspsTrackingNumber.length,
-      jsonSaveBody.uspsTrackingNumber.length < 20,
-      jsonSaveBody.uspsTrackingNumber > 22
-    );
+
     if (
       jsonSaveBody.uspsTrackingNumber.length < 20 ||
       jsonSaveBody.uspsTrackingNumber.length > 22
@@ -316,7 +312,6 @@ const saveItem = async (
     }
 
     if (jsonSaveBody.supplyKitId.length !== 9) {
-      debugger;
       return alert("supply kit id must be 9 characters");
     }
 


### PR DESCRIPTION
This PR addresses the following features & issues:
--> Fix duplicate check error. The problem, 16 out of the 22 digits of the USPS tracking number would be accessed correctly. However, the remaining 6 digits number values would be converted to 0s. This would result in the duplicate check conditional from being incorrect. The solution, instead of converting the input string into a number data type, leave the number with a data type of string as is. Leaving the string number (ex. "3374889321009425653720") will prevent errors when checking for duplicates in an existing array.
--> Add labels and placeholders for input fields inside table cells for respective table headers. Provides the user examples of what inputs are accepted. 
--> Automatically remove alert from a successful GET request. A solution was not made earlier because achieving the desired result of removing the alert would require jQuery. 

Checklist:
- [ ] Code cleanup
- [x] Check for ES Lint warnings
- [x] Verify test cases
- [x] Check for GIT conflicts
- [ ] Verified unit tests pass with current changes
- [ ] Any dependencies or modules added 
- [x] Attach PoC
- [x] Notes added

Styling: 
<p style="display:flex">
<img width="80%"  alt="Screen Shot 2021-09-02 at 1 06 38 PM" src="https://user-images.githubusercontent.com/33293205/131896019-bede2a72-2813-4ada-8f9c-e214e493d271.png"/>

</p>

Test Cases:
-> Enter or Scan a USPS tracking number outside the character length of less than 20 or greater than 22, an alert should pop up
-> Input an existing USPS tracking number a alert that the number is duplicate should appear
-> Upon pressing enter a an alert notifying the user that the kit has been saved should appear.

PoC: 
<img width="1140" alt="Screen Shot 2021-09-02 at 12 48 22 PM" src="https://user-images.githubusercontent.com/33293205/131896446-8b6dcaaf-4467-426b-ae57-363175a693cd.png">


TC 1:
<img width="436" alt="Screen Shot 2021-09-02 at 1 47 20 PM" src="https://user-images.githubusercontent.com/33293205/131896374-9262b60b-70e4-4ba8-ad59-182c74432ed6.png">


TC 2: 
<img width="448" alt="Screen Shot 2021-09-02 at 1 16 08 PM" src="https://user-images.githubusercontent.com/33293205/131896888-590f822a-b334-46d3-be1d-b9dbf41dbf12.png">


TC 3:
<img width="1245" alt="Screen Shot 2021-09-02 at 1 25 09 PM" src="https://user-images.githubusercontent.com/33293205/131896703-b6077481-e710-4112-be3b-aa7a6f08b253.png">

Notes:
An additional PR will be needed to change the alert messages to warning text below the respective input field text boxes. Note that scanning a USPS tracking barcode added an additional 8 digits. I was able to trim the 8 digits. More information where the first 8 digits originate from can be read from the https://www.endicia.com/tools-resources/harrys-hints/new-usps-tracking-barcodes/