### PR TITLE
Issue#279 Remove not collected reasons

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -1952,7 +1952,7 @@ const collectionSubmission = async (dt, biospecimenData, cntd) => {
         await storeSpecimen([data]);
         const specimenData = (await searchSpecimen(biospecimenData['820476880'])).data;
         hideAnimation();
-        finalizeTemplate(dt, specimenData);
+        explanationTemplate(dt, specimenData);
     }
     else {
         await storeSpecimen([data]);

--- a/src/events.js
+++ b/src/events.js
@@ -1952,7 +1952,7 @@ const collectionSubmission = async (dt, biospecimenData, cntd) => {
         await storeSpecimen([data]);
         const specimenData = (await searchSpecimen(biospecimenData['820476880'])).data;
         hideAnimation();
-        explanationTemplate(dt, specimenData);
+        finalizeTemplate(dt, specimenData);
     }
     else {
         await storeSpecimen([data]);

--- a/src/pages/explanation.js
+++ b/src/pages/explanation.js
@@ -7,6 +7,8 @@ export const explanationTemplate = (dt, biospecimenData) => {
     const notCollected = Array.from(document.getElementsByClassName('tube-collected')).filter(dt => dt.checked === false);
     const deviated = Array.from(document.getElementsByClassName('tube-deviated')).filter(dt => dt.checked === true);
     const tubes = workflows[getWorflow()];
+    const includeNotCollectedFormFields = false;
+
     if(notCollected.length > 0 || deviated.length > 0) {
         let template = `</br>
         <div class="row">
@@ -28,7 +30,7 @@ export const explanationTemplate = (dt, biospecimenData) => {
         </br>
         <form id="explanationForm" method="POST">`;
         let array = [];
-        notCollected.forEach(ele => {
+        includeNotCollectedFormFields && notCollected.forEach(ele => {
             const notCollectedOptions = tubes.filter(tube => tube.concept === ele.id)[0].tubeNotCollectedOptions
             const tubeType = ele.dataset.tubeType;
             if(array.includes(tubeType)) return


### PR DESCRIPTION
On the Clinical Labeling and Receipt screen,  form fields for the reasons why tubes were not collected are no longer displayed.


https://github.com/episphere/connect/issues/279