### PR TITLE
[BPTL] - Unsaved Changes Message on Package Receipt

### DIFF
--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -838,7 +838,7 @@ const alertTemplate = (message, status = "warn", duration = 5000) => {
 };
 
 // Automatically Close Alert Message
-const closeAlert = (status = "warn", duration = 5000) => {
+export const closeAlert = (status = "warn", duration = 5000) => {
   if (status === "success") {
     const alertSuccess = document.getElementById("alert-success");
     alertSuccess.style.display = "block";

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -838,7 +838,7 @@ const alertTemplate = (message, status = "warn", duration = 5000) => {
 };
 
 // Automatically Close Alert Message
-export const closeAlert = (status = "warn", duration = 5000) => {
+const closeAlert = (status = "warn", duration = 5000) => {
   if (status === "success") {
     const alertSuccess = document.getElementById("alert-success");
     alertSuccess.style.display = "block";

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -9,7 +9,6 @@ const inputObject = {
   inputChange: false
 }
 
-
 export const packageReceiptScreen = async (auth, route) => {
   const user = auth.currentUser;
   if (!user) return;
@@ -21,101 +20,8 @@ export const packageReceiptScreen = async (auth, route) => {
   enableCollectionCardFields();
   formSubmit();
   targetAnchorTagEl();
-
-  // Receive Packages: barcode, packageconditions,receive package comments, date received
-  const scannedBarcodeInputEl = document.getElementById("scannedBarcode");
-  const packageConditionEl = document.getElementById("packageCondition");
-  const receivePackageCommentsEl = document.getElementById("receivePackageComments");
-  const dateReceivedEl = document.getElementById("dateReceived");
-
-  scannedBarcodeInputEl.addEventListener("input",hasChanged)
-  packageConditionEl.addEventListener("change",handleConditionChange)
-  receivePackageCommentsEl.addEventListener("input",hasChanged)
-  dateReceivedEl.addEventListener("input",hasChanged)
-
-  // Collection Card Date Entry: collectionCheckBox,collectionId, dateCollectionCard,timeCollectionCard,collectionComments
-
-  const collectionCheckBoxEl = document.getElementById("collectionCheckBox")
-  const collectionIdEl = document.getElementById("collectionId")
-  const dateCollectionCardEl = document.getElementById("dateCollectionCard")
-  const timeCollectionCardEl = document.getElementById("timeCollectionCard")
-  const collectionCommentsEl = document.getElementById("collectionComments")
-  collectionCheckBoxEl.addEventListener("change",isChecked)
-  collectionIdEl.addEventListener("input",hasChanged)
-  dateCollectionCardEl.addEventListener("change",hasChanged)
-  timeCollectionCardEl.addEventListener("input",hasChanged)
-  collectionCommentsEl.addEventListener("input",hasChanged)
+  addListenersOnPageLoad();
 }
-
-/*
-scannedBarcodeInputEl 
-receivePackageCommentsEl
-dateReceivedEl
-*/ 
-const hasChanged = (e) => {
-  // array of input has no value of true (false to true)
-  if(e.target.value.trim() ==="" && !checkAllInputChanges()) {
-    inputObject.inputChange = false
-    targetAnchorTagEl(inputObject.inputChange)
-    cancelChanges(inputObject.inputChange)
-    unsavedMessageUnload(inputObject.inputChange)
-  }
-  else if(e.target.value.trim() !== ""){
-    inputObject.inputChange = true
-    targetAnchorTagEl(inputObject.inputChange)
-    cancelChanges(inputObject.inputChange)
-    unsavedMessageUnload(inputObject.inputChange)
-    return
-  }
-}
-
-// collectionCheckBoxEl
-const isChecked = (e) => {
-  if(e.target.checked) {
-    inputObject.inputChange = true
-    targetAnchorTagEl(inputObject.inputChange)
-    cancelChanges(inputObject.inputChange)
-    unsavedMessageUnload(inputObject.inputChange)
-  }
-  // if no check and array of input has no value of true (false to true)
-  else if (!e.target.checked && !checkAllInputChanges()){
-    inputObject.inputChange = false
-    targetAnchorTagEl(inputObject.inputChange)
-    cancelChanges(inputObject.inputChange)
-    unsavedMessageUnload(inputObject.inputChange)
-  }
-}
-
-
-const handleConditionChange = (e) => {
-  let arr = Array.from(e.target.selectedOptions, option => option.value);
-  // Removes Empty String from first option value
-  const filteredArr = arr.filter(condition => condition !== "")
-
-  if(filteredArr.length) {
-    // filteredArr.forEach(condition => packageConditionsArr.push(condition))
-    inputObject.inputChange = true
-    document.getElementById("packageCondition").setAttribute("data-selected",`${JSON.stringify(filteredArr)}`)
-    // call function to add eventlistener to anchor tags  
-    targetAnchorTagEl(inputObject.inputChange)
-    cancelChanges(inputObject.inputChange)
-    unsavedMessageUnload(inputObject.inputChange)
-  }
-  // if no check and array of input has no value of true (false to true)
-  else if(!filteredArr.length){
-    // set data-selected attribute
-    document.getElementById("packageCondition").setAttribute("data-selected","[]")
-    if(!checkAllInputChanges()){
-      inputObject.inputChange = false
-      // call function to remove eventlistener from anchor tags
-      targetAnchorTagEl(inputObject.inputChange)
-      cancelChanges(inputObject.inputChange)
-      unsavedMessageUnload(inputObject.inputChange)
-    }
-  }
-}
-
-
 
 const packageReceiptTemplate = async (name, auth, route) => {
     let template = ``;
@@ -222,27 +128,28 @@ const checkCourierType = () => {
   if (a) {
     a.addEventListener("input", (e) => {
       input = e.target.value.trim()
-      if (input.length === 22) {
-            document.getElementById('courierType').innerHTML = `<i class="fa fa-check-circle" aria-hidden="true"></i> FEDEX` 
-            document.getElementById('collectionCheckBox').checked = true;
-            checkCardIncluded()
-            disableCollectionCardFields();
-            return
-          }
-      else if (input.length === 30){
-      document.getElementById('courierType').innerHTML = `<i class="fa fa-check-circle" aria-hidden="true"></i> USPS`
-      document.getElementById('collectionCheckBox').checked = false;
-      enableCollectionCardFields()
-      return
-      }
-      else {
+      if(input.length === 0){
         document.getElementById('courierType').innerHTML = ``
+        enableCollectionCardFields();
         document.getElementById('collectionCheckBox').checked = false;
-        enableCollectionCardFields()
         return
       }
-    }) }
-}
+      else if (input.length <= 12) {
+        document.getElementById('courierType').innerHTML = `<i class="fa fa-check-circle" aria-hidden="true"></i> FEDEX` 
+        document.getElementById('collectionCheckBox').checked = true;
+        checkCardIncluded();
+        disableCollectionCardFields();
+        return
+      }
+      else {
+        document.getElementById('courierType').innerHTML = `<i class="fa fa-check-circle" aria-hidden="true"></i> USPS`
+        document.getElementById('collectionCheckBox').checked = false;
+        enableCollectionCardFields();
+        return
+      }
+    }) 
+  }
+};
 
 const checkCardIncluded = () => {
   const a = document.getElementById('collectionCheckBox')
@@ -301,64 +208,6 @@ const formSubmit = () => {
   })
 }      
 
-
-// onload attach event listener
-// input changes add event listener - use click me as test
-// no input changes and not onload - remove click me as test
-
-// Add two parameters and check truthy and falsy values
-const cancelChanges = (inputChanges) => {
-    const cancelChanges = document.getElementById("clearForm");
-    if(inputChanges) {
-      cancelChanges.addEventListener("click",cancelConfirm)
-    }
-    else {
-      cancelChanges.removeEventListener("click",cancelConfirm)
-    }
-};
-
-const cancelConfirm = (e) => {
-    const cancelChanges = document.getElementById("clearForm");
-    let result = confirm("Changes were made and will not be saved.")
-
-    if(result){
-      document.getElementById("courierType").innerHTML = ``;
-      document.getElementById("scannedBarcode").value = "";
-      document.getElementById("packageCondition").value = "";
-      document.getElementById("receivePackageComments").value = "";
-      document.getElementById("dateReceived").value = "";
-      
-      document.getElementById("collectionComments").value = "";
-      document.getElementById("collectionId").value = "";
-      enableCollectionCardFields()
-      enableCollectionCheckBox()
-      document.getElementById("packageCondition").setAttribute("data-selected","[]")
-      targetAnchorTagEl()
-      cancelChanges.removeEventListener("click",cancelConfirm)
-      window.removeEventListener("beforeunload",beforeUnloadMessage)
-      
-      if (document.getElementById("collectionId").value) {
-        document.getElementById("collectionId").value = "";
-        document.getElementById("dateCollectionCard").value = "";
-        document.getElementById("timeCollectionCard").value = "";
-        document.getElementById("collectionCheckBox").checked = false;
-        document.getElementById("collectionComments").value = "";
-
-        enableCollectionCardFields();
-        enableCollectionCheckBox();
-        document.getElementById("packageCondition").setAttribute("data-selected","[]");
-        targetAnchorTagEl()
-        cancelChanges.removeEventListener("click",cancelConfirm);
-        window.removeEventListener("beforeunload",beforeUnloadMessage);
-
-      }
-    }
-    else {
-      return 
-    }
-  
-}
-
 const storePackageReceipt = async (data) => {
     showAnimation();
     const idToken = await getIdToken();
@@ -391,12 +240,19 @@ const storePackageReceipt = async (data) => {
     }
 };
 
+const enableCollectionCheckBox = () => {
+  const collectionCheckBoxEl = document.getElementById("collectionCheckBox")
+  collectionCheckBoxEl.removeAttribute("disabled")
+  collectionCheckBoxEl.checked = false
+}
 
 /*
+=========================================
 FUNCTIONS FOR UNSAVED CHANGES
+=========================================
 */
 
-// Add to shared.js later as an export function expression
+/* TARGET ALL ANCHOR TAG ELEMENTS */ 
 const targetAnchorTagEl = (inputChange = false) => {
   // Target all items with anchor tags, convert HTML Collection to a normal array of elements
   // Filter and remove current anchor tag with the current location.hash
@@ -405,28 +261,48 @@ const targetAnchorTagEl = (inputChange = false) => {
   
   if(inputChange) {
     filteredAnchorTags.forEach(el => {
-        // el.addEventListener("click", clickMe)
         el.addEventListener("click", unsavedChangesRoutingMessage)
     })
   }
   else {
     filteredAnchorTags.forEach(el => {
-      // el.removeEventListener("click", clickMe)
       el.removeEventListener("click", unsavedChangesRoutingMessage)
     })
   }
 }
 
+/* ADD EVENT LISTENERS TO INPUTS THAT CAN BE SUBMITTED WHEN PAGE LOADS */ 
+const addListenersOnPageLoad = () => {
+  // Receive Packages: barcode, packageconditions,receive package comments, date received
+  const scannedBarcodeInputEl = document.getElementById("scannedBarcode");
+  const packageConditionEl = document.getElementById("packageCondition");
+  const receivePackageCommentsEl = document.getElementById("receivePackageComments");
+  const dateReceivedEl = document.getElementById("dateReceived");
+
+  scannedBarcodeInputEl.addEventListener("input", hasInputChanged)
+  packageConditionEl.addEventListener("change",handleConditionChange)
+  receivePackageCommentsEl.addEventListener("input", hasInputChanged)
+  dateReceivedEl.addEventListener("input", hasInputChanged)
+
+  // Collection Card Date Entry: collectionCheckBox,collectionId, dateCollectionCard,timeCollectionCard,collectionComments
+
+  const collectionCheckBoxEl = document.getElementById("collectionCheckBox")
+  const collectionIdEl = document.getElementById("collectionId")
+  const dateCollectionCardEl = document.getElementById("dateCollectionCard")
+  const timeCollectionCardEl = document.getElementById("timeCollectionCard")
+  const collectionCommentsEl = document.getElementById("collectionComments")
+  collectionCheckBoxEl.addEventListener("change",isChecked)
+  collectionIdEl.addEventListener("input", hasInputChanged)
+  dateCollectionCardEl.addEventListener("change", hasInputChanged)
+  timeCollectionCardEl.addEventListener("input", hasInputChanged)
+  collectionCommentsEl.addEventListener("input", hasInputChanged)
+}
+
+/* NAMED EVENT LISTENERS FOR UNSAVED CHANGES ADDED / REMOVED */
+
 const unsavedChangesRoutingMessage = (e) => {
   unsavedMessageConfirmation(e)
 }
-
-const enableCollectionCheckBox = () => {
-  const collectionCheckBoxEl = document.getElementById("collectionCheckBox")
-  collectionCheckBoxEl.removeAttribute("disabled")
-  collectionCheckBoxEl.checked = false
-}
-
 
 // Reusable message alert
 const unsavedMessageConfirmation = (e) => {
@@ -436,10 +312,130 @@ const unsavedMessageConfirmation = (e) => {
     return false
   }
   else { 
+    // IMPORTANT - REMOVES EVENT LISTENER FROM WINDOW OBJECT AFTER ROUTE CHANGE IS CONFIRMED
     window.removeEventListener("beforeunload",beforeUnloadMessage)
     return true
   }
 }
+
+/*
+WINDOW
+*/
+const beforeUnloadMessage = (e) => { 
+  e.preventDefault()
+  // Chrome requires returnValue to be set.
+  e.returnValue = "";
+  return
+}
+
+/*
+INPUT ELEMENTS - scannedBarcodeInputEl, receivePackageCommentsEl, dateReceivedEl
+*/ 
+const hasInputChanged = (e) => {
+  // array of input has no value of true (false to true)
+  if(e.target.value.trim() ==="" && !checkAllInputChanges()) {
+    inputObject.inputChange = false
+    targetAnchorTagEl(inputObject.inputChange)
+    clearChanges(inputObject.inputChange)
+    unsavedMessageUnload(inputObject.inputChange)
+  }
+  else if(e.target.value.trim() !== ""){
+    inputObject.inputChange = true
+    targetAnchorTagEl(inputObject.inputChange)
+    clearChanges(inputObject.inputChange)
+    unsavedMessageUnload(inputObject.inputChange)
+    return
+  }
+}
+
+// INPUT(CHECKBOX) ELEMENT - collectionCheckBoxEl
+const isChecked = (e) => {
+  if(e.target.checked) {
+    inputObject.inputChange = true
+    targetAnchorTagEl(inputObject.inputChange)
+    clearChanges(inputObject.inputChange)
+    unsavedMessageUnload(inputObject.inputChange)
+  }
+  // if no check and array of input has no value of true (false to true)
+  else if (!e.target.checked && !checkAllInputChanges()){
+    inputObject.inputChange = false
+    targetAnchorTagEl(inputObject.inputChange)
+    clearChanges(inputObject.inputChange)
+    unsavedMessageUnload(inputObject.inputChange)
+  }
+}
+
+// SELECT ELEMENT - packageConditionEl
+const handleConditionChange = (e) => {
+  let arr = Array.from(e.target.selectedOptions, option => option.value);
+  // Removes Empty String from first option value
+  const filteredArr = arr.filter(condition => condition !== "")
+
+  if(filteredArr.length) {
+    // filteredArr.forEach(condition => packageConditionsArr.push(condition))
+    inputObject.inputChange = true
+    document.getElementById("packageCondition").setAttribute("data-selected",`${JSON.stringify(filteredArr)}`)
+    // call function to add eventlistener to anchor tags  
+    targetAnchorTagEl(inputObject.inputChange)
+    clearChanges(inputObject.inputChange)
+    unsavedMessageUnload(inputObject.inputChange)
+  }
+  // if no check and array of input has no value of true (false to true)
+  else if(!filteredArr.length){
+    // set data-selected attribute
+    document.getElementById("packageCondition").setAttribute("data-selected","[]")
+    if(!checkAllInputChanges()){
+      inputObject.inputChange = false
+      // call function to remove eventlistener from anchor tags
+      targetAnchorTagEl(inputObject.inputChange)
+      clearChanges(inputObject.inputChange)
+      unsavedMessageUnload(inputObject.inputChange)
+    }
+  }
+}
+
+const cancelConfirm = (e) => {
+  const clearButtonEl = document.getElementById("clearForm");
+  let result = confirm("Changes were made and will not be saved.")
+
+  if(result){
+    document.getElementById("courierType").innerHTML = ``;
+    document.getElementById("scannedBarcode").value = "";
+    document.getElementById("packageCondition").value = "";
+    document.getElementById("receivePackageComments").value = "";
+    document.getElementById("dateReceived").value = "";
+    
+    document.getElementById("collectionComments").value = "";
+    document.getElementById("collectionId").value = "";
+    enableCollectionCardFields()
+    enableCollectionCheckBox()
+    document.getElementById("packageCondition").setAttribute("data-selected","[]")
+    targetAnchorTagEl()
+    clearButtonEl.removeEventListener("click",cancelConfirm)
+    window.removeEventListener("beforeunload",beforeUnloadMessage)
+    
+    if (document.getElementById("collectionId").value) {
+      document.getElementById("collectionId").value = "";
+      document.getElementById("dateCollectionCard").value = "";
+      document.getElementById("timeCollectionCard").value = "";
+      document.getElementById("collectionCheckBox").checked = false;
+      document.getElementById("collectionComments").value = "";
+
+      enableCollectionCardFields();
+      enableCollectionCheckBox();
+      document.getElementById("packageCondition").setAttribute("data-selected","[]");
+      targetAnchorTagEl()
+      clearButtonEl.removeEventListener("click",cancelConfirm);
+      window.removeEventListener("beforeunload",beforeUnloadMessage);
+
+    }
+  }
+  else {
+    return 
+  }
+}
+
+// OTHER UNSAVED CHANGES FUNCTIONS 
 
 const unsavedMessageUnload = (inputChange) => {
   if(inputChange) {
@@ -450,23 +446,25 @@ const unsavedMessageUnload = (inputChange) => {
   }
 }
 
-const beforeUnloadMessage = (e) => { 
-  e.preventDefault()
-  // Chrome requires returnValue to be set.
-  e.returnValue = "";
-  return
-}
-
+// Add two parameters and check truthy and falsy values
+const clearChanges = (inputChanges) => {
+  const clearButtonEl = document.getElementById("clearForm");
+  if(inputChanges) {
+    clearButtonEl.addEventListener("click",cancelConfirm)
+  }
+  else {
+    clearButtonEl.removeEventListener("click",cancelConfirm)
+  }
+};
 
 const checkAllInputChanges = () => {
-  
   /*
   Get values, data-sets, checked ---> 
   Compare to --> 
   empty string, data-selected not "", checkbox not checked
   || document.getElementById("packageCondition").getAttribute("data-selected").length !== 0
   */ 
-  // Input Change made !== "" or checked === true or 
+  // Input Change made !== "" or checked === true or data selected any option element selected !== "select packaage condition"
 
   const condition1 = document.getElementById("scannedBarcode").value !== "" 
   const condition2 = parseDataSelected(document.getElementById("packageCondition").getAttribute("data-selected"))

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -244,7 +244,7 @@ const checkCourierType = () => {
   if (a) {
     a.addEventListener("input", (e) => {
       input = e.target.value
-      if (input.length === 22) {
+      if (input.length === 34) {
         console.log(`${e.target.value}`)
         console.log(input.length)
         // console.log(e.target.value,e.target.value.length,typeof input.length)
@@ -489,7 +489,7 @@ const unsavedMessageUnload = (inputChange) => {
 const beforeUnloadMessage = (e) => { 
   e.preventDefault()
   // Chrome requires returnValue to be set.
-  // e.returnValue = "";
+  e.returnValue = "";
   return
 }
 

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -86,7 +86,7 @@ const isChecked = (e) => {
   }
   // if no check and array of input has no value of true (false to true)
   else if (!e.target.checked && !checkAllInputChanges()){
-    // console.log(checkAllInputChanges())
+    console.log(checkAllInputChanges())
     inputObject.inputChange = false
     targetAnchorTagEl(inputObject.inputChange)
     cancelChanges(inputObject.inputChange)
@@ -136,6 +136,7 @@ const handleConditionChange = (e) => {
 }
 
 
+
 const packageReceiptTemplate = async (name, auth, route) => {
     let template = ``;
     template += receiptsNavbar();
@@ -145,13 +146,13 @@ const packageReceiptTemplate = async (name, auth, route) => {
                       <form method="post" class="mt-3" id="configForm">
                         <h5 style="text-align: left;">Receive Packages</h5>
 
-                        <div class="row form-group">
-                            <label class="col-form-label col-md-4" for="scannedBarcode">Scan FedEx/USPS Barcode</label>
-                            <div style="display:inline-block;">
-                              <input autocomplete="off" required class="col-md-8 form-control" type="text" id="scannedBarcode" style="width: 600px;">
-                              <span id='courierType' style="padding-left: 10px;"></span>
-                            </div>
-                        </div>
+                    <div class="row form-group">
+                      <label class="col-form-label col-md-4" for="scannedBarcode">Scan FedEx/USPS Barcode</label>
+                      <div style="display:inline-block;">
+                        <input autocomplete="off" required="" class="col-md-8" type="text" id="scannedBarcode" style="width: 600px;" placeholder="Scan a Fedex or USPS barcode">
+                        <span id="courierType" style="padding-left: 10px;"></span>
+                      </div>
+                    </div>
                         
                         <div class="row form-group">
                             <label class="col-form-label col-md-4" for="packageCondition">Select Package Condition</label>
@@ -185,7 +186,7 @@ const packageReceiptTemplate = async (name, auth, route) => {
 
                         <div class="row form-group">
                             <label class="col-form-label col-md-4" for="receivePackageComments">Comment</label>
-                            <textarea class="col-md-8 form-control" required id="receivePackageComments" cols="30" rows="3"></textarea>
+                            <textarea class="col-md-8 form-control" required id="receivePackageComments" cols="30" rows="3" placeholder="Any comments?"></textarea>
                         </div>
 
                         <div class="row form-group">
@@ -203,7 +204,7 @@ const packageReceiptTemplate = async (name, auth, route) => {
 
                             <div class="row form-group">
                                 <label class="col-form-label col-md-4" for="collectionId">Collection ID</label>
-                                <input autocomplete="off" class="col-md-8 form-control" type="text" id="collectionId">
+                                <input autocomplete="off" class="col-md-8 form-control" type="text" id="collectionId" placeholder="Scan or Enter a Collection ID">
                             </div>
 
                             <div class="row form-group">
@@ -218,7 +219,7 @@ const packageReceiptTemplate = async (name, auth, route) => {
 
                             <div class="row form-group">
                                 <label class="col-form-label col-md-4" for="collectionComments">Comments on Card Returned</label>
-                                <textarea class="col-md-8 form-control" id="collectionComments" cols="30" rows="3"></textarea>
+                                <textarea class="col-md-8 form-control" id="collectionComments" cols="30" rows="3" placeholder="Comments on the card?"></textarea>
                             </div>
                           </div>
                         
@@ -237,11 +238,12 @@ const packageReceiptTemplate = async (name, auth, route) => {
 };
 
 const checkCourierType = () => {
-  // TODO: Add a stricter check
+  // if fedex remove first 8 characters
   const a = document.getElementById("scannedBarcode");
   if (a) {
-    a.addEventListener("change", () => {
-      if (a.value.trim().length <= 12) { 
+    a.addEventListener("input", () => {
+      if (a.value.trim().length <= 12) {
+        console.log(a.value)
             document.getElementById('courierType').innerHTML = `<i class="fa fa-check-circle" aria-hidden="true"></i> FEDEX` 
             document.getElementById('collectionCheckBox').disabled = true;
             disableCollectionCardFields();
@@ -249,6 +251,7 @@ const checkCourierType = () => {
           }
             else {
             document.getElementById('courierType').innerHTML = `<i class="fa fa-check-circle" aria-hidden="true"></i> USPS`}
+            enableCollectionCardFields()
     }) }
 }
 
@@ -451,7 +454,10 @@ const unsavedMessageConfirmation = (e) => {
     e.preventDefault()
     return false
   }
-  else return true
+  else { 
+    window.removeEventListener("beforeunload",beforeUnloadMessage)
+    return true
+  }
 }
 
 const unsavedMessageUnload = (inputChange) => {
@@ -465,6 +471,8 @@ const unsavedMessageUnload = (inputChange) => {
 
 const beforeUnloadMessage = (e) => { 
   e.preventDefault()
+  // Chrome requires returnValue to be set.
+  e.returnValue = "";
   return
 }
 
@@ -517,7 +525,7 @@ const checkAllInputChanges = () => {
 
 function parseDataSelected(value) {
   let parseData = JSON.parse(value)
-  console.log(parseData)
+  // console.log(parseData)
   if(parseData.length === 0){
     return false
   }
@@ -528,32 +536,3 @@ function parseDataSelected(value) {
   }
   return false
 }
-
-// if(empty input && checkAllInputChanges === false) -- > remove event listeners
-
-// if(empty input && checkAllinputChanges === true) --> do not remove event listeners
-
-// TODO: Disable window before unload eventlistener after cancel confirm and save 
-
-
-// condition1 = document.getElementById("scannedBarcode").value !== "" 
-// condition2 = parseDataSelected(document.getElementById("packageCondition").getAttribute("data-selected"))
-// condition3 = document.getElementById("receivePackageComments").value !== "";
-// condition4 = document.getElementById("dateReceived").value !== "";
-
-// condition5 = document.getElementById("collectionCheckBox").checked === true;
-// condition6 = document.getElementById("collectionId").value !== "";
-// condition7 = document.getElementById("dateCollectionCard").value !== "";
-// condition8 = document.getElementById("timeCollectionCard").value !== "";
-// condition9 = document.getElementById("collectionComments").value !== "";
-// conditionsArr = [
-//   condition1,
-//   condition2,
-//   condition3,
-//   condition4,
-//   condition5,
-//   condition6,
-//   condition7,
-//   condition8,
-//   condition9
-// ]

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -314,6 +314,8 @@ const cancelConfirm = (e) => {
       document.getElementById("dateReceived").value = "";
       
       // Remove Later include with error handling for USPS and Fedex?
+      document.getElementById("collectionComments").value = "";
+      document.getElementById("collectionId").value = "";
       enableCollectionCardFields()
       enableCollectionCheckBox()
       cancelChanges.removeEventListener("click",cancelConfirm)

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -332,6 +332,7 @@ const cancelConfirm = (e) => {
       enableCollectionCardFields()
       enableCollectionCheckBox()
       document.getElementById("packageCondition").setAttribute("data-selected","[]")
+      targetAnchorTagEl()
       cancelChanges.removeEventListener("click",cancelConfirm)
       window.removeEventListener("beforeunload",beforeUnloadMessage)
       
@@ -345,6 +346,7 @@ const cancelConfirm = (e) => {
         enableCollectionCardFields();
         enableCollectionCheckBox();
         document.getElementById("packageCondition").setAttribute("data-selected","[]");
+        targetAnchorTagEl()
         cancelChanges.removeEventListener("click",cancelConfirm);
         window.removeEventListener("beforeunload",beforeUnloadMessage);
 

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -8,6 +8,7 @@ const inputObject = {
   inputChange: false
 }
 
+let packageConditionsArr = []
 
 export const packageReceiptScreen = async (auth, route) => {
   const user = auth.currentUser;
@@ -20,16 +21,40 @@ export const packageReceiptScreen = async (auth, route) => {
   enableCollectionCardFields();
   formSubmit();
   cancelChanges();
-  targetAnchorTagEl()
+  targetAnchorTagEl();
 
-  const scannedBarcodeInputEl = document.getElementById("scannedBarcode")
-  const packageConditionEl = document.getElementById("packageCondition")
+  // Receive Packages: barcode, packageconditions,receive package comments, date received
+  const scannedBarcodeInputEl = document.getElementById("scannedBarcode");
+  const packageConditionEl = document.getElementById("packageCondition");
+  const receivePackageCommentsEl = document.getElementById("receivePackageComments");
+  const dateReceivedEl = document.getElementById("dateReceived");
+
   scannedBarcodeInputEl.addEventListener("input",hasChanged)
-  packageConditionEl.addEventListener("change",hasChangedSelection)
+  packageConditionEl.addEventListener("change",handleChange)
+  receivePackageCommentsEl.addEventListener("input",hasChanged)
+  dateReceivedEl.addEventListener("input",hasChanged)
+
+  // Collection Card Date Entry: collectionCheckBox,collectionId, dateCollectionCard,timeCollectionCard,collectionComments
+
+  const collectionCheckBoxEl = document.getElementById("collectionCheckBox")
+  const collectionIdEl = document.getElementById("collectionId")
+  const dateCollectionCardEl = document.getElementById("dateCollectionCard")
+  const timeCollectionCardEl = document.getElementById("timeCollectionCard")
+  const collectionCommentsEl = document.getElementById("collectionComments")
+  collectionCheckBoxEl.addEventListener("change",isChecked)
+  collectionIdEl.addEventListener("input",hasChanged)
+  dateCollectionCardEl.addEventListener("change",hasChanged)
+  timeCollectionCardEl.addEventListener("input",hasChanged)
+  collectionCommentsEl.addEventListener("input",hasChanged)
 
   
 }
 
+/*
+scannedBarcodeInputEl 
+receivePackageCommentsEl
+dateReceivedEl
+*/ 
 const hasChanged = (e) => {
   if(e.target.value.trim() ==="") {
     inputObject.inputChange = false
@@ -38,13 +63,36 @@ const hasChanged = (e) => {
   else if(e.target.value.trim() !== ""){
     inputObject.inputChange = true
     console.log(e.target.value,e.target,inputObject)
+    // console.log(packageConditionsArr)
     return
   }
   else return
 }
 
-const hasChangedSelection = (e) => {
-  console.log(e.target.value)
+// collectionCheckBoxEl
+const isChecked = (e) => {
+  if(e.target.checked) {
+    inputObject.inputChange = true
+    console.log(e.target.checked)
+    console.log(e.target.value,inputObject)
+  }
+  else {
+    inputObject.inputChange = false
+    console.log(e.target.checked)
+    console.log(e.target.value,inputObject)
+  }
+}
+
+
+// packageConditionEl
+const handleChange = (e) => {
+  let arr = Array.from(e.target.selectedOptions, option => option.value);
+  console.log(arr)
+  // Removes Empty String from first option value
+  const filteredArr = arr.filter(condition => condition !== "")
+  console.log(filteredArr)
+  packageConditionsArr.length = 0
+  // return packageConditionsArr.push(value)
 }
 
 
@@ -208,7 +256,7 @@ const formSubmit = () => {
         obj['collectionComments'] = document.getElementById('collectionComments').value;
        
       }
-      storePackageReceipt(obj);
+      // storePackageReceipt(obj);
 
   })
 }      
@@ -294,3 +342,5 @@ const targetAnchorTagEl = (state = false) => {
 function clickMe(e) {
   console.log(e.target,"Clicked")
 }
+
+// document.getElementById("dateReceived").value

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -288,7 +288,7 @@ const formSubmit = () => {
         obj['collectionComments'] = document.getElementById('collectionComments').value;
        
       }
-      // storePackageReceipt(obj);
+      storePackageReceipt(obj);
 
   })
 }      
@@ -463,20 +463,39 @@ const clickMe = (e) => {
 
 const checkAllInputChanges = () => {
   
-  // Get values, data-sets, checked ---> Compare to --> empty string, data-selected not "", checkbox not checked
-  document.getElementById("scannedBarcode").value;
-  document.getElementById("packageCondition").value;
-  document.getElementById("receivePackageComments").value;
-  document.getElementById("dateReceived").value;
+  /*
+  Get values, data-sets, checked ---> 
+  Compare to --> 
+  empty string, data-selected not "", checkbox not checked
+  */ 
 
-  document.getElementById("collectionCheckBox").value;
-  document.getElementById("collectionId").value;
-  document.getElementById("dateCollectionCard").value;
-  document.getElementById("timeCollectionCard").value;
-  document.getElementById("collectionComments").value;
 
-  
-  
+  const condition1 = document.getElementById("scannedBarcode").value !== "" 
+  const condition2 = document.getElementById("packageCondition").getAttribute("data-selected") !== ""
+  const condition3 = document.getElementById("receivePackageComments").value !== "";
+  const condition4 = document.getElementById("dateReceived").value !== "";
+
+  const condition5 = document.getElementById("collectionCheckBox").checked === true;
+  const condition6 = document.getElementById("collectionId").value !== "";
+  const condition7 = document.getElementById("dateCollectionCard").value !== "";
+  const condition8 = document.getElementById("timeCollectionCard").value !== "";
+  const condition9 = document.getElementById("collectionComments").value !== "";
+  const conditionsArr = [
+    condition1,
+    condition2,
+    condition3,
+    condition4,
+    condition5,
+    condition6,
+    condition7,
+    condition8,
+    condition9
+  ]
+
+  // if any items returm
+  if(conditionsArr.includes(true)) {
+    return true
+  } else return false
 }
 
-// Disable window before unload eventlistener after cancel confirm and save 
+// TODO: Disable window before unload eventlistener after cancel confirm and save 

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -222,7 +222,7 @@ const checkCourierType = () => {
   let input = ""
   if (a) {
     a.addEventListener("input", (e) => {
-      input = e.target.value
+      input = e.target.value.trim()
       if (input.length === 22) {
             document.getElementById('courierType').innerHTML = `<i class="fa fa-check-circle" aria-hidden="true"></i> FEDEX` 
             document.getElementById('collectionCheckBox').checked = true;
@@ -490,7 +490,6 @@ const checkAllInputChanges = () => {
     condition8,
     condition9
   ]
-
   // if any items returns true (Any input changes are made)
   if(conditionsArr.includes(true)) {
     return true

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -4,6 +4,11 @@ import { nonUserNavBar, unAuthorizedUser } from "../../navbar.js";
 import { receiptsNavbar } from "./receiptsNavbar.js";
 import { activeReceiptsNavbar } from "./activeReceiptsNavbar.js";
 
+const inputObject = {
+  inputChange: false
+}
+
+
 export const packageReceiptScreen = async (auth, route) => {
   const user = auth.currentUser;
   if (!user) return;
@@ -16,6 +21,30 @@ export const packageReceiptScreen = async (auth, route) => {
   formSubmit();
   cancelChanges();
   targetAnchorTagEl()
+
+  const scannedBarcodeInputEl = document.getElementById("scannedBarcode")
+  const packageConditionEl = document.getElementById("packageCondition")
+  scannedBarcodeInputEl.addEventListener("input",hasChanged)
+  packageConditionEl.addEventListener("change",hasChangedSelection)
+
+  
+}
+
+const hasChanged = (e) => {
+  if(e.target.value.trim() ==="") {
+    inputObject.inputChange = false
+    console.log(e.target.value,inputObject)
+  }
+  else if(e.target.value.trim() !== ""){
+    inputObject.inputChange = true
+    console.log(e.target.value,e.target,inputObject)
+    return
+  }
+  else return
+}
+
+const hasChangedSelection = (e) => {
+  console.log(e.target.value)
 }
 
 

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -14,6 +14,7 @@ export const packageReceiptScreen = async (auth, route) => {
   if (!user) return;
   const username = user.displayName ? user.displayName : user.email;
   packageReceiptTemplate(username, auth, route);
+  defaultDateReceived(getCurrentDate);
   checkCourierType();
   checkCardIncluded();
   disableCollectionCardFields();
@@ -282,7 +283,7 @@ const addListenersOnPageLoad = () => {
   scannedBarcodeInputEl.addEventListener("input", hasInputChanged)
   packageConditionEl.addEventListener("change",handleConditionChange)
   receivePackageCommentsEl.addEventListener("input", hasInputChanged)
-  dateReceivedEl.addEventListener("input", hasInputChanged)
+  dateReceivedEl.addEventListener("input", hasInputDateChanged)
 
   // Collection Card Date Entry: collectionCheckBox,collectionId, dateCollectionCard,timeCollectionCard,collectionComments
 
@@ -348,6 +349,25 @@ const hasInputChanged = (e) => {
   }
 }
 
+/*
+INPUT(DATE) ELEMENT - dateReceivedEl
+*/ 
+const hasInputDateChanged = (e) => {
+    if(e.target.value.trim() === getCurrentDate() && !checkAllInputChanges()) {
+      inputObject.inputChange = false
+      targetAnchorTagEl(inputObject.inputChange)
+      clearChanges(inputObject.inputChange)
+      unsavedMessageUnload(inputObject.inputChange)
+    }
+    else if(e.target.value.trim() !== getCurrentDate()){
+      inputObject.inputChange = true
+      targetAnchorTagEl(inputObject.inputChange)
+      clearChanges(inputObject.inputChange)
+      unsavedMessageUnload(inputObject.inputChange)
+      return
+    }
+}
+
 // INPUT(CHECKBOX) ELEMENT - collectionCheckBoxEl
 const isChecked = (e) => {
   if(e.target.checked) {
@@ -394,7 +414,7 @@ const handleConditionChange = (e) => {
   }
 }
 
-const cancelConfirm = (e) => {
+const cancelConfirm = () => {
   const clearButtonEl = document.getElementById("clearForm");
   let result = confirm("Changes were made and will not be saved.")
 
@@ -403,7 +423,7 @@ const cancelConfirm = (e) => {
     document.getElementById("scannedBarcode").value = "";
     document.getElementById("packageCondition").value = "";
     document.getElementById("receivePackageComments").value = "";
-    document.getElementById("dateReceived").value = "";
+    document.getElementById("dateReceived").value = getCurrentDate();
     
     document.getElementById("collectionComments").value = "";
     document.getElementById("collectionId").value = "";
@@ -469,7 +489,7 @@ const checkAllInputChanges = () => {
   const condition1 = document.getElementById("scannedBarcode").value !== "" 
   const condition2 = parseDataSelected(document.getElementById("packageCondition").getAttribute("data-selected"))
   const condition3 = document.getElementById("receivePackageComments").value !== "";
-  const condition4 = document.getElementById("dateReceived").value !== "";
+  const condition4 = document.getElementById("dateReceived").value !== getCurrentDate();
 
   const condition5 = document.getElementById("collectionCheckBox").checked === true;
   const condition6 = document.getElementById("collectionId").value !== "";
@@ -502,4 +522,18 @@ const parseDataSelected = (value) => {
     return true
   }
   return false
+}
+
+const defaultDateReceived = (getCurrentDate) => {
+  const dateReceivedEl = document.getElementById("dateReceived")
+  if(getCurrentDate()){
+    dateReceivedEl.value = getCurrentDate()
+  }
+  else dateReceivedEl.value = ""
+}
+
+// returns current date in english canada format ("YYYY-MM-DD")
+const getCurrentDate = () => {
+  const currentDate = new Date().toLocaleDateString('en-CA');
+  return currentDate
 }

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -297,8 +297,7 @@ const formSubmit = () => {
     }
     window.removeEventListener("beforeunload",beforeUnloadMessage)
     targetAnchorTagEl()
-    console.log(obj)
-    // storePackageReceipt(obj);
+    storePackageReceipt(obj);
   })
 }      
 

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -240,18 +240,35 @@ const packageReceiptTemplate = async (name, auth, route) => {
 const checkCourierType = () => {
   // if fedex remove first 8 characters
   const a = document.getElementById("scannedBarcode");
+  let input = ""
   if (a) {
-    a.addEventListener("input", () => {
-      if (a.value.trim().length <= 12) {
-        console.log(a.value)
+    a.addEventListener("input", (e) => {
+      input = e.target.value
+      if (input.length === 22) {
+        console.log(`${e.target.value}`)
+        console.log(input.length)
+        // console.log(e.target.value,e.target.value.length,typeof input.length)
             document.getElementById('courierType').innerHTML = `<i class="fa fa-check-circle" aria-hidden="true"></i> FEDEX` 
-            document.getElementById('collectionCheckBox').disabled = true;
+            // document.getElementById('collectionCheckBox').disabled = true;
+            document.getElementById('collectionCheckBox').checked = true;
+            checkCardIncluded()
+
             disableCollectionCardFields();
-   
+            return
           }
-            else {
-            document.getElementById('courierType').innerHTML = `<i class="fa fa-check-circle" aria-hidden="true"></i> USPS`}
+            else if (input.length === 30){
+            document.getElementById('courierType').innerHTML = `<i class="fa fa-check-circle" aria-hidden="true"></i> USPS`
+            document.getElementById('collectionCheckBox').checked = false;
             enableCollectionCardFields()
+            return
+          }
+          else {
+            document.getElementById('courierType').innerHTML = ``
+            document.getElementById('collectionCheckBox').checked = false;
+            enableCollectionCardFields()
+            return
+          }
+            // enableCollectionCardFields()
     }) }
 }
 
@@ -472,7 +489,7 @@ const unsavedMessageUnload = (inputChange) => {
 const beforeUnloadMessage = (e) => { 
   e.preventDefault()
   // Chrome requires returnValue to be set.
-  e.returnValue = "";
+  // e.returnValue = "";
   return
 }
 

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -327,6 +327,7 @@ const cancelConfirm = (e) => {
       document.getElementById("collectionId").value = "";
       enableCollectionCardFields()
       enableCollectionCheckBox()
+      document.getElementById("packageCondition").setAttribute("data-selected","")
       cancelChanges.removeEventListener("click",cancelConfirm)
       window.removeEventListener("beforeunload",beforeUnloadMessage)
       
@@ -340,6 +341,7 @@ const cancelConfirm = (e) => {
         // Remove Later include with error handling for USPS and Fedex?
         enableCollectionCardFields()
         enableCollectionCheckBox()
+        document.getElementById("packageCondition").setAttribute("data-selected","")
         cancelChanges.removeEventListener("click",cancelConfirm)
         window.removeEventListener("beforeunload",beforeUnloadMessage)
 
@@ -497,5 +499,9 @@ const checkAllInputChanges = () => {
     return true
   } else return false
 }
+
+// if(empty input && checkAllInputChanges === false) -- > remove event listeners
+
+// if(empty input && checkAllinputChanges === true) --> do not remove event listeners
 
 // TODO: Disable window before unload eventlistener after cancel confirm and save 

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -143,7 +143,6 @@ const checkCourierType = () => {
         document.getElementById('collectionCheckBox').checked = false;
         document.getElementById('collectionCheckBox').removeAttribute("disabled")
         enableCollectionCardFields();
-        debugger;
         return
       }
       // USPS
@@ -153,7 +152,6 @@ const checkCourierType = () => {
         document.getElementById('collectionCheckBox').checked = false;
         document.getElementById('collectionCheckBox').removeAttribute("disabled")
         enableCollectionCardFields();
-        debugger;
         return
       }
       // FEDEX
@@ -572,35 +570,6 @@ const getCurrentDate = () => {
   const currentDate = new Date().toLocaleDateString('en-CA');
   return currentDate
 }
-
-/* 
-IF / ELSE 
-
-a1 - enable
-a2 - disable
-b1 - uncheck checkbox
-b2- check checkbox
-c1 - enable checkbox
-c2 - disable checkbox
-
-USPS - a1, b1, c1
-FEDEX - a2, c2
-
-1. if length 0 --> None a1, b1
-
-2. if number starts with 420 --> USPS
-OR 
-if number is 34 AND Starts with 420 --> usps
-
-3. if number is 22  || 20 length--> usps
-
-4. if number is 34 --> Fedex 
-
-5. if number is 12 Fedex
-
-6. input length <= 12 --> None
-
-*/
 
 const uspsFirstThreeNumbersCheck = (input) => {
   const regExp = /^420[0-9]{31}$/

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -8,7 +8,6 @@ const inputObject = {
   inputChange: false
 }
 
-let packageConditionsArr = []
 
 export const packageReceiptScreen = async (auth, route) => {
   const user = auth.currentUser;
@@ -30,7 +29,7 @@ export const packageReceiptScreen = async (auth, route) => {
   const dateReceivedEl = document.getElementById("dateReceived");
 
   scannedBarcodeInputEl.addEventListener("input",hasChanged)
-  packageConditionEl.addEventListener("change",handleChange)
+  packageConditionEl.addEventListener("change",handleConditionChange)
   receivePackageCommentsEl.addEventListener("input",hasChanged)
   dateReceivedEl.addEventListener("input",hasChanged)
 
@@ -85,14 +84,26 @@ const isChecked = (e) => {
 
 
 // packageConditionEl
-const handleChange = (e) => {
+const handleConditionChange = (e) => {
   let arr = Array.from(e.target.selectedOptions, option => option.value);
-  console.log(arr)
   // Removes Empty String from first option value
   const filteredArr = arr.filter(condition => condition !== "")
-  console.log(filteredArr)
-  packageConditionsArr.length = 0
-  // return packageConditionsArr.push(value)
+
+  if(filteredArr.length) {
+    // filteredArr.forEach(condition => packageConditionsArr.push(condition))
+    inputObject.inputChange = true
+    // call function to add eventlistener to anchor tags
+    targetAnchorTagEl(inputObject.inputChange)
+    console.log(filteredArr)
+    console.log(inputObject)
+  }
+  else {
+    inputObject.inputChange = false
+    targetAnchorTagEl(inputObject.inputChange)
+    // call function to remove eventlistener from anchor tags
+    console.log(filteredArr)
+    console.log(inputObject)
+  }
 }
 
 
@@ -327,16 +338,16 @@ const targetAnchorTagEl = (state = false) => {
   
   console.log(filteredAnchorTags)
   
-  // if(!state) {
-  //   allAnchorTags.forEach(el => {
-  //       el.addEventListener("click", clickMe)
-  //   })
-  // }
-  // else {
-  //   allAnchorTags.forEach(el => {
-  //     el.removeEventListener("click", clickMe)
-  //   })
-  // }
+  if(state) {
+    allAnchorTags.forEach(el => {
+        el.addEventListener("click", clickMe)
+    })
+  }
+  else {
+    allAnchorTags.forEach(el => {
+      el.removeEventListener("click", clickMe)
+    })
+  }
 }
 
 function clickMe(e) {

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -60,16 +60,12 @@ const hasChanged = (e) => {
     targetAnchorTagEl(inputObject.inputChange)
     cancelChanges(inputObject.inputChange)
     unsavedMessageUnload(inputObject.inputChange)
-    // console.log(e.target.value,inputObject)
-    
   }
   else if(e.target.value.trim() !== ""){
     inputObject.inputChange = true
     targetAnchorTagEl(inputObject.inputChange)
     cancelChanges(inputObject.inputChange)
     unsavedMessageUnload(inputObject.inputChange)
-    // console.log(e.target.value,e.target,inputObject)
-    // console.log(packageConditionsArr)
     return
   }
 }
@@ -81,18 +77,13 @@ const isChecked = (e) => {
     targetAnchorTagEl(inputObject.inputChange)
     cancelChanges(inputObject.inputChange)
     unsavedMessageUnload(inputObject.inputChange)
-    console.log(e.target.checked)
-    console.log(e.target.value,inputObject)
   }
   // if no check and array of input has no value of true (false to true)
   else if (!e.target.checked && !checkAllInputChanges()){
-    console.log(checkAllInputChanges())
     inputObject.inputChange = false
     targetAnchorTagEl(inputObject.inputChange)
     cancelChanges(inputObject.inputChange)
     unsavedMessageUnload(inputObject.inputChange)
-    console.log(e.target.checked)
-    console.log(e.target.value,inputObject)
   }
 }
 
@@ -101,20 +92,15 @@ const handleConditionChange = (e) => {
   let arr = Array.from(e.target.selectedOptions, option => option.value);
   // Removes Empty String from first option value
   const filteredArr = arr.filter(condition => condition !== "")
-  console.log("arr", arr)
-  console.log("filteredArr", filteredArr)
 
   if(filteredArr.length) {
     // filteredArr.forEach(condition => packageConditionsArr.push(condition))
     inputObject.inputChange = true
     document.getElementById("packageCondition").setAttribute("data-selected",`${JSON.stringify(filteredArr)}`)
-    console.log(document.getElementById("packageCondition").getAttribute("data-selected"))
     // call function to add eventlistener to anchor tags  
     targetAnchorTagEl(inputObject.inputChange)
     cancelChanges(inputObject.inputChange)
     unsavedMessageUnload(inputObject.inputChange)
-    console.log(filteredArr)
-    console.log(inputObject)
   }
   // if no check and array of input has no value of true (false to true)
   else if(!filteredArr.length){
@@ -122,15 +108,10 @@ const handleConditionChange = (e) => {
     document.getElementById("packageCondition").setAttribute("data-selected","[]")
     if(!checkAllInputChanges()){
       inputObject.inputChange = false
-
       // call function to remove eventlistener from anchor tags
       targetAnchorTagEl(inputObject.inputChange)
       cancelChanges(inputObject.inputChange)
       unsavedMessageUnload(inputObject.inputChange)
-      console.log(filteredArr)
-      console.log(inputObject)
-      // debugger;
-      // return
     }
   }
 }
@@ -245,14 +226,9 @@ const checkCourierType = () => {
     a.addEventListener("input", (e) => {
       input = e.target.value
       if (input.length === 34) {
-        console.log(`${e.target.value}`)
-        console.log(input.length)
-        // console.log(e.target.value,e.target.value.length,typeof input.length)
             document.getElementById('courierType').innerHTML = `<i class="fa fa-check-circle" aria-hidden="true"></i> FEDEX` 
-            // document.getElementById('collectionCheckBox').disabled = true;
             document.getElementById('collectionCheckBox').checked = true;
             checkCardIncluded()
-
             disableCollectionCardFields();
             return
           }
@@ -268,7 +244,6 @@ const checkCourierType = () => {
             enableCollectionCardFields()
             return
           }
-            // enableCollectionCardFields()
     }) }
 }
 
@@ -317,13 +292,10 @@ const formSubmit = () => {
         obj['collectionComments'] = document.getElementById('collectionComments').value;
        
       }
-      // document.getElementById("clearForm").removeEventListener("click",cancelConfirm);
+      
       window.removeEventListener("beforeunload",beforeUnloadMessage)
       targetAnchorTagEl()
-      
-      console.log(obj)
-      // storePackageReceipt(obj);
-
+      storePackageReceipt(obj);
   })
 }      
 
@@ -428,9 +400,6 @@ const targetAnchorTagEl = (inputChange = false) => {
   const allAnchorTags = Array.from(document.getElementsByTagName("a"));
   const filteredAnchorTags = allAnchorTags.filter(el => el.getAttribute("href") !== location.hash)
   
-  // console.log(allAnchorTags)
-  // console.log(filteredAnchorTags)
-  
   if(inputChange) {
     filteredAnchorTags.forEach(el => {
         // el.addEventListener("click", clickMe)
@@ -446,16 +415,8 @@ const targetAnchorTagEl = (inputChange = false) => {
 }
 
 const unsavedChangesRoutingMessage = (e) => {
-  // REMOVE LATER- ADDED E PREVENT DEFAULT FOR TESTING PURPOSES
-
-  // e.preventDefault()
-  // console.log(e.target,"Clicked")
   unsavedMessageConfirmation(e)
 }
-
-
-
-// document.getElementById("dateReceived").value
 
 const enableCollectionCheckBox = () => {
   const collectionCheckBoxEl = document.getElementById("collectionCheckBox")
@@ -493,11 +454,6 @@ const beforeUnloadMessage = (e) => {
   return
 }
 
-const clickMe = (e) => {
-  // REMOVE LATER- ADDED E PREVENT DEFAULT FOR TESTING PURPOSES
-  e.preventDefault()
-  console.log(e.target,"Clicked")
-}
 
 const checkAllInputChanges = () => {
   
@@ -507,9 +463,6 @@ const checkAllInputChanges = () => {
   empty string, data-selected not "", checkbox not checked
   || document.getElementById("packageCondition").getAttribute("data-selected").length !== 0
   */ 
-
-  // condition2 problems
-
   // Input Change made !== "" or checked === true or 
 
   const condition1 = document.getElementById("scannedBarcode").value !== "" 
@@ -542,13 +495,10 @@ const checkAllInputChanges = () => {
 
 function parseDataSelected(value) {
   let parseData = JSON.parse(value)
-  // console.log(parseData)
   if(parseData.length === 0){
     return false
   }
   else if (parseData.length > 0) {
-    // JSON.parse(document.getElementById("packageCondition").getAttribute("data-selected")).length !== 0;
-    console.log("> 0", parseData.length)
     return true
   }
   return false

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -136,7 +136,7 @@ const packageReceiptTemplate = async (name, auth, route) => {
                         </div>
                         
                         <div class="row form-group">
-                            <label class="col-form-label col-md-4" for="packageConditionSelection">Select Package Condition</label>
+                            <label class="col-form-label col-md-4" for="packageCondition">Select Package Condition</label>
                              <div style="display:inline-block; max-width:90%;"> 
                                 <select required class="col form-control" id="packageCondition" style="width:100%" multiple="multiple">
                                     <option id="select-dashboard" value="">-- Select Package Condition --</option>
@@ -166,7 +166,7 @@ const packageReceiptTemplate = async (name, auth, route) => {
                         </div>
 
                         <div class="row form-group">
-                            <label class="col-form-label col-md-4">Comment</label>
+                            <label class="col-form-label col-md-4" for="receivePackageComments">Comment</label>
                             <textarea class="col-md-8" required id="receivePackageComments" cols="30" rows="3"></textarea>
                         </div>
 
@@ -179,13 +179,13 @@ const packageReceiptTemplate = async (name, auth, route) => {
                             <h5 style="text-align: left;">Collection Card Data Entry</h5>
 
                             <div class="row form-group">
-                                <label class="col-form-label col-md-4">Check if card not included</label>
+                                <label class="col-form-label col-md-4 for="collectionCheckBox">Check if card not included</label>
                                 <input type="checkbox" name="collectionCheckBox" id="collectionCheckBox">
                             </div>
 
                             <div class="row form-group">
-                                <label class="col-form-label col-md-4">Collection ID</label>
-                                <input autocomplete="off" class="col-md-8" type="text" id="collectionId">
+                                <label class="col-form-label col-md-4" for="collectionId">Collection ID</label>
+                                <input autocomplete="off" class="col-md-8 form-control" type="text" id="collectionId">
                             </div>
 
                             <div class="row form-group">
@@ -199,8 +199,8 @@ const packageReceiptTemplate = async (name, auth, route) => {
                             </div>
 
                             <div class="row form-group">
-                                <label class="col-form-label col-md-4">Comments on Card Returned</label>
-                                <textarea class="col-md-8" id="collectionComments" cols="30" rows="3"></textarea>
+                                <label class="col-form-label col-md-4" for="collectionComments">Comments on Card Returned</label>
+                                <textarea class="col-md-8 form-control" id="collectionComments" cols="30" rows="3"></textarea>
                             </div>
                           </div>
                         

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -101,29 +101,37 @@ const handleConditionChange = (e) => {
   let arr = Array.from(e.target.selectedOptions, option => option.value);
   // Removes Empty String from first option value
   const filteredArr = arr.filter(condition => condition !== "")
+  console.log("arr", arr)
+  console.log("filteredArr", filteredArr)
 
   if(filteredArr.length) {
     // filteredArr.forEach(condition => packageConditionsArr.push(condition))
     inputObject.inputChange = true
-    document.getElementById("packageCondition").setAttribute("data-selected",`${filteredArr}`)
-    console.log(document.getElementById("packageCondition").setAttribute("data-selected",`${filteredArr}`))
-    // call function to add eventlistener to anchor tags
+    document.getElementById("packageCondition").setAttribute("data-selected",`${JSON.stringify(filteredArr)}`)
+    console.log(document.getElementById("packageCondition").getAttribute("data-selected"))
+    // call function to add eventlistener to anchor tags  
     targetAnchorTagEl(inputObject.inputChange)
     cancelChanges(inputObject.inputChange)
     unsavedMessageUnload(inputObject.inputChange)
     console.log(filteredArr)
     console.log(inputObject)
   }
-  else if(!filteredArr.length && !checkAllInputChanges()){
-    inputObject.inputChange = false
+  // if no check and array of input has no value of true (false to true)
+  else if(!filteredArr.length){
     // set data-selected attribute
-    document.getElementById("packageCondition").setAttribute("data-selected","")
-    // call function to remove eventlistener from anchor tags
-    targetAnchorTagEl(inputObject.inputChange)
-    cancelChanges(inputObject.inputChange)
-    unsavedMessageUnload(inputObject.inputChange)
-    console.log(filteredArr)
-    console.log(inputObject)
+    document.getElementById("packageCondition").setAttribute("data-selected","[]")
+    if(!checkAllInputChanges()){
+      inputObject.inputChange = false
+
+      // call function to remove eventlistener from anchor tags
+      targetAnchorTagEl(inputObject.inputChange)
+      cancelChanges(inputObject.inputChange)
+      unsavedMessageUnload(inputObject.inputChange)
+      console.log(filteredArr)
+      console.log(inputObject)
+      // debugger;
+      // return
+    }
   }
 }
 
@@ -148,7 +156,7 @@ const packageReceiptTemplate = async (name, auth, route) => {
                         <div class="row form-group">
                             <label class="col-form-label col-md-4" for="packageCondition">Select Package Condition</label>
                              <div style="display:inline-block; max-width:90%;"> 
-                                <select required class="col form-control" id="packageCondition" style="width:100%" multiple="multiple" data-selected="">
+                                <select required class="col form-control" id="packageCondition" style="width:100%" multiple="multiple" data-selected="[]">
                                     <option id="select-dashboard" value="">-- Select Package Condition --</option>
                                     <option id="select-noIcePack" value="noIcePack">No Ice Pack</option>
                                     <option id="select-warmIcePack" value="warmIcePack">Warm Ice Pack</option>
@@ -289,13 +297,16 @@ const formSubmit = () => {
         obj['collectionComments'] = document.getElementById('collectionComments').value;
        
       }
-      storePackageReceipt(obj);
+      // document.getElementById("clearForm").removeEventListener("click",cancelConfirm);
+      window.removeEventListener("beforeunload",beforeUnloadMessage)
+      targetAnchorTagEl()
+      
+      console.log(obj)
+      // storePackageReceipt(obj);
 
   })
 }      
 
-// Important question: does an event listener need to be attached as soon as page loads?
-// When page loads every input is blank.
 
 // onload attach event listener
 // input changes add event listener - use click me as test
@@ -328,7 +339,7 @@ const cancelConfirm = (e) => {
       document.getElementById("collectionId").value = "";
       enableCollectionCardFields()
       enableCollectionCheckBox()
-      document.getElementById("packageCondition").setAttribute("data-selected","")
+      document.getElementById("packageCondition").setAttribute("data-selected","[]")
       cancelChanges.removeEventListener("click",cancelConfirm)
       window.removeEventListener("beforeunload",beforeUnloadMessage)
       
@@ -339,12 +350,11 @@ const cancelConfirm = (e) => {
         document.getElementById("collectionCheckBox").checked = false;
         document.getElementById("collectionComments").value = "";
 
-        // Remove Later include with error handling for USPS and Fedex?
-        enableCollectionCardFields()
-        enableCollectionCheckBox()
-        document.getElementById("packageCondition").setAttribute("data-selected","")
-        cancelChanges.removeEventListener("click",cancelConfirm)
-        window.removeEventListener("beforeunload",beforeUnloadMessage)
+        enableCollectionCardFields();
+        enableCollectionCheckBox();
+        document.getElementById("packageCondition").setAttribute("data-selected","[]");
+        cancelChanges.removeEventListener("click",cancelConfirm);
+        window.removeEventListener("beforeunload",beforeUnloadMessage);
 
       }
     }
@@ -470,11 +480,15 @@ const checkAllInputChanges = () => {
   Get values, data-sets, checked ---> 
   Compare to --> 
   empty string, data-selected not "", checkbox not checked
+  || document.getElementById("packageCondition").getAttribute("data-selected").length !== 0
   */ 
 
+  // condition2 problems
+
+  // Input Change made !== "" or checked === true or 
 
   const condition1 = document.getElementById("scannedBarcode").value !== "" 
-  const condition2 = document.getElementById("packageCondition").getAttribute("data-selected") !== ""
+  const condition2 = parseDataSelected(document.getElementById("packageCondition").getAttribute("data-selected"))
   const condition3 = document.getElementById("receivePackageComments").value !== "";
   const condition4 = document.getElementById("dateReceived").value !== "";
 
@@ -495,10 +509,24 @@ const checkAllInputChanges = () => {
     condition9
   ]
 
-  // if any items returm
+  // if any items returns true (Any input changes are made)
   if(conditionsArr.includes(true)) {
     return true
   } else return false
+}
+
+function parseDataSelected(value) {
+  let parseData = JSON.parse(value)
+  console.log(parseData)
+  if(parseData.length === 0){
+    return false
+  }
+  else if (parseData.length > 0) {
+    // JSON.parse(document.getElementById("packageCondition").getAttribute("data-selected")).length !== 0;
+    console.log("> 0", parseData.length)
+    return true
+  }
+  return false
 }
 
 // if(empty input && checkAllInputChanges === false) -- > remove event listeners
@@ -506,3 +534,26 @@ const checkAllInputChanges = () => {
 // if(empty input && checkAllinputChanges === true) --> do not remove event listeners
 
 // TODO: Disable window before unload eventlistener after cancel confirm and save 
+
+
+// condition1 = document.getElementById("scannedBarcode").value !== "" 
+// condition2 = parseDataSelected(document.getElementById("packageCondition").getAttribute("data-selected"))
+// condition3 = document.getElementById("receivePackageComments").value !== "";
+// condition4 = document.getElementById("dateReceived").value !== "";
+
+// condition5 = document.getElementById("collectionCheckBox").checked === true;
+// condition6 = document.getElementById("collectionId").value !== "";
+// condition7 = document.getElementById("dateCollectionCard").value !== "";
+// condition8 = document.getElementById("timeCollectionCard").value !== "";
+// condition9 = document.getElementById("collectionComments").value !== "";
+// conditionsArr = [
+//   condition1,
+//   condition2,
+//   condition3,
+//   condition4,
+//   condition5,
+//   condition6,
+//   condition7,
+//   condition8,
+//   condition9
+// ]

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -137,7 +137,8 @@ const checkCourierType = () => {
       }
       else if (input.length <= 12) {
         document.getElementById('courierType').innerHTML = `<i class="fa fa-check-circle" aria-hidden="true"></i> FEDEX` 
-        document.getElementById('collectionCheckBox').checked = true;
+        document.getElementById('collectionCheckBox').checked = false;
+        document.getElementById('collectionCheckBox').disabled = true;
         checkCardIncluded();
         disableCollectionCardFields();
         return
@@ -145,6 +146,7 @@ const checkCourierType = () => {
       else {
         document.getElementById('courierType').innerHTML = `<i class="fa fa-check-circle" aria-hidden="true"></i> USPS`
         document.getElementById('collectionCheckBox').checked = false;
+        document.getElementById('collectionCheckBox').removeAttribute("disabled")
         enableCollectionCardFields();
         return
       }
@@ -537,3 +539,35 @@ const getCurrentDate = () => {
   const currentDate = new Date().toLocaleDateString('en-CA');
   return currentDate
 }
+
+
+
+
+
+/* 
+IF / ELSE 
+
+a1 - enable
+a2 - disable
+b1 - uncheck checkbox
+b2- check checkbox
+c1 - enable checkbox
+c2 - disable checkbox
+
+USPS - a1, b1
+
+if length 0 --> a1, b1
+
+if number starts with 420 --> USPS
+OR 
+if number is 34 AND Starts with 420 --> usps
+
+if number is 22  || 20 length--> usps
+
+if number is 34 --> Fedex 
+
+if number is 12 Fedex
+
+input length <= 12 --> 
+
+*/

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -127,15 +127,37 @@ const checkCourierType = () => {
   const a = document.getElementById("scannedBarcode");
   let input = ""
   if (a) {
-    a.addEventListener("input", (e) => {
+    a.addEventListener("change", (e) => {
       input = e.target.value.trim()
+      // None
       if(input.length === 0){
         document.getElementById('courierType').innerHTML = ``
         enableCollectionCardFields();
         document.getElementById('collectionCheckBox').checked = false;
         return
       }
-      else if (input.length <= 12) {
+      // USPS
+      else if (uspsFirstThreeNumbersCheck(input) || (input.length === 34 && uspsFirstThreeNumbersCheck(input))) {
+        // console.log(uspsFirstThreeNumbersCheck(input))
+        document.getElementById('courierType').innerHTML = `<i class="fa fa-check-circle" aria-hidden="true"></i> USPS`
+        document.getElementById('collectionCheckBox').checked = false;
+        document.getElementById('collectionCheckBox').removeAttribute("disabled")
+        enableCollectionCardFields();
+        debugger;
+        return
+      }
+      // USPS
+      else if (input.length === 22 || input.length === 20) {
+        // console.log(uspsFirstThreeNumbersCheck(input))
+        document.getElementById('courierType').innerHTML = `<i class="fa fa-check-circle" aria-hidden="true"></i> USPS`
+        document.getElementById('collectionCheckBox').checked = false;
+        document.getElementById('collectionCheckBox').removeAttribute("disabled")
+        enableCollectionCardFields();
+        debugger;
+        return
+      }
+      // FEDEX
+      else if (input.length === 34) {
         document.getElementById('courierType').innerHTML = `<i class="fa fa-check-circle" aria-hidden="true"></i> FEDEX` 
         document.getElementById('collectionCheckBox').checked = false;
         document.getElementById('collectionCheckBox').disabled = true;
@@ -143,8 +165,18 @@ const checkCourierType = () => {
         disableCollectionCardFields();
         return
       }
+      // FEDEX
+      else if (input.length === 12) {
+        document.getElementById('courierType').innerHTML = `<i class="fa fa-check-circle" aria-hidden="true"></i> FEDEX` 
+        document.getElementById('collectionCheckBox').checked = false;
+        document.getElementById('collectionCheckBox').disabled = true;
+        checkCardIncluded();
+        disableCollectionCardFields();
+        return
+      }
+      // None
       else {
-        document.getElementById('courierType').innerHTML = `<i class="fa fa-check-circle" aria-hidden="true"></i> USPS`
+        document.getElementById('courierType').innerHTML = ``
         document.getElementById('collectionCheckBox').checked = false;
         document.getElementById('collectionCheckBox').removeAttribute("disabled")
         enableCollectionCardFields();
@@ -189,7 +221,7 @@ const formSubmit = () => {
       if (option.selected) {packageConditions.push(option.value)}
     }
     obj[`${fieldMapping.packageCondition}`] = packageConditions;
-    if (scannedBarcode.length <= 12) {  
+    if (scannedBarcode.length === 12 || (!uspsFirstThreeNumbersCheck(scannedBarcode) && scannedBarcode.length === 34)) {  
       obj[`${fieldMapping.siteShipmentReceived}`] = fieldMapping.yes
       obj[`${fieldMapping.siteShipmentComments}`] = document.getElementById('receivePackageComments').value.trim();
       obj[`${fieldMapping.siteShipmentDateReceived}`] = document.getElementById('dateReceived').value;
@@ -207,6 +239,7 @@ const formSubmit = () => {
     }
     window.removeEventListener("beforeunload",beforeUnloadMessage)
     targetAnchorTagEl()
+    console.log(obj)
     storePackageReceipt(obj);
   })
 }      
@@ -540,10 +573,6 @@ const getCurrentDate = () => {
   return currentDate
 }
 
-
-
-
-
 /* 
 IF / ELSE 
 
@@ -554,20 +583,27 @@ b2- check checkbox
 c1 - enable checkbox
 c2 - disable checkbox
 
-USPS - a1, b1
+USPS - a1, b1, c1
+FEDEX - a2, c2
 
-if length 0 --> a1, b1
+1. if length 0 --> None a1, b1
 
-if number starts with 420 --> USPS
+2. if number starts with 420 --> USPS
 OR 
 if number is 34 AND Starts with 420 --> usps
 
-if number is 22  || 20 length--> usps
+3. if number is 22  || 20 length--> usps
 
-if number is 34 --> Fedex 
+4. if number is 34 --> Fedex 
 
-if number is 12 Fedex
+5. if number is 12 Fedex
 
-input length <= 12 --> 
+6. input length <= 12 --> None
 
 */
+
+const uspsFirstThreeNumbersCheck = (input) => {
+  const regExp = /^420[0-9]{31}$/
+  return regExp.test(input);
+}
+

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -54,7 +54,8 @@ receivePackageCommentsEl
 dateReceivedEl
 */ 
 const hasChanged = (e) => {
-  if(e.target.value.trim() ==="") {
+  // array of input has no value of true (false to true)
+  if(e.target.value.trim() ==="" && !checkAllInputChanges()) {
     inputObject.inputChange = false
     targetAnchorTagEl(inputObject.inputChange)
     cancelChanges(inputObject.inputChange)
@@ -71,7 +72,6 @@ const hasChanged = (e) => {
     // console.log(packageConditionsArr)
     return
   }
-  else return
 }
 
 // collectionCheckBoxEl
@@ -84,7 +84,9 @@ const isChecked = (e) => {
     console.log(e.target.checked)
     console.log(e.target.value,inputObject)
   }
-  else {
+  // if no check and array of input has no value of true (false to true)
+  else if (!e.target.checked && !checkAllInputChanges()){
+    // console.log(checkAllInputChanges())
     inputObject.inputChange = false
     targetAnchorTagEl(inputObject.inputChange)
     cancelChanges(inputObject.inputChange)
@@ -95,7 +97,6 @@ const isChecked = (e) => {
 }
 
 
-// packageConditionEl
 const handleConditionChange = (e) => {
   let arr = Array.from(e.target.selectedOptions, option => option.value);
   // Removes Empty String from first option value
@@ -113,7 +114,7 @@ const handleConditionChange = (e) => {
     console.log(filteredArr)
     console.log(inputObject)
   }
-  else {
+  else if(!filteredArr.length && !checkAllInputChanges()){
     inputObject.inputChange = false
     // set data-selected attribute
     document.getElementById("packageCondition").setAttribute("data-selected","")

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -57,11 +57,14 @@ dateReceivedEl
 const hasChanged = (e) => {
   if(e.target.value.trim() ==="") {
     inputObject.inputChange = false
-    console.log(e.target.value,inputObject)
+    targetAnchorTagEl(inputObject.inputChange)
+    // console.log(e.target.value,inputObject)
+    
   }
   else if(e.target.value.trim() !== ""){
     inputObject.inputChange = true
-    console.log(e.target.value,e.target,inputObject)
+    targetAnchorTagEl(inputObject.inputChange)
+    // console.log(e.target.value,e.target,inputObject)
     // console.log(packageConditionsArr)
     return
   }
@@ -72,11 +75,13 @@ const hasChanged = (e) => {
 const isChecked = (e) => {
   if(e.target.checked) {
     inputObject.inputChange = true
+    targetAnchorTagEl(inputObject.inputChange)
     console.log(e.target.checked)
     console.log(e.target.value,inputObject)
   }
   else {
     inputObject.inputChange = false
+    targetAnchorTagEl(inputObject.inputChange)
     console.log(e.target.checked)
     console.log(e.target.value,inputObject)
   }
@@ -274,22 +279,31 @@ const formSubmit = () => {
 
 const cancelChanges = () => {
     const cancelChanges = document.getElementById("clearForm");
-    cancelChanges.addEventListener("click", (e) => {
-        document.getElementById("courierType").innerHTML = ``;
-        document.getElementById("scannedBarcode").value = "";
-        document.getElementById("packageCondition").value = "";
-        document.getElementById("receivePackageComments").value = "";
-        document.getElementById("dateReceived").value = "";
-
-        if (document.getElementById("collectionId").value) {
-            document.getElementById("collectionId").value = "";
-            document.getElementById("dateCollectionCard").value = "";
-            document.getElementById("timeCollectionCard").value = "";
-            document.getElementById("collectionCheckBox").checked = false;
-            document.getElementById("collectionComments").value = "";
-        }
-    });
+    cancelChanges.addEventListener("click",cancelConfirm);
 };
+
+const cancelConfirm = (e) => {
+  let result = window.confirm("Changes were made and will be unsaved.")
+
+  if(result){
+    document.getElementById("courierType").innerHTML = ``;
+    document.getElementById("scannedBarcode").value = "";
+    document.getElementById("packageCondition").value = "";
+    document.getElementById("receivePackageComments").value = "";
+    document.getElementById("dateReceived").value = "";
+  
+    if (document.getElementById("collectionId").value) {
+        document.getElementById("collectionId").value = "";
+        document.getElementById("dateCollectionCard").value = "";
+        document.getElementById("timeCollectionCard").value = "";
+        document.getElementById("collectionCheckBox").checked = false;
+        document.getElementById("collectionComments").value = "";
+    }
+  }
+  else {
+    return
+  }
+}
 
 const storePackageReceipt = async (data) => {
     showAnimation();
@@ -336,7 +350,7 @@ const targetAnchorTagEl = (state = false) => {
   const allAnchorTags = Array.from(document.getElementsByTagName("a"));
   const filteredAnchorTags = allAnchorTags.filter(el => el.getAttribute("href") !== location.hash)
   
-  console.log(filteredAnchorTags)
+  // console.log(filteredAnchorTags)
   
   if(state) {
     allAnchorTags.forEach(el => {
@@ -351,6 +365,8 @@ const targetAnchorTagEl = (state = false) => {
 }
 
 function clickMe(e) {
+  // REMOVE LATER- ADDED E PREVENT DEFAULT FOR TESTING PURPOSES
+  e.preventDefault()
   console.log(e.target,"Clicked")
 }
 

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -15,6 +15,7 @@ export const packageReceiptScreen = async (auth, route) => {
   enableCollectionCardFields();
   formSubmit();
   cancelChanges();
+  targetAnchorTagEl()
 }
 
 
@@ -233,3 +234,34 @@ const storePackageReceipt = async (data) => {
         alert("Error");
     }
 };
+
+
+/*
+FUNCTIONS FOR UNSAVED CHANGES
+*/
+
+// Add to shared.js later as an export function expression
+const targetAnchorTagEl = (state = false) => {
+  // Target all items with anchor tags, convert HTML Collection to a normal array of elements
+  // Filter and remove current anchor tag with the current location.hash
+  console.log(location.hash)
+  const allAnchorTags = Array.from(document.getElementsByTagName("a"));
+  const filteredAnchorTags = allAnchorTags.filter(el => el.getAttribute("href") !== location.hash)
+  
+  console.log(filteredAnchorTags)
+  
+  // if(!state) {
+  //   allAnchorTags.forEach(el => {
+  //       el.addEventListener("click", clickMe)
+  //   })
+  // }
+  // else {
+  //   allAnchorTags.forEach(el => {
+  //     el.removeEventListener("click", clickMe)
+  //   })
+  // }
+}
+
+function clickMe(e) {
+  console.log(e.target,"Clicked")
+}

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -19,7 +19,7 @@ export const packageReceiptScreen = async (auth, route) => {
   disableCollectionCardFields();
   enableCollectionCardFields();
   formSubmit();
-  cancelChanges();
+  // cancelChanges();
   targetAnchorTagEl();
 
   // Receive Packages: barcode, packageconditions,receive package comments, date received
@@ -58,12 +58,14 @@ const hasChanged = (e) => {
   if(e.target.value.trim() ==="") {
     inputObject.inputChange = false
     targetAnchorTagEl(inputObject.inputChange)
+    cancelChanges(inputObject.inputChange)
     // console.log(e.target.value,inputObject)
     
   }
   else if(e.target.value.trim() !== ""){
     inputObject.inputChange = true
     targetAnchorTagEl(inputObject.inputChange)
+    cancelChanges(inputObject.inputChange)
     // console.log(e.target.value,e.target,inputObject)
     // console.log(packageConditionsArr)
     return
@@ -76,12 +78,14 @@ const isChecked = (e) => {
   if(e.target.checked) {
     inputObject.inputChange = true
     targetAnchorTagEl(inputObject.inputChange)
+    cancelChanges(inputObject.inputChange)
     console.log(e.target.checked)
     console.log(e.target.value,inputObject)
   }
   else {
     inputObject.inputChange = false
     targetAnchorTagEl(inputObject.inputChange)
+    cancelChanges(inputObject.inputChange)
     console.log(e.target.checked)
     console.log(e.target.value,inputObject)
   }
@@ -99,13 +103,15 @@ const handleConditionChange = (e) => {
     inputObject.inputChange = true
     // call function to add eventlistener to anchor tags
     targetAnchorTagEl(inputObject.inputChange)
+    cancelChanges(inputObject.inputChange)
     console.log(filteredArr)
     console.log(inputObject)
   }
   else {
     inputObject.inputChange = false
-    targetAnchorTagEl(inputObject.inputChange)
     // call function to remove eventlistener from anchor tags
+    targetAnchorTagEl(inputObject.inputChange)
+    cancelChanges(inputObject.inputChange)
     console.log(filteredArr)
     console.log(inputObject)
   }
@@ -213,6 +219,7 @@ const packageReceiptTemplate = async (name, auth, route) => {
 };
 
 const checkCourierType = () => {
+  // TODO: Add a stricter check
   const a = document.getElementById("scannedBarcode");
   if (a) {
     a.addEventListener("change", () => {
@@ -277,32 +284,57 @@ const formSubmit = () => {
   })
 }      
 
-const cancelChanges = () => {
+// Important question: does an event listener need to be attached as soon as page loads?
+// When page loads every input is blank.
+
+// onload attach event listener
+// input changes add event listener - use click me as test
+// no input changes and not onload - remove click me as test
+
+// Add two parameters and check truthy and falsy values
+const cancelChanges = (inputChanges) => {
     const cancelChanges = document.getElementById("clearForm");
-    cancelChanges.addEventListener("click",cancelConfirm);
+    if(inputChanges) {
+      cancelChanges.addEventListener("click",cancelConfirm)
+    }
+    else {
+      cancelChanges.removeEventListener("click",cancelConfirm)
+    }
 };
 
 const cancelConfirm = (e) => {
-  let result = window.confirm("Changes were made and will be unsaved.")
+    const cancelChanges = document.getElementById("clearForm");
+    let result = confirm("Changes were made and will not be saved.")
 
-  if(result){
-    document.getElementById("courierType").innerHTML = ``;
-    document.getElementById("scannedBarcode").value = "";
-    document.getElementById("packageCondition").value = "";
-    document.getElementById("receivePackageComments").value = "";
-    document.getElementById("dateReceived").value = "";
-  
-    if (document.getElementById("collectionId").value) {
-        document.getElementById("collectionId").value = "";
-        document.getElementById("dateCollectionCard").value = "";
-        document.getElementById("timeCollectionCard").value = "";
-        document.getElementById("collectionCheckBox").checked = false;
-        document.getElementById("collectionComments").value = "";
+    if(result){
+      document.getElementById("courierType").innerHTML = ``;
+      document.getElementById("scannedBarcode").value = "";
+      document.getElementById("packageCondition").value = "";
+      document.getElementById("receivePackageComments").value = "";
+      document.getElementById("dateReceived").value = "";
+      
+      // Remove Later include with error handling for USPS and Fedex?
+      enableCollectionCardFields()
+      enableCollectionCheckBox()
+      cancelChanges.removeEventListener("click",cancelConfirm)
+
+      if (document.getElementById("collectionId").value) {
+          document.getElementById("collectionId").value = "";
+          document.getElementById("dateCollectionCard").value = "";
+          document.getElementById("timeCollectionCard").value = "";
+          document.getElementById("collectionCheckBox").checked = false;
+          document.getElementById("collectionComments").value = "";
+
+          // Remove Later include with error handling for USPS and Fedex?
+          enableCollectionCardFields()
+          enableCollectionCheckBox()
+          cancelChanges.removeEventListener("click",cancelConfirm)
+      }
     }
-  }
-  else {
-    return
-  }
+    else {
+      return 
+    }
+  
 }
 
 const storePackageReceipt = async (data) => {
@@ -371,3 +403,9 @@ function clickMe(e) {
 }
 
 // document.getElementById("dateReceived").value
+
+const enableCollectionCheckBox = () => {
+  const collectionCheckBoxEl = document.getElementById("collectionCheckBox")
+  collectionCheckBoxEl.removeAttribute("disabled")
+  collectionCheckBoxEl.checked = false
+}

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -19,7 +19,6 @@ export const packageReceiptScreen = async (auth, route) => {
   disableCollectionCardFields();
   enableCollectionCardFields();
   formSubmit();
-  // cancelChanges();
   targetAnchorTagEl();
 
   // Receive Packages: barcode, packageconditions,receive package comments, date received
@@ -59,6 +58,7 @@ const hasChanged = (e) => {
     inputObject.inputChange = false
     targetAnchorTagEl(inputObject.inputChange)
     cancelChanges(inputObject.inputChange)
+    unsavedMessageUnload(inputObject.inputChange)
     // console.log(e.target.value,inputObject)
     
   }
@@ -66,6 +66,7 @@ const hasChanged = (e) => {
     inputObject.inputChange = true
     targetAnchorTagEl(inputObject.inputChange)
     cancelChanges(inputObject.inputChange)
+    unsavedMessageUnload(inputObject.inputChange)
     // console.log(e.target.value,e.target,inputObject)
     // console.log(packageConditionsArr)
     return
@@ -79,6 +80,7 @@ const isChecked = (e) => {
     inputObject.inputChange = true
     targetAnchorTagEl(inputObject.inputChange)
     cancelChanges(inputObject.inputChange)
+    unsavedMessageUnload(inputObject.inputChange)
     console.log(e.target.checked)
     console.log(e.target.value,inputObject)
   }
@@ -86,6 +88,7 @@ const isChecked = (e) => {
     inputObject.inputChange = false
     targetAnchorTagEl(inputObject.inputChange)
     cancelChanges(inputObject.inputChange)
+    unsavedMessageUnload(inputObject.inputChange)
     console.log(e.target.checked)
     console.log(e.target.value,inputObject)
   }
@@ -101,17 +104,23 @@ const handleConditionChange = (e) => {
   if(filteredArr.length) {
     // filteredArr.forEach(condition => packageConditionsArr.push(condition))
     inputObject.inputChange = true
+    document.getElementById("packageCondition").setAttribute("data-selected",`${filteredArr}`)
+    console.log(document.getElementById("packageCondition").setAttribute("data-selected",`${filteredArr}`))
     // call function to add eventlistener to anchor tags
     targetAnchorTagEl(inputObject.inputChange)
     cancelChanges(inputObject.inputChange)
+    unsavedMessageUnload(inputObject.inputChange)
     console.log(filteredArr)
     console.log(inputObject)
   }
   else {
     inputObject.inputChange = false
+    // set data-selected attribute
+    document.getElementById("packageCondition").setAttribute("data-selected","")
     // call function to remove eventlistener from anchor tags
     targetAnchorTagEl(inputObject.inputChange)
     cancelChanges(inputObject.inputChange)
+    unsavedMessageUnload(inputObject.inputChange)
     console.log(filteredArr)
     console.log(inputObject)
   }
@@ -130,7 +139,7 @@ const packageReceiptTemplate = async (name, auth, route) => {
                         <div class="row form-group">
                             <label class="col-form-label col-md-4" for="scannedBarcode">Scan FedEx/USPS Barcode</label>
                             <div style="display:inline-block;">
-                              <input autocomplete="off" required class="col-md-8" type="text" id="scannedBarcode" style="width: 600px;">
+                              <input autocomplete="off" required class="col-md-8 form-control" type="text" id="scannedBarcode" style="width: 600px;">
                               <span id='courierType' style="padding-left: 10px;"></span>
                             </div>
                         </div>
@@ -138,7 +147,7 @@ const packageReceiptTemplate = async (name, auth, route) => {
                         <div class="row form-group">
                             <label class="col-form-label col-md-4" for="packageCondition">Select Package Condition</label>
                              <div style="display:inline-block; max-width:90%;"> 
-                                <select required class="col form-control" id="packageCondition" style="width:100%" multiple="multiple">
+                                <select required class="col form-control" id="packageCondition" style="width:100%" multiple="multiple" data-selected="">
                                     <option id="select-dashboard" value="">-- Select Package Condition --</option>
                                     <option id="select-noIcePack" value="noIcePack">No Ice Pack</option>
                                     <option id="select-warmIcePack" value="warmIcePack">Warm Ice Pack</option>
@@ -167,7 +176,7 @@ const packageReceiptTemplate = async (name, auth, route) => {
 
                         <div class="row form-group">
                             <label class="col-form-label col-md-4" for="receivePackageComments">Comment</label>
-                            <textarea class="col-md-8" required id="receivePackageComments" cols="30" rows="3"></textarea>
+                            <textarea class="col-md-8 form-control" required id="receivePackageComments" cols="30" rows="3"></textarea>
                         </div>
 
                         <div class="row form-group">
@@ -319,18 +328,21 @@ const cancelConfirm = (e) => {
       enableCollectionCardFields()
       enableCollectionCheckBox()
       cancelChanges.removeEventListener("click",cancelConfirm)
-
+      window.removeEventListener("beforeunload",beforeUnloadMessage)
+      
       if (document.getElementById("collectionId").value) {
-          document.getElementById("collectionId").value = "";
-          document.getElementById("dateCollectionCard").value = "";
-          document.getElementById("timeCollectionCard").value = "";
-          document.getElementById("collectionCheckBox").checked = false;
-          document.getElementById("collectionComments").value = "";
+        document.getElementById("collectionId").value = "";
+        document.getElementById("dateCollectionCard").value = "";
+        document.getElementById("timeCollectionCard").value = "";
+        document.getElementById("collectionCheckBox").checked = false;
+        document.getElementById("collectionComments").value = "";
 
-          // Remove Later include with error handling for USPS and Fedex?
-          enableCollectionCardFields()
-          enableCollectionCheckBox()
-          cancelChanges.removeEventListener("click",cancelConfirm)
+        // Remove Later include with error handling for USPS and Fedex?
+        enableCollectionCardFields()
+        enableCollectionCheckBox()
+        cancelChanges.removeEventListener("click",cancelConfirm)
+        window.removeEventListener("beforeunload",beforeUnloadMessage)
+
       }
     }
     else {
@@ -377,20 +389,19 @@ FUNCTIONS FOR UNSAVED CHANGES
 */
 
 // Add to shared.js later as an export function expression
-const targetAnchorTagEl = (state = false) => {
+const targetAnchorTagEl = (inputChange = false) => {
   // Target all items with anchor tags, convert HTML Collection to a normal array of elements
   // Filter and remove current anchor tag with the current location.hash
-  console.log(location.hash)
   const allAnchorTags = Array.from(document.getElementsByTagName("a"));
   const filteredAnchorTags = allAnchorTags.filter(el => el.getAttribute("href") !== location.hash)
   
   // console.log(allAnchorTags)
   // console.log(filteredAnchorTags)
   
-  if(state) {
+  if(inputChange) {
     filteredAnchorTags.forEach(el => {
         // el.addEventListener("click", clickMe)
-        el.addEventListener("click", clickMe)
+        el.addEventListener("click", unsavedChangesRoutingMessage)
     })
   }
   else {
@@ -406,7 +417,7 @@ const unsavedChangesRoutingMessage = (e) => {
 
   // e.preventDefault()
   // console.log(e.target,"Clicked")
-  unsavedMessageConfirmation()
+  unsavedMessageConfirmation(e)
 }
 
 
@@ -421,13 +432,27 @@ const enableCollectionCheckBox = () => {
 
 
 // Reusable message alert
-const unsavedMessageConfirmation = () => {
-  const result = confirm("Any unsaved changes will be lost.\n Are you sure you want to leave the page? ")
+const unsavedMessageConfirmation = (e) => {
+  const result = confirm("Changes were made and will not be saved.\n\nAre you sure you want to leave the page? ")
   if(!result) {
     e.preventDefault()
-    return
+    return false
   }
-  else return
+  else return true
+}
+
+const unsavedMessageUnload = (inputChange) => {
+  if(inputChange) {
+    window.addEventListener("beforeunload",beforeUnloadMessage)
+  }
+  else if (!inputChange) {
+    window.removeEventListener("beforeunload",beforeUnloadMessage)
+  }
+}
+
+const beforeUnloadMessage = (e) => { 
+  e.preventDefault()
+  return
 }
 
 const clickMe = (e) => {
@@ -435,3 +460,23 @@ const clickMe = (e) => {
   e.preventDefault()
   console.log(e.target,"Clicked")
 }
+
+const checkAllInputChanges = () => {
+  
+  // Get values, data-sets, checked ---> Compare to --> empty string, data-selected not "", checkbox not checked
+  document.getElementById("scannedBarcode").value;
+  document.getElementById("packageCondition").value;
+  document.getElementById("receivePackageComments").value;
+  document.getElementById("dateReceived").value;
+
+  document.getElementById("collectionCheckBox").value;
+  document.getElementById("collectionId").value;
+  document.getElementById("dateCollectionCard").value;
+  document.getElementById("timeCollectionCard").value;
+  document.getElementById("collectionComments").value;
+
+  
+  
+}
+
+// Disable window before unload eventlistener after cancel confirm and save 

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -217,7 +217,6 @@ const packageReceiptTemplate = async (name, auth, route) => {
 };
 
 const checkCourierType = () => {
-  // if fedex remove first 8 characters
   const a = document.getElementById("scannedBarcode");
   let input = ""
   if (a) {
@@ -298,7 +297,8 @@ const formSubmit = () => {
     }
     window.removeEventListener("beforeunload",beforeUnloadMessage)
     targetAnchorTagEl()
-    storePackageReceipt(obj);
+    console.log(obj)
+    // storePackageReceipt(obj);
   })
 }      
 

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -44,8 +44,6 @@ export const packageReceiptScreen = async (auth, route) => {
   dateCollectionCardEl.addEventListener("change",hasChanged)
   timeCollectionCardEl.addEventListener("input",hasChanged)
   collectionCommentsEl.addEventListener("input",hasChanged)
-
-  
 }
 
 /*
@@ -225,25 +223,25 @@ const checkCourierType = () => {
   if (a) {
     a.addEventListener("input", (e) => {
       input = e.target.value
-      if (input.length === 34) {
+      if (input.length === 22) {
             document.getElementById('courierType').innerHTML = `<i class="fa fa-check-circle" aria-hidden="true"></i> FEDEX` 
             document.getElementById('collectionCheckBox').checked = true;
             checkCardIncluded()
             disableCollectionCardFields();
             return
           }
-            else if (input.length === 30){
-            document.getElementById('courierType').innerHTML = `<i class="fa fa-check-circle" aria-hidden="true"></i> USPS`
-            document.getElementById('collectionCheckBox').checked = false;
-            enableCollectionCardFields()
-            return
-          }
-          else {
-            document.getElementById('courierType').innerHTML = ``
-            document.getElementById('collectionCheckBox').checked = false;
-            enableCollectionCardFields()
-            return
-          }
+      else if (input.length === 30){
+      document.getElementById('courierType').innerHTML = `<i class="fa fa-check-circle" aria-hidden="true"></i> USPS`
+      document.getElementById('collectionCheckBox').checked = false;
+      enableCollectionCardFields()
+      return
+      }
+      else {
+        document.getElementById('courierType').innerHTML = ``
+        document.getElementById('collectionCheckBox').checked = false;
+        enableCollectionCardFields()
+        return
+      }
     }) }
 }
 
@@ -326,7 +324,6 @@ const cancelConfirm = (e) => {
       document.getElementById("receivePackageComments").value = "";
       document.getElementById("dateReceived").value = "";
       
-      // Remove Later include with error handling for USPS and Fedex?
       document.getElementById("collectionComments").value = "";
       document.getElementById("collectionId").value = "";
       enableCollectionCardFields()
@@ -495,7 +492,7 @@ const checkAllInputChanges = () => {
   } else return false
 }
 
-function parseDataSelected(value) {
+const parseDataSelected = (value) => {
   let parseData = JSON.parse(value)
   if(parseData.length === 0){
     return false

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -384,25 +384,32 @@ const targetAnchorTagEl = (state = false) => {
   const allAnchorTags = Array.from(document.getElementsByTagName("a"));
   const filteredAnchorTags = allAnchorTags.filter(el => el.getAttribute("href") !== location.hash)
   
+  // console.log(allAnchorTags)
   // console.log(filteredAnchorTags)
   
   if(state) {
-    allAnchorTags.forEach(el => {
+    filteredAnchorTags.forEach(el => {
+        // el.addEventListener("click", clickMe)
         el.addEventListener("click", clickMe)
     })
   }
   else {
-    allAnchorTags.forEach(el => {
-      el.removeEventListener("click", clickMe)
+    filteredAnchorTags.forEach(el => {
+      // el.removeEventListener("click", clickMe)
+      el.removeEventListener("click", unsavedChangesRoutingMessage)
     })
   }
 }
 
-function clickMe(e) {
+const unsavedChangesRoutingMessage = (e) => {
   // REMOVE LATER- ADDED E PREVENT DEFAULT FOR TESTING PURPOSES
-  e.preventDefault()
-  console.log(e.target,"Clicked")
+
+  // e.preventDefault()
+  // console.log(e.target,"Clicked")
+  unsavedMessageConfirmation()
 }
+
+
 
 // document.getElementById("dateReceived").value
 
@@ -410,4 +417,21 @@ const enableCollectionCheckBox = () => {
   const collectionCheckBoxEl = document.getElementById("collectionCheckBox")
   collectionCheckBoxEl.removeAttribute("disabled")
   collectionCheckBoxEl.checked = false
+}
+
+
+// Reusable message alert
+const unsavedMessageConfirmation = () => {
+  const result = confirm("Any unsaved changes will be lost.\n Are you sure you want to leave the page? ")
+  if(!result) {
+    e.preventDefault()
+    return
+  }
+  else return
+}
+
+const clickMe = (e) => {
+  // REMOVE LATER- ADDED E PREVENT DEFAULT FOR TESTING PURPOSES
+  e.preventDefault()
+  console.log(e.target,"Clicked")
 }


### PR DESCRIPTION
The Pull Request addresses the following features:
- Alerting the user of unsaved changes using alert modals by detecting changes in input fields

POC: 

Unsaved Changes Message Alert for Anchor Tag Event Listener on Click
<img width="452" alt="Screen Shot 2021-11-01 at 10 51 34 AM" src="https://user-images.githubusercontent.com/33293205/139703713-df5a1235-e3c4-49ac-a09c-f6bdb3c947f8.png">

https://user-images.githubusercontent.com/33293205/139704830-f1ce5453-9575-49f2-a086-caba4b199904.mov



https://user-images.githubusercontent.com/33293205/139704450-ab7d9618-17e4-4f53-81eb-6ed7034488b3.mov

Unsaved ChangesMessage Alert for Window on beforeunload(close window, refresh window, close tab)
<img width="266" alt="Screen Shot 2021-11-01 at 10 51 44 AM" src="https://user-images.githubusercontent.com/33293205/139703715-ac2b8f7a-5be2-4064-8ebc-332aaf53cbbf.png">





Note:

On load, event listeners are attached to the input field elements, the checkbox element and the select element to detect changes. If any changes occur a [beforeunload](https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload) event listener is added to the window or click event listener is added to all anchor tags on page. Changes are **TRUE** based on the following:
- Inputs: current value is not an empty string 
- Checkbox: checkbox checked attribute is not unchecked
- Select: selected option element is not chosen or select package condition is chosen (has a value of "")

If a user presses clear button (given changes were made previously), clears input field(s) manually, chooses only "select package condition" or unchecks a checkbox after being checked, then the following occurs: 
- remove beforeunload event listener from the window
- remove click event listener from anchor tag elements


**IMPORTANT**
USPS and Fedex variations will play a vital role in the code's functionality, this topic requires careful consideration
The current code uses length to determine courier type which needs to be improved. Different courier types have different speed services which will vary the length of the scannable code

https://stackoverflow.com/questions/619977/regular-expression-patterns-for-tracking-numbers

https://andrewkurochkin.com/blog/code-for-recognizing-delivery-company-by-track 

