### PR TITLE
Shipping fix hide orphan header

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -730,13 +730,14 @@ export const populateSpecimensList = async (hiddenJSON) => {
         }
     }
 
+    let orphanHeader = document.getElementById('orphanHeader')
     let orphanPanel = document.getElementById('orphansPanel');
     let orphanTable = document.getElementById('orphansList')
     let specimenPanel = document.getElementById('specimenPanel')
     orphanTable.innerHTML = '';
 
     if (orphansIndex != -1 && specimenObject['unlabelled'].length > 0) {
-
+        orphanHeader.style.display = 'block'
         orphanPanel.style.display = 'block'
         specimenPanel.style.height = '400px'
 

--- a/src/pages/shipping.js
+++ b/src/pages/shipping.js
@@ -113,7 +113,7 @@ export const startShipping = async (userName) => {
             </table>
     </div>
 
-    <h3 style="margin:1rem auto; text-align:center">Location Unknown</h3>
+    <h3 style="margin:1rem auto; text-align:center; display:none;" id="orphanHeader">Location Unknown</h3>
     <div class="panel panel-default" style="border-style:solid;height:150px;border-width:1px;overflow:auto;" id="orphansPanel">
             <table class = "table" style="width: 100%; margin-bottom:0px;" id="orphansList" >
                 


### PR DESCRIPTION
Quick fix: Hide orphan header on Shipping Page from being displayed, if orphan table is not displayed