### PR TITLE
allow full scan and chop off sequence number

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -75,7 +75,10 @@ export const addEventsearchSpecimen = () => {
     form.addEventListener('submit', async e => {
         e.preventDefault();
         removeAllErrors();
-        const masterSpecimenId = document.getElementById('masterSpecimenId').value.toUpperCase();
+        let masterSpecimenId = document.getElementById('masterSpecimenId').value.toUpperCase();
+
+        if(masterSpecimenId.length > masterSpecimenIDRequirement.length) masterSpecimenId = masterSpecimenId.substring(0, masterSpecimenIDRequirement.length);
+
         if (!masterSpecimenIDRequirement.regExp.test(masterSpecimenId) || masterSpecimenId.length !== masterSpecimenIDRequirement.length) {
             errorMessage('masterSpecimenId', `Collection ID must be ${masterSpecimenIDRequirement.length} characters long and in CXA123456 format.`, true);
             return;
@@ -1833,7 +1836,10 @@ const btnsClicked = async (connectId, formData) => {
 
     removeAllErrors();
 
-    const scanSpecimenID = document.getElementById('scanSpecimenID').value;
+    let scanSpecimenID = document.getElementById('scanSpecimenID').value;
+
+    if(scanSpecimenID.length > masterSpecimenIDRequirement.length) scanSpecimenID = scanSpecimenID.substring(0, masterSpecimenIDRequirement.length);
+
     const enterSpecimenID1 = document.getElementById('enterSpecimenID1').value.toUpperCase();
     const enterSpecimenID2 = document.getElementById('enterSpecimenID2').value.toUpperCase();
     const accessionID1 = document.getElementById('accessionID1');
@@ -2062,6 +2068,10 @@ export const addEventBiospecimenCollectionFormText = (dt, biospecimenData) => {
 
             let value = getValue(`${input.id}`).toUpperCase();
             if (value.length != 0) {
+
+                const tubeCheckBox = document.getElementById(input.id.replace('Id',''));
+
+                if(tubeCheckBox) input.required = tubeCheckBox.checked;
 
                 const masterID = value.substr(0, masterSpecimenIDRequirement.length);
                 const tubeID = value.substr(masterSpecimenIDRequirement.length + 1, totalCollectionIDLength);
@@ -2809,23 +2819,6 @@ export const addEventClearScannedBarcode = (id) => {
         document.getElementById(clearInputBtn.dataset.barcodeInput).value = '';
         clearInputBtn.hidden = true;
     });
-}
-
-export const addEventCntdToCollectProcess = () => {
-    const btns = document.getElementsByClassName('continue-collect-process');
-    Array.from(btns).forEach(btn => {
-        btn.addEventListener('click', async () => {
-            const connectID = btn.dataset.connectId;
-            const collectionID = btn.dataset.collectionId;
-            let query = `connectId=${parseInt(connectID)}`;
-            showAnimation();
-            const response = await findParticipant(query);
-            const data = response.data[0];
-            const specimenData = (await searchSpecimen(collectionID)).data;
-            hideAnimation();
-            tubeCollectedTemplate(data, specimenData);
-        });
-    })
 }
 
 export const populateCourierBox = async () => {

--- a/src/pages/specimen.js
+++ b/src/pages/specimen.js
@@ -1,5 +1,5 @@
 import { addEventBarCodeScanner, collectionSettings, generateBarCode, getWorflow, removeActiveClass, siteLocations, visitType } from "./../shared.js";
-import { addEventSpecimenLinkForm, addEventNavBarParticipantCheckIn, addEventBackToSearch, addEventCntdToCollectProcess } from "./../events.js";
+import { addEventSpecimenLinkForm, addEventNavBarParticipantCheckIn, addEventBackToSearch } from "./../events.js";
 import { masterSpecimenIDRequirement } from "../tubeValidation.js";
 
 export const specimenTemplate = async (data, formData, collections) => {
@@ -86,7 +86,6 @@ export const specimenTemplate = async (data, formData, collections) => {
     // addEventBarCodeScanner('scanSpecimenIDBarCodeBtn', 0, masterSpecimenIDRequirement.length);
     // if(document.getElementById('scanAccessionIDBarCodeBtn')) addEventBarCodeScanner('scanAccessionIDBarCodeBtn');
     generateBarCode('connectIdBarCode', data.Connect_ID);
-    addEventCntdToCollectProcess();
     addEventSpecimenLinkForm(formData);
     addEventBackToSearch('navBarSearch');
     addEventNavBarParticipantCheckIn();


### PR DESCRIPTION
* added logic to allow full scans for searching specimen and entering specimen link
* fixed bug where error text wasn't automatically popping up on specimen ID input fields
* removed unnecessary addEventCntdToCollectProcess() function from events.js
* removed references to addEventCntdToCollectProcess() function from specimen.js