### PR TITLE
[shpg] issue#418 - save issue for shipment tracking info

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -1,4 +1,4 @@
-import { performSearch, showAnimation, addBiospecimenUsers, hideAnimation, showNotifications, biospecimenUsers, removeBiospecimenUsers, findParticipant, errorMessage, removeAllErrors, storeSpecimen, searchSpecimen, generateBarCode, searchSpecimenInstitute, storeBox, getBoxes, ship, getLocationsInstitute, getBoxesByLocation, disableInput, allStates, removeBag, removeMissingSpecimen, getAllBoxes, getNextTempCheck, updateNewTempDate, getParticipantCollections, getSiteTubesLists, getWorflow, collectionSettings, getSiteCouriers, getPage, getNumPages, allTubesCollected, removeSingleError, siteContactInformation, updateParticipant, displayContactInformation, checkShipForage, matchingArrs} from './shared.js'
+import { performSearch, showAnimation, addBiospecimenUsers, hideAnimation, showNotifications, biospecimenUsers, removeBiospecimenUsers, findParticipant, errorMessage, removeAllErrors, storeSpecimen, searchSpecimen, generateBarCode, searchSpecimenInstitute, storeBox, getBoxes, ship, getLocationsInstitute, getBoxesByLocation, disableInput, allStates, removeBag, removeMissingSpecimen, getAllBoxes, getNextTempCheck, updateNewTempDate, getParticipantCollections, getSiteTubesLists, getWorflow, collectionSettings, getSiteCouriers, getPage, getNumPages, allTubesCollected, removeSingleError, siteContactInformation, updateParticipant, displayContactInformation, checkShipForage} from './shared.js'
 import { searchTemplate, searchBiospecimenTemplate } from './pages/dashboard.js';
 import { showReportsManifest, startReport } from './pages/reportsQuery.js';
 import { startShipping, boxManifest, shippingManifest, finalShipmentTracking, shipmentTracking } from './pages/shipping.js';
@@ -2631,7 +2631,6 @@ export const addEventCheckValidTrackInputs = (hiddenJSON) => {
         // remove invalid
         document.getElementById(box+"trackingId").classList.remove("invalid")
         document.getElementById(box+"trackingIdConfirm").classList.remove("invalid")
-        
         inputErrorMsg.textContent = ""
         inputConfirmErrorMsg.textContent = ""
       }
@@ -2766,9 +2765,7 @@ export const populateTrackingQuery = async (hiddenJSON) => {
     
 }
 
-// modify 
 export const addEventCompleteButton = (hiddenJSON, userName, tempChecked) => {
-
     document.getElementById('completeTracking').addEventListener('click', () => {
         let boxes = Object.keys(hiddenJSON).sort(compareBoxIds);
         let emptyField = false;
@@ -2886,7 +2883,6 @@ export const addEventSaveContinue = (hiddenJSON) => {
           shippingData.push({ "959708259": boxi, confirmTrackNum: boxiConfirm, "boxId":boxes[i]})
       }
       localforage.setItem("shipData",shippingData)
-      console.log("success")
 }
 
 export const addEventCompleteShippingButton = (hiddenJSON, userName, tempChecked, shipmentCourier) => {

--- a/src/events.js
+++ b/src/events.js
@@ -1,4 +1,4 @@
-import { performSearch, showAnimation, addBiospecimenUsers, hideAnimation, showNotifications, biospecimenUsers, removeBiospecimenUsers, findParticipant, errorMessage, removeAllErrors, storeSpecimen, searchSpecimen, generateBarCode, searchSpecimenInstitute, storeBox, getBoxes, ship, getLocationsInstitute, getBoxesByLocation, disableInput, allStates, removeBag, removeMissingSpecimen, getAllBoxes, getNextTempCheck, updateNewTempDate, getParticipantCollections, getSiteTubesLists, getWorflow, collectionSettings, getSiteCouriers, getPage, getNumPages, allTubesCollected, removeSingleError, siteContactInformation, updateParticipant, displayContactInformation, checkShipForage} from './shared.js'
+import { performSearch, showAnimation, addBiospecimenUsers, hideAnimation, showNotifications, biospecimenUsers, removeBiospecimenUsers, findParticipant, errorMessage, removeAllErrors, storeSpecimen, searchSpecimen, generateBarCode, searchSpecimenInstitute, storeBox, getBoxes, ship, getLocationsInstitute, getBoxesByLocation, disableInput, allStates, removeBag, removeMissingSpecimen, getAllBoxes, getNextTempCheck, updateNewTempDate, getParticipantCollections, getSiteTubesLists, getWorflow, collectionSettings, getSiteCouriers, getPage, getNumPages, allTubesCollected, removeSingleError, siteContactInformation, updateParticipant, displayContactInformation, checkShipForage, matchingArrs} from './shared.js'
 import { searchTemplate, searchBiospecimenTemplate } from './pages/dashboard.js';
 import { showReportsManifest, startReport } from './pages/reportsQuery.js';
 import { startShipping, boxManifest, shippingManifest, finalShipmentTracking, shipmentTracking } from './pages/shipping.js';
@@ -2560,13 +2560,13 @@ export const addEventTrimTrackingNums = () => {
   // Trim Function here
   boxTrackingIdEls.forEach(el => el.addEventListener("blur", e => {
     let inputTrack = e.target.value.trim()
-    if(inputTrack > 12) {
+    if(inputTrack.length > 12) {
       e.target.value = inputTrack.slice(-12)
     }
   }))
   boxTrackingIdConfirmEls.forEach(el => el.addEventListener("blur", e => {
     let inputTrackConfirm = e.target.value.trim()
-    if(inputTrackConfirm > 12) {
+    if(inputTrackConfirm.length > 12) {
       e.target.value = inputTrackConfirm.slice(-12)
     }
   }))
@@ -2765,7 +2765,9 @@ export const populateTrackingQuery = async (hiddenJSON) => {
     
 }
 
+// modify 
 export const addEventCompleteButton = (hiddenJSON, userName, tempChecked) => {
+  
     document.getElementById('completeTracking').addEventListener('click', () => {
         let boxes = Object.keys(hiddenJSON).sort(compareBoxIds);
         let emptyField = false;
@@ -2804,6 +2806,7 @@ export const addEventCompleteButton = (hiddenJSON, userName, tempChecked) => {
 
         if (emptyField == false) {
             document.getElementById('shippingHiddenTable').innerText = JSON.stringify(hiddenJSON);
+            addEventSaveContinue(hiddenJSON)
             let shipmentCourier = document.getElementById('courierSelect').value;
             finalShipmentTracking(hiddenJSON, userName, tempChecked, shipmentCourier);
         }
@@ -2850,6 +2853,39 @@ export const addEventSaveButton = async (hiddenJSON) => {
           timer: 1600,
         })
     })
+}
+
+export const addEventSaveContinue = (hiddenJSON) => {
+      let boxes = Object.keys(hiddenJSON).sort(compareBoxIds);
+      for (let i = 0; i < boxes.length; i++) {
+          let boxi = document.getElementById(boxes[i] + "trackingId").value.toUpperCase();
+          let boxiConfirm = document.getElementById(boxes[i] + "trackingIdConfirm").value.toUpperCase();
+          // if '959708259' exists update tracking number
+          if (hiddenJSON[boxes[i]].hasOwnProperty('959708259')) {
+            hiddenJSON[boxes[i]]['959708259'] = boxi
+          }
+          // if 'confirmTrackNum' exists update tracking number
+          if (hiddenJSON[boxes[i]].hasOwnProperty('confirmTrackNum')) {
+            hiddenJSON[boxes[i]]['confirmTrackNum'] = boxiConfirm 
+          }
+          // if specimens exists update, else add following key/values
+          if (hiddenJSON[boxes[i]].hasOwnProperty('specimens')) {
+            hiddenJSON[boxes[i]]['specimens'] = hiddenJSON[boxes[i]]['specimens'] 
+          } 
+          else {
+            hiddenJSON[boxes[i]] = { '959708259': boxi, confirmTrackNum: boxiConfirm, specimens: hiddenJSON[boxes[i]] }
+          }  
+      }
+      
+      let shippingData = []
+
+      for(let i = 0; i < boxes.length; i++){
+        let boxi = document.getElementById(boxes[i] + "trackingId").value.toUpperCase();
+        let boxiConfirm = document.getElementById(boxes[i] + "trackingIdConfirm").value.toUpperCase();
+          shippingData.push({ "959708259": boxi, confirmTrackNum: boxiConfirm, "boxId":boxes[i]})
+      }
+      localforage.setItem("shipData",shippingData)
+      console.log("success")
 }
 
 export const addEventCompleteShippingButton = (hiddenJSON, userName, tempChecked, shipmentCourier) => {

--- a/src/events.js
+++ b/src/events.js
@@ -2558,13 +2558,13 @@ export const addEventTrimTrackingNums = () => {
   let boxTrackingIdEls = Array.from(document.getElementsByClassName("boxTrackingId"))
   let boxTrackingIdConfirmEls = Array.from(document.getElementsByClassName("boxTrackingIdConfirm"))
   // Trim Function here
-  boxTrackingIdEls.forEach(el => el.addEventListener("blur", e => {
+  boxTrackingIdEls.forEach(el => el.addEventListener("input", e => {
     let inputTrack = e.target.value.trim()
     if(inputTrack.length > 12) {
       e.target.value = inputTrack.slice(-12)
     }
   }))
-  boxTrackingIdConfirmEls.forEach(el => el.addEventListener("blur", e => {
+  boxTrackingIdConfirmEls.forEach(el => el.addEventListener("input", e => {
     let inputTrackConfirm = e.target.value.trim()
     if(inputTrackConfirm.length > 12) {
       e.target.value = inputTrackConfirm.slice(-12)
@@ -2597,7 +2597,7 @@ export const addEventCheckValidTrackInputs = (hiddenJSON) => {
   })
 
   boxes.forEach(box => {
-    document.getElementById(box+"trackingId").addEventListener("blur", e => {
+    document.getElementById(box+"trackingId").addEventListener("input", e => {
       let input = document.getElementById(box+"trackingId").value.trim()
       let inputConfirm = document.getElementById(box+"trackingIdConfirm").value.trim()
       let inputErrorMsg = document.getElementById(box+"trackingIdErrorMsg")
@@ -2616,7 +2616,7 @@ export const addEventCheckValidTrackInputs = (hiddenJSON) => {
         inputConfirmErrorMsg.textContent = ""
       }
     })
-    document.getElementById(box+"trackingIdConfirm").addEventListener("blur",e => {
+    document.getElementById(box+"trackingIdConfirm").addEventListener("input",e => {
       let input = document.getElementById(box+"trackingId").value.trim()
       let inputConfirm = document.getElementById(box+"trackingIdConfirm").value.trim()
       let inputErrorMsg = document.getElementById(box+"trackingIdErrorMsg")
@@ -2631,6 +2631,7 @@ export const addEventCheckValidTrackInputs = (hiddenJSON) => {
         // remove invalid
         document.getElementById(box+"trackingId").classList.remove("invalid")
         document.getElementById(box+"trackingIdConfirm").classList.remove("invalid")
+        
         inputErrorMsg.textContent = ""
         inputConfirmErrorMsg.textContent = ""
       }
@@ -2741,16 +2742,16 @@ export const populateTrackingQuery = async (hiddenJSON) => {
         toBeInnerHTML +=`
         <div class = "row" style="justify-content:space-around">
                             <div class="form-group" style="margin-top:30px; width:380px;">
-                                <label style="float:left;margin-top:5px">`+'Enter / Scan Shipping Tracking Number for ' + boxes[i] + `</label>
+                                <label style="float:left;margin-top:5px">`+'Enter / Scan Shipping Tracking Number for ' + `<span style="font-weight:600;display:block;">${boxes[i]}</span>` + `</label>
                                 <br>
                                 <div style="float:left;">
-                                    <input class="form-control boxTrackingId" type="text" id="` + boxes[i] + 'trackingId' + `" placeholder="Enter/Scan Tracking Number" value="${trackNum ?? ""}" data-toggle="tooltip" data-placement="top" title="Scan or manually type to the tracking number" autocomplete="off"/>
+                                    <input class="form-control boxTrackingId" type="text" id="` + boxes[i] + 'trackingId' + `" placeholder="Enter/Scan Tracking Number" value="${trackNum ?? ""}" data-toggle="tooltip" data-placement="top" title="Scan or manually type tracking number" autocomplete="off"/>
                                     <p style="font-size:.8rem; margin-top:.5rem;">Ex. 457424072905</p>
                                     <p id="${boxes[i]}trackingIdErrorMsg" class="text-danger"></p>
                                 </div>
                             </div>
                             <div class="form-group" style="margin-top:30px; width:380px;">
-                                <label style="float:left;margin-top:5px">`+'Confirm Shipping Tracking Number for '+ boxes[i] + `</label>
+                                <label style="float:left;margin-top:5px">`+'Confirm Shipping Tracking Number for '+ `<span style="font-weight:600;display:block;">${boxes[i]}</span>` + `</label>
                                 <br>
                                 <div style="float:left;">
                                     <input class="form-control boxTrackingIdConfirm" type="text" id="` + boxes[i] + 'trackingIdConfirm' + `" placeholder="Enter/Scan Tracking Number" value="${trackNumConfirm ?? ""}" data-toggle="tooltip" data-placement="top" title="Scan or manually type to confirm the correct tracking number" autocomplete="off"/>
@@ -2767,7 +2768,7 @@ export const populateTrackingQuery = async (hiddenJSON) => {
 
 // modify 
 export const addEventCompleteButton = (hiddenJSON, userName, tempChecked) => {
-  
+
     document.getElementById('completeTracking').addEventListener('click', () => {
         let boxes = Object.keys(hiddenJSON).sort(compareBoxIds);
         let emptyField = false;

--- a/src/pages/shipping.js
+++ b/src/pages/shipping.js
@@ -1,5 +1,5 @@
 import { userAuthorization, removeActiveClass, addEventBarCodeScanner, storeBox, getBoxes, getAllBoxes, getBoxesByLocation, hideAnimation, showAnimation, showNotifications, getPage, siteContactInformation} from "./../shared.js"
-import { addEventSearchForm1, addEventBackToSearch, addEventSearchForm2, addEventSearchForm3, addEventSearchForm4, addEventSelectParticipantForm, addEventAddSpecimenToBox, addEventNavBarSpecimenSearch, populateSpecimensList, addEventNavBarShipment, addEventNavBarBoxManifest, populateBoxManifestTable, populateBoxManifestHeader, populateSaveTable, populateShippingManifestBody,populateShippingManifestHeader, addEventNavBarShippingManifest, populateTrackingQuery, addEventCompleteButton, populateFinalCheck, populateBoxSelectList, addEventBoxSelectListChanged, populateModalSelect, addEventCompleteShippingButton, populateSelectLocationList, addEventChangeLocationSelect, addEventModalAddBox, populateTempNotification, populateTempCheck, populateTempSelect, addEventNavBarTracking, addEventReturnToShippingManifest, populateCourierBox, addEventSaveButton, addEventTrimTrackingNums, addEventCheckValidTrackInputs, addEventPreventTrackNumPaste} from "./../events.js";
+import { addEventSearchForm1, addEventBackToSearch, addEventSearchForm2, addEventSearchForm3, addEventSearchForm4, addEventSelectParticipantForm, addEventAddSpecimenToBox, addEventNavBarSpecimenSearch, populateSpecimensList, addEventNavBarShipment, addEventNavBarBoxManifest, populateBoxManifestTable, populateBoxManifestHeader, populateSaveTable, populateShippingManifestBody,populateShippingManifestHeader, addEventNavBarShippingManifest, populateTrackingQuery, addEventCompleteButton, populateFinalCheck, populateBoxSelectList, addEventBoxSelectListChanged, populateModalSelect, addEventCompleteShippingButton, populateSelectLocationList, addEventChangeLocationSelect, addEventModalAddBox, populateTempNotification, populateTempCheck, populateTempSelect, addEventNavBarTracking, addEventReturnToShippingManifest, populateCourierBox, addEventSaveButton, addEventTrimTrackingNums, addEventCheckValidTrackInputs, addEventPreventTrackNumPaste, addEventSaveContinue} from "./../events.js";
 import { homeNavBar, bodyNavBar, shippingNavBar} from '../navbar.js';
 
 const conversion = {
@@ -527,10 +527,10 @@ export const shipmentTracking = async (hiddenJSON, userName, tempCheckChecked) =
     addEventReturnToShippingManifest('navBarShippingManifest', hiddenJSON, userName, tempCheckChecked)
     await populateTrackingQuery(hiddenJSON);
     addEventTrimTrackingNums()
-    addEventPreventTrackNumPaste()
+    // addEventPreventTrackNumPaste()
     addEventCheckValidTrackInputs(hiddenJSON)
-    addEventCompleteButton(hiddenJSON, userName, tempCheckChecked);
     addEventSaveButton(hiddenJSON);
+    addEventCompleteButton(hiddenJSON, userName, tempCheckChecked);
     //addEventCompleteShippingButton(hiddenJSON);
     //addEventBackToSearch('navBarShippingDash');
     // addEventBarCodeScanner('masterSpecimenIdBarCodeBtn', 0, 9, 0);

--- a/src/pages/shipping.js
+++ b/src/pages/shipping.js
@@ -501,7 +501,7 @@ export const shipmentTracking = async (hiddenJSON, userName, tempCheckChecked) =
             </div>
             <div style="float:left;width: 33%;" id="boxManifestCol3">
                 <button type="button" class="btn btn-primary" data-dismiss="modal" id="saveTracking" style="margin-right:.5rem;">Save</button>
-                <button type="button" class="btn btn-primary" data-dismiss="modal" id="completeTracking">Continue</button>
+                <button type="button" class="btn btn-primary" data-dismiss="modal" id="completeTracking">Save and Continue</button>
             </div>
         </div>
 

--- a/src/pages/shipping.js
+++ b/src/pages/shipping.js
@@ -527,7 +527,7 @@ export const shipmentTracking = async (hiddenJSON, userName, tempCheckChecked) =
     addEventReturnToShippingManifest('navBarShippingManifest', hiddenJSON, userName, tempCheckChecked)
     await populateTrackingQuery(hiddenJSON);
     addEventTrimTrackingNums()
-    // addEventPreventTrackNumPaste()
+    addEventPreventTrackNumPaste()
     addEventCheckValidTrackInputs(hiddenJSON)
     addEventSaveButton(hiddenJSON);
     addEventCompleteButton(hiddenJSON, userName, tempCheckChecked);

--- a/src/shared.js
+++ b/src/shared.js
@@ -1124,3 +1124,18 @@ export const checkShipForage = async (shipSetForage, boxesToShip) => {
       await localforage.setItem("shipData", shipSetForage)
   }
 }
+
+export const matchingArrs = (arr1,arr2) => {
+    // match length of arrays 
+    if(arr1.length !== arr2.length) {
+      return false
+    }
+    // loop through each array and see if index matches
+    for(let i = 0; i < arr1.length; i++) {
+      if(arr1[i] !== arr2[i]) {
+        console.log(arr1[i],arr2[i])
+        return false
+      }
+    }
+    return true
+}

--- a/src/shared.js
+++ b/src/shared.js
@@ -1124,18 +1124,3 @@ export const checkShipForage = async (shipSetForage, boxesToShip) => {
       await localforage.setItem("shipData", shipSetForage)
   }
 }
-
-export const matchingArrs = (arr1,arr2) => {
-    // match length of arrays 
-    if(arr1.length !== arr2.length) {
-      return false
-    }
-    // loop through each array and see if index matches
-    for(let i = 0; i < arr1.length; i++) {
-      if(arr1[i] !== arr2[i]) {
-        console.log(arr1[i],arr2[i])
-        return false
-      }
-    }
-    return true
-}


### PR DESCRIPTION
[issue#418](https://github.com/episphere/connect/issues/418)

Change blur to input event listeners
Add length logic to input comparisons
Add save localforage feature to Save and Continue Button
Style Box Id labels with bolder text and display block properties for alignment

Save Functionality Explained:

Saved Data is Reset when:

1) Box Id is finalized at last step of Summary and Review
2) Box Id is saved during Assign Tracking Information but user goes back to Packaging Step and chooses a Box Id or Group of Box Ids that do not include the previous Box Id

Ex. User selects Box1 from Packaging. User enters Box1's tracking number and presses save or save and continue. User goes back to Packaging and selects Box2 and Box3. User makes it to Assign Tracking Information with Box2 and Box3. The previous Box1 data that persisted will be gone. User selects Box1 again and goes to Assign Tracking Information. The previously entered data will be gone.