### PR TITLE
handling empty visit concept

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -1840,7 +1840,12 @@ export const addEventCheckInCompleteForm = (isCheckedIn) => {
                 },
             });
 
-            if (confirmVal === "confirmed") specimenTemplate(data);
+            if (confirmVal === "confirmed") {
+                const updatedResponse = await findParticipant(query);
+                const updatedData = updatedResponse.data[0];
+
+                specimenTemplate(updatedData);
+            }
         }
     });
 };

--- a/src/shared.js
+++ b/src/shared.js
@@ -1058,7 +1058,7 @@ export const checkInParticipant = async (data, visitConcept) => {
     else {
 
         visits = {
-            visitConcept: {
+            [visitConcept]: {
                 '135591601': 353358909,
                 '840048338': new Date()
             }


### PR DESCRIPTION
* getting updated "data" after posting visit concept after first check-in
* fixed bug where "visitConcept" was getting posted to backend instead of visit concept