### PR TITLE
[shpg] issue#474 - change button wording on shipping manifest screen 

### DIFF
--- a/src/pages/shipping.js
+++ b/src/pages/shipping.js
@@ -389,7 +389,7 @@ export const shippingManifest = async (boxesToShip, userName, tempMonitorThere) 
                 <button type="button" class="btn btn-primary" data-dismiss="modal" id="returnToPackaging">Return to Packaging</button>
             </div>
             <div style="float: left;width: 33%;">
-                <button type="button" class="btn btn-primary print-manifest" data-dismiss="modal" id="printBox">Print Full Manifest</button>
+                <button type="button" class="btn btn-primary print-manifest" data-dismiss="modal" id="printBox">Optional: Print Shipment Manifest</button>
             </div>
             <div style="float:left;width: 33%;" id="boxManifestCol3">
                 <button type="button" class="btn btn-primary" data-dismiss="modal" id="completePackaging">Continue to Assign Tracking Number</button>


### PR DESCRIPTION
(https://github.com/episphere/connect/issues/474)

- rename "Print Full Manifest" button to "Optional: Print Shipment Manifest"