### PR TITLE
[shpg] issue#475 - change error messages on the assign tracking number screen

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -1,4 +1,4 @@
-import { performSearch, showAnimation, addBiospecimenUsers, hideAnimation, showNotifications, biospecimenUsers, removeBiospecimenUsers, findParticipant, errorMessage, removeAllErrors, storeSpecimen, searchSpecimen, generateBarCode, searchSpecimenInstitute, storeBox, getBoxes, ship, getLocationsInstitute, getBoxesByLocation, disableInput, allStates, removeBag, removeMissingSpecimen, getAllBoxes, getNextTempCheck, updateNewTempDate, getParticipantCollections, getSiteTubesLists, getWorflow, collectionSettings, getSiteCouriers, getPage, getNumPages, allTubesCollected, removeSingleError, siteContactInformation, updateParticipant, displayContactInformation, checkShipForage, checkAlertState, sortBiospecimensList, convertTime, convertNumsToCondition, checkFedexShipDuplicate, shippingDuplicateMessage, checkInParticipant, checkOutParticipant, getCheckedInVisit, shippingPrintManifestReminder} from './shared.js'
+import { performSearch, showAnimation, addBiospecimenUsers, hideAnimation, showNotifications, biospecimenUsers, removeBiospecimenUsers, findParticipant, errorMessage, removeAllErrors, storeSpecimen, searchSpecimen, generateBarCode, searchSpecimenInstitute, storeBox, getBoxes, ship, getLocationsInstitute, getBoxesByLocation, disableInput, allStates, removeBag, removeMissingSpecimen, getAllBoxes, getNextTempCheck, updateNewTempDate, getParticipantCollections, getSiteTubesLists, getWorflow, collectionSettings, getSiteCouriers, getPage, getNumPages, allTubesCollected, removeSingleError, siteContactInformation, updateParticipant, displayContactInformation, checkShipForage, checkAlertState, sortBiospecimensList, convertTime, convertNumsToCondition, checkFedexShipDuplicate, shippingDuplicateMessage, checkInParticipant, checkOutParticipant, getCheckedInVisit, shippingPrintManifestReminder, checkNonAlphanumericStr, shippingNonAlphaNumericStrMessage} from './shared.js'
 import { searchTemplate, searchBiospecimenTemplate } from './pages/dashboard.js';
 import { showReportsManifest, startReport } from './pages/reportsQuery.js';
 import { startShipping, boxManifest, shippingManifest, finalShipmentTracking, shipmentTracking } from './pages/shipping.js';
@@ -2868,6 +2868,11 @@ export const addEventCompleteButton = (hiddenJSON, userName, tempChecked) => {
         if(checkFedexShipDuplicate(boxes) && boxes.length > 1){
           shippingDuplicateMessage()
           return
+        }
+
+        if(checkNonAlphanumericStr(boxes)) {
+          shippingNonAlphaNumericStrMessage()
+          return 
         }
 
         if (emptyField == false) {

--- a/src/events.js
+++ b/src/events.js
@@ -2596,11 +2596,12 @@ export const addEventNavBarTracking = (element, userName, hiddenJSON, tempChecke
 export const addEventTrimTrackingNums = () => {
   let boxTrackingIdEls = Array.from(document.getElementsByClassName("boxTrackingId"))
   let boxTrackingIdConfirmEls = Array.from(document.getElementsByClassName("boxTrackingIdConfirm"))
+  const alphaNumericRegExp = /[^a-zA-Z0-9]/gm;
   // Trim Function here
   boxTrackingIdEls.forEach(el => el.addEventListener("input", e => {
     let inputTrack = e.target.value.trim()
     if(inputTrack.length >= 0) {
-      e.target.value = inputTrack.replace(/\s/g, '')
+      e.target.value = inputTrack.replace(alphaNumericRegExp, '')
     }
     if(inputTrack.length > 12) {
       e.target.value = inputTrack.slice(-12)
@@ -2608,8 +2609,8 @@ export const addEventTrimTrackingNums = () => {
   }))
   boxTrackingIdConfirmEls.forEach(el => el.addEventListener("input", e => {
     let inputTrackConfirm = e.target.value.trim()
-    if(inputTrackConfirm.length >=  0) {
-      e.target.value = inputTrackConfirm.replace(/\s/g, '')
+    if(inputTrackConfirm.length >= 0) {
+      e.target.value = inputTrackConfirm.replace(alphaNumericRegExp, '')
     }
     if(inputTrackConfirm.length > 12) {
       e.target.value = inputTrackConfirm.slice(-12)
@@ -2617,7 +2618,7 @@ export const addEventTrimTrackingNums = () => {
   }))
 }
 
-export const addEventPreventTrackNumPaste = () => {
+export const addEventPreventTrackingConfirmPaste = () => {
   let boxTrackingIdConfirmEls = Array.from(document.getElementsByClassName("boxTrackingIdConfirm"));
   boxTrackingIdConfirmEls.forEach(el => {
     el.addEventListener("paste", e => e.preventDefault())

--- a/src/events.js
+++ b/src/events.js
@@ -2627,184 +2627,75 @@ export const addEventPreventTrackNumPaste = () => {
 export const addEventCheckValidTrackInputs = (hiddenJSON) => {
 
   let boxes = Object.keys(hiddenJSON).sort(compareBoxIds);
-
-  // Check on page load 
-
-  // boxes.forEach(box => {
-  //   let input = document.getElementById(box+"trackingId").value.trim()
-  //   let inputConfirm = document.getElementById(box+"trackingIdConfirm").value.trim()
-  //   let inputErrorMsg = document.getElementById(box+"trackingIdErrorMsg")
-  //   let inputConfirmErrorMsg = document.getElementById(box+"trackingIdConfirmErrorMsg")
-  //   if(input.length > 0 && input.length < 12) {
-  //     document.getElementById(box+"trackingId").classList.add("invalid")
-  //     inputErrorMsg.textContent = `Please input a 12 digit tracking number`
-  //   }
-  //   if(inputConfirm.length > 0 && inputConfirm.length < 12) {
-  //     document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
-  //     inputConfirmErrorMsg.textContent = `Please input a 12 digit tracking number`
-  //   }
-  //   if(input !== inputConfirm && input.length > 0 && input.length < 12 && inputConfirm.length > 0 && inputConfirm.length < 12) {
-  //     document.getElementById(box+"trackingId").classList.add("invalid")
-  //     document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
-  //     inputErrorMsg.textContent = `Please match ${box} confirm input and input a 12 digit tracking number` 
-  //     inputConfirmErrorMsg.textContent = `Please match ${box} start input and input a 12 digit tracking number` 
-  //   }
-  //   else if(input !== inputConfirm) {
-  //     document.getElementById(box+"trackingId").classList.add("invalid")
-  //     document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
-  //     inputConfirmErrorMsg.textContent = "Please match " + box + " start input"
-  //     inputErrorMsg.textContent = "Please match " + box + " confirm input"
-  //   }
-  // })
-      
-  // boxes.forEach(box => {
-  //   document.getElementById(box+"trackingId").addEventListener("input", e => {
-  //     let input = document.getElementById(box+"trackingId").value.trim()
-  //     let inputConfirm = document.getElementById(box+"trackingIdConfirm").value.trim()
-  //     let inputErrorMsg = document.getElementById(box+"trackingIdErrorMsg")
-  //     let inputConfirmErrorMsg = document.getElementById(box+"trackingIdConfirmErrorMsg")
-
-      
-  //     if(input.length < 12 && input !== inputConfirm) {
-  //       document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
-  //       inputErrorMsg.textContent = `Please match ${box} confirm input and input a 12 digit tracking number` 
-  //     }
-  //     else if(input.length < 12) {
-  //       document.getElementById(box+"trackingId").classList.add("invalid")
-  //       inputErrorMsg.textContent = `Please input a 12 digit tracking number`
-  //     }
-  //     else if(input !== inputConfirm && input !== "" && inputConfirm !== "") {
-  //       // add invalid red border
-  //       document.getElementById(box+"trackingId").classList.add("invalid")
-  //       document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
-  //       inputConfirmErrorMsg.textContent = "Please match " + box + " start input"
-  //       inputErrorMsg.textContent = "Please match " + box + " confirm input"
-  //     } 
-  //     else if (input === inputConfirm && input.length >= 12) {
-  //       // remove invalid
-  //       document.getElementById(box+"trackingId").classList.remove("invalid")
-  //       document.getElementById(box+"trackingIdConfirm").classList.remove("invalid")
-  //       inputErrorMsg.textContent = ""
-  //       inputConfirmErrorMsg.textContent = ""
-  //     }
-  //   })
-
-    // document.getElementById(box+"trackingIdConfirm").addEventListener("input",e => {
-    //   let input = document.getElementById(box+"trackingId").value.trim()
-    //   let inputConfirm = document.getElementById(box+"trackingIdConfirm").value.trim()
-    //   let inputErrorMsg = document.getElementById(box+"trackingIdErrorMsg")
-    //   let inputConfirmErrorMsg = document.getElementById(box+"trackingIdConfirmErrorMsg")
-
-    //   if(inputConfirm.length < 12 && inputConfirm !== input) {
-    //     document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
-    //     inputConfirmErrorMsg.textContent = `Please match ${box} start input and input a 12 digit tracking number` 
-    //   }
-    //   else if(inputConfirm.length < 12){
-    //     document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
-    //     inputConfirmErrorMsg.textContent = "Please input a 12 digit tracking number"
-    //   }
-    //   else if(input !== inputConfirm && input !== "" && inputConfirm !== "") {
-    //     // add invalid red border
-    //     document.getElementById(box+"trackingId").classList.add("invalid")
-    //     document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
-    //     inputConfirmErrorMsg.textContent = "Please match " + box + " start input"
-    //     inputErrorMsg.textContent = "Please match " + box + " confirm input"
-    //   } else if (input === inputConfirm && inputConfirm.length >= 12) {
-    //     // remove invalid
-    //     document.getElementById(box+"trackingId").classList.remove("invalid")
-    //     document.getElementById(box+"trackingIdConfirm").classList.remove("invalid")
-    //     inputErrorMsg.textContent = ""
-    //     inputConfirmErrorMsg.textContent = ""
-    //   }
-    // })
-  // })
-
-  /* 
-  Steps Check - ON LOAD 
-  Check if input is 12 digits - ???
-  Check if input confirm matches input - ???
-  */
+  /* Check Tracking Numbers - ON SCREEN LOAD */
   boxes.forEach(box => {
     let input = document.getElementById(box+"trackingId").value.trim()
     let inputConfirm = document.getElementById(box+"trackingIdConfirm").value.trim()
     let inputErrorMsg = document.getElementById(box+"trackingIdErrorMsg")
     let inputConfirmErrorMsg = document.getElementById(box+"trackingIdConfirmErrorMsg")
     if(input.length !== 0 && input.length < 12) {
-      console.log("input field does not equal 12")
       document.getElementById(box+"trackingId").classList.add("invalid")
       inputErrorMsg.textContent = `Tracking number must be 12 digits`
     }
     if(inputConfirm !== input ) {
-      console.log(`inputConfirm does not match input`)
       document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
       inputConfirmErrorMsg.textContent = `Tracking numbers must match`
     }
   })
-
+  /* Check Tracking Numbers - User Input */
   boxes.forEach(box => {
-    // let input = document.getElementById(box+"trackingId").value.trim()
-    // let inputConfirm = document.getElementById(box+"trackingIdConfirm").value.trim()
-    // let inputTest = document.getElementById(box+"trackingId").value
-    // let inputConfirmTest = document.getElementById(box+"trackingIdConfirm").value
-    // let inputErrorMsg = document.getElementById(box+"trackingIdErrorMsg")
-    // let inputConfirmErrorMsg = document.getElementById(box+"trackingIdConfirmErrorMsg")
-
-    //     document.getElementById(box+"trackingId").classList.remove("invalid")
-    //     document.getElementById(box+"trackingIdConfirm").classList.remove("invalid")
-
     // box tracking id 
-    // input must equal 12 characters
     document.getElementById(box+"trackingId").addEventListener("input", e => {
         let input = document.getElementById(box+"trackingId").value.trim()
         let inputConfirm = document.getElementById(box+"trackingIdConfirm").value.trim()
-        let inputTest = document.getElementById(box+"trackingId").value
-        let inputConfirmTest = document.getElementById(box+"trackingIdConfirm").value
         let inputErrorMsg = document.getElementById(box+"trackingIdErrorMsg") 
         let inputConfirmErrorMsg = document.getElementById(box+"trackingIdConfirmErrorMsg")
-        console.log(`input trim val: ${input}, input no trim val: ${inputTest}`)
-        console.log(`input confirm trim val: ${inputConfirm}, input confirm no trim val: ${inputConfirmTest}`)
-      if(input.length  === 12) {
-        console.log("tracking id input is 12 characters")
+
+      if(input.length === 12) {
           inputErrorMsg.textContent = ``
           document.getElementById(box+"trackingId").classList.remove("invalid")
-          
+
           if (input === inputConfirm) { 
-              console.log(`input and inputConfirm match!`)
-              console.log("Value:" + inputConfirmErrorMsg)
-              inputConfirmErrorMsg.textContent = ``
-              document.getElementById(box+"trackingIdConfirm").classList.remove("invalid")
+            inputConfirmErrorMsg.textContent = ``
+            document.getElementById(box+"trackingIdConfirm").classList.remove("invalid")
           }
           else {
             inputConfirmErrorMsg.textContent = `Tracking numbers must match`
+            document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
           }
       }
-      else {
-        console.log("tracking id input length does not equal 12 characters")
+      else if (input.length < 12 && input === inputConfirm) { 
+        inputConfirmErrorMsg.textContent = ``
+        document.getElementById(box+"trackingIdConfirm").classList.remove("invalid")
         inputErrorMsg.textContent = `Tracking number must be 12 digits`
+        document.getElementById(box+"trackingId").classList.add("invalid")
+      }
+      else if(input.length < 12 && input !== inputConfirm) {
+        inputErrorMsg.textContent = `Tracking number must be 12 digits`
+        document.getElementById(box+"trackingId").classList.add("invalid")
+        inputConfirmErrorMsg.textContent = `Tracking numbers must match`
+        document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
+      }
+      else {
+        inputErrorMsg.textContent = `Tracking number must be 12 digits`
+        document.getElementById(box+"trackingId").classList.add("invalid")
       }
     })
     // box tracking id confirm
-    // trackingid input confirm must equal tackingid input 
-      document.getElementById(box + "trackingIdConfirm").addEventListener("input", e => {
-        let input = document.getElementById(box+"trackingId").value.trim()
-        let inputConfirm = document.getElementById(box+"trackingIdConfirm").value.trim()
-        let inputTest = document.getElementById(box+"trackingId").value
-        let inputConfirmTest = document.getElementById(box+"trackingIdConfirm").value
-        let inputErrorMsg = document.getElementById(box+"trackingIdErrorMsg")
-        let inputConfirmErrorMsg = document.getElementById(box+"trackingIdConfirmErrorMsg")
-        console.log(`input trim val: ${input}, input no trim val: ${inputTest}`)
-        console.log(`input confirm trim val: ${inputConfirm}, input confirm no trim val: ${inputConfirmTest}`)
+    document.getElementById(box + "trackingIdConfirm").addEventListener("input", e => {
+      let input = document.getElementById(box+"trackingId").value.trim()
+      let inputConfirm = document.getElementById(box+"trackingIdConfirm").value.trim()
+      let inputConfirmErrorMsg = document.getElementById(box+"trackingIdConfirmErrorMsg")
+      
       if(inputConfirm === input) {
-        console.log("Input trackingid confirm MATCHES trackingid")
           inputConfirmErrorMsg.textContent = ``
           document.getElementById(box+"trackingIdConfirm").classList.remove("invalid")
       }
       else {
-        console.log("Input trackingid confirm DOES NOT MATCH trackingid")
+        document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
         inputConfirmErrorMsg.textContent = `Tracking numbers must match`
       }
     })
-
   })
 }
 

--- a/src/events.js
+++ b/src/events.js
@@ -2720,7 +2720,7 @@ export const addEventCheckValidTrackInputs = (hiddenJSON) => {
   // })
 
   /* 
-  Steps Check - On Load
+  Steps Check - ON LOAD 
   Check if input is 12 digits - ???
   Check if input confirm matches input - ???
   */
@@ -2729,8 +2729,7 @@ export const addEventCheckValidTrackInputs = (hiddenJSON) => {
     let inputConfirm = document.getElementById(box+"trackingIdConfirm").value.trim()
     let inputErrorMsg = document.getElementById(box+"trackingIdErrorMsg")
     let inputConfirmErrorMsg = document.getElementById(box+"trackingIdConfirmErrorMsg")
-
-    if(input.length == 0 && input.length < 12) {
+    if(input.length !== 0 && input.length < 12) {
       console.log("input field does not equal 12")
       document.getElementById(box+"trackingId").classList.add("invalid")
       inputErrorMsg.textContent = `Tracking number must be 12 digits`
@@ -2743,34 +2742,66 @@ export const addEventCheckValidTrackInputs = (hiddenJSON) => {
   })
 
   boxes.forEach(box => {
-    let input = document.getElementById(box+"trackingId").value.trim()
-    let inputConfirm = document.getElementById(box+"trackingIdConfirm").value.trim()
-    let inputTest = document.getElementById(box+"trackingId").value
-    let inputConfirmTest = document.getElementById(box+"trackingIdConfirm").value
-    let inputErrorMsg = document.getElementById(box+"trackingIdErrorMsg")
-    let inputConfirmErrorMsg = document.getElementById(box+"trackingIdConfirmErrorMsg")
+    // let input = document.getElementById(box+"trackingId").value.trim()
+    // let inputConfirm = document.getElementById(box+"trackingIdConfirm").value.trim()
+    // let inputTest = document.getElementById(box+"trackingId").value
+    // let inputConfirmTest = document.getElementById(box+"trackingIdConfirm").value
+    // let inputErrorMsg = document.getElementById(box+"trackingIdErrorMsg")
+    // let inputConfirmErrorMsg = document.getElementById(box+"trackingIdConfirmErrorMsg")
 
-    console.log(`input trim val: ${input}, input no trim val: ${inputTest}`)
-    console.log(`input confirm trim val: ${inputConfirm}, input confirm no trim val: ${inputConfirmTest}`)
+    //     document.getElementById(box+"trackingId").classList.remove("invalid")
+    //     document.getElementById(box+"trackingIdConfirm").classList.remove("invalid")
 
     // box tracking id 
     // input must equal 12 characters
     document.getElementById(box+"trackingId").addEventListener("input", e => {
+        let input = document.getElementById(box+"trackingId").value.trim()
+        let inputConfirm = document.getElementById(box+"trackingIdConfirm").value.trim()
+        let inputTest = document.getElementById(box+"trackingId").value
+        let inputConfirmTest = document.getElementById(box+"trackingIdConfirm").value
+        let inputErrorMsg = document.getElementById(box+"trackingIdErrorMsg") 
+        let inputConfirmErrorMsg = document.getElementById(box+"trackingIdConfirmErrorMsg")
+        console.log(`input trim val: ${input}, input no trim val: ${inputTest}`)
+        console.log(`input confirm trim val: ${inputConfirm}, input confirm no trim val: ${inputConfirmTest}`)
       if(input.length  === 12) {
         console.log("tracking id input is 12 characters")
+          inputErrorMsg.textContent = ``
+          document.getElementById(box+"trackingId").classList.remove("invalid")
+          
+          if (input === inputConfirm) { 
+              console.log(`input and inputConfirm match!`)
+              console.log("Value:" + inputConfirmErrorMsg)
+              inputConfirmErrorMsg.textContent = ``
+              document.getElementById(box+"trackingIdConfirm").classList.remove("invalid")
+          }
+          else {
+            inputConfirmErrorMsg.textContent = `Tracking numbers must match`
+          }
       }
       else {
         console.log("tracking id input length does not equal 12 characters")
+        inputErrorMsg.textContent = `Tracking number must be 12 digits`
       }
     })
     // box tracking id confirm
     // trackingid input confirm must equal tackingid input 
-    document.getElementById(box+"trackingIdConfirm").addEventListener("input", e => {
+      document.getElementById(box + "trackingIdConfirm").addEventListener("input", e => {
+        let input = document.getElementById(box+"trackingId").value.trim()
+        let inputConfirm = document.getElementById(box+"trackingIdConfirm").value.trim()
+        let inputTest = document.getElementById(box+"trackingId").value
+        let inputConfirmTest = document.getElementById(box+"trackingIdConfirm").value
+        let inputErrorMsg = document.getElementById(box+"trackingIdErrorMsg")
+        let inputConfirmErrorMsg = document.getElementById(box+"trackingIdConfirmErrorMsg")
+        console.log(`input trim val: ${input}, input no trim val: ${inputTest}`)
+        console.log(`input confirm trim val: ${inputConfirm}, input confirm no trim val: ${inputConfirmTest}`)
       if(inputConfirm === input) {
         console.log("Input trackingid confirm MATCHES trackingid")
+          inputConfirmErrorMsg.textContent = ``
+          document.getElementById(box+"trackingIdConfirm").classList.remove("invalid")
       }
       else {
-        console.oog("Input trackingid confirm DOES NOT MATCH trackingid")
+        console.log("Input trackingid confirm DOES NOT MATCH trackingid")
+        inputConfirmErrorMsg.textContent = `Tracking numbers must match`
       }
     })
 

--- a/src/events.js
+++ b/src/events.js
@@ -527,7 +527,7 @@ export const addEventAddSpecimensToListModalButton = (bagid, tableIndex, isOrpha
         let boxIds = Object.keys(hiddenJSON).sort(compareBoxIds);
 
         for (let i = 0; i < boxIds.length; i++) {
-            let currTime = new Date();
+            let currTime = new Date().toISOString();
             let toPass = {};
             let found = false;
             if (boxIds[i] == boxId) {
@@ -544,13 +544,13 @@ export const addEventAddSpecimensToListModalButton = (bagid, tableIndex, isOrpha
                 }
 
                 if (found == false) {
-                    toPass['672863981'] = currTime.toString();
+                    toPass['672863981'] = currTime;
                 }
 
                 toPass['132929440'] = boxIds[i];
                 toPass['bags'] = hiddenJSON[boxIds[i]]
                 toPass['560975149'] = locations[boxIds[i]]
-                toPass['555611076'] = currTime.toString();
+                toPass['555611076'] = currTime;
                 await storeBox(toPass);
             }
         }
@@ -2727,15 +2727,10 @@ export const addEventCheckValidTrackInputs = (hiddenJSON) => {
   boxes.forEach(box => {
     let input = document.getElementById(box+"trackingId").value.trim()
     let inputConfirm = document.getElementById(box+"trackingIdConfirm").value.trim()
-    let inputTest = document.getElementById(box+"trackingId").value
-    let inputConfirmTest = document.getElementById(box+"trackingIdConfirm").value
     let inputErrorMsg = document.getElementById(box+"trackingIdErrorMsg")
     let inputConfirmErrorMsg = document.getElementById(box+"trackingIdConfirmErrorMsg")
 
-    console.log(`input trim val: ${input}, input no trim val: ${inputTest}`)
-    console.log(`input confirm trim val: ${inputConfirm}, input confirm no trim val: ${inputConfirmTest}`)
-
-    if(input.length == 12) {
+    if(input.length == 0 && input.length < 12) {
       console.log("input field does not equal 12")
       document.getElementById(box+"trackingId").classList.add("invalid")
       inputErrorMsg.textContent = `Tracking number must be 12 digits`
@@ -2747,7 +2742,41 @@ export const addEventCheckValidTrackInputs = (hiddenJSON) => {
     }
   })
 
+  boxes.forEach(box => {
+    let input = document.getElementById(box+"trackingId").value.trim()
+    let inputConfirm = document.getElementById(box+"trackingIdConfirm").value.trim()
+    let inputTest = document.getElementById(box+"trackingId").value
+    let inputConfirmTest = document.getElementById(box+"trackingIdConfirm").value
+    let inputErrorMsg = document.getElementById(box+"trackingIdErrorMsg")
+    let inputConfirmErrorMsg = document.getElementById(box+"trackingIdConfirmErrorMsg")
+
+    console.log(`input trim val: ${input}, input no trim val: ${inputTest}`)
+    console.log(`input confirm trim val: ${inputConfirm}, input confirm no trim val: ${inputConfirmTest}`)
+
+    // box tracking id 
+    // input must equal 12 characters
+    document.getElementById(box+"trackingId").addEventListener("input", e => {
+      if(input.length  === 12) {
+        console.log("tracking id input is 12 characters")
+      }
+      else {
+        console.log("tracking id input length does not equal 12 characters")
+      }
+    })
+    // box tracking id confirm
+    // trackingid input confirm must equal tackingid input 
+    document.getElementById(box+"trackingIdConfirm").addEventListener("input", e => {
+      if(inputConfirm === input) {
+        console.log("Input trackingid confirm MATCHES trackingid")
+      }
+      else {
+        console.oog("Input trackingid confirm DOES NOT MATCH trackingid")
+      }
+    })
+
+  })
 }
+
 
 export const populateSelectLocationList = async () => {
     let currSelect = document.getElementById('selectLocationList')

--- a/src/events.js
+++ b/src/events.js
@@ -2629,94 +2629,124 @@ export const addEventCheckValidTrackInputs = (hiddenJSON) => {
   let boxes = Object.keys(hiddenJSON).sort(compareBoxIds);
 
   // Check on page load 
+
+  // boxes.forEach(box => {
+  //   let input = document.getElementById(box+"trackingId").value.trim()
+  //   let inputConfirm = document.getElementById(box+"trackingIdConfirm").value.trim()
+  //   let inputErrorMsg = document.getElementById(box+"trackingIdErrorMsg")
+  //   let inputConfirmErrorMsg = document.getElementById(box+"trackingIdConfirmErrorMsg")
+  //   if(input.length > 0 && input.length < 12) {
+  //     document.getElementById(box+"trackingId").classList.add("invalid")
+  //     inputErrorMsg.textContent = `Please input a 12 digit tracking number`
+  //   }
+  //   if(inputConfirm.length > 0 && inputConfirm.length < 12) {
+  //     document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
+  //     inputConfirmErrorMsg.textContent = `Please input a 12 digit tracking number`
+  //   }
+  //   if(input !== inputConfirm && input.length > 0 && input.length < 12 && inputConfirm.length > 0 && inputConfirm.length < 12) {
+  //     document.getElementById(box+"trackingId").classList.add("invalid")
+  //     document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
+  //     inputErrorMsg.textContent = `Please match ${box} confirm input and input a 12 digit tracking number` 
+  //     inputConfirmErrorMsg.textContent = `Please match ${box} start input and input a 12 digit tracking number` 
+  //   }
+  //   else if(input !== inputConfirm) {
+  //     document.getElementById(box+"trackingId").classList.add("invalid")
+  //     document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
+  //     inputConfirmErrorMsg.textContent = "Please match " + box + " start input"
+  //     inputErrorMsg.textContent = "Please match " + box + " confirm input"
+  //   }
+  // })
+      
+  // boxes.forEach(box => {
+  //   document.getElementById(box+"trackingId").addEventListener("input", e => {
+  //     let input = document.getElementById(box+"trackingId").value.trim()
+  //     let inputConfirm = document.getElementById(box+"trackingIdConfirm").value.trim()
+  //     let inputErrorMsg = document.getElementById(box+"trackingIdErrorMsg")
+  //     let inputConfirmErrorMsg = document.getElementById(box+"trackingIdConfirmErrorMsg")
+
+      
+  //     if(input.length < 12 && input !== inputConfirm) {
+  //       document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
+  //       inputErrorMsg.textContent = `Please match ${box} confirm input and input a 12 digit tracking number` 
+  //     }
+  //     else if(input.length < 12) {
+  //       document.getElementById(box+"trackingId").classList.add("invalid")
+  //       inputErrorMsg.textContent = `Please input a 12 digit tracking number`
+  //     }
+  //     else if(input !== inputConfirm && input !== "" && inputConfirm !== "") {
+  //       // add invalid red border
+  //       document.getElementById(box+"trackingId").classList.add("invalid")
+  //       document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
+  //       inputConfirmErrorMsg.textContent = "Please match " + box + " start input"
+  //       inputErrorMsg.textContent = "Please match " + box + " confirm input"
+  //     } 
+  //     else if (input === inputConfirm && input.length >= 12) {
+  //       // remove invalid
+  //       document.getElementById(box+"trackingId").classList.remove("invalid")
+  //       document.getElementById(box+"trackingIdConfirm").classList.remove("invalid")
+  //       inputErrorMsg.textContent = ""
+  //       inputConfirmErrorMsg.textContent = ""
+  //     }
+  //   })
+
+    // document.getElementById(box+"trackingIdConfirm").addEventListener("input",e => {
+    //   let input = document.getElementById(box+"trackingId").value.trim()
+    //   let inputConfirm = document.getElementById(box+"trackingIdConfirm").value.trim()
+    //   let inputErrorMsg = document.getElementById(box+"trackingIdErrorMsg")
+    //   let inputConfirmErrorMsg = document.getElementById(box+"trackingIdConfirmErrorMsg")
+
+    //   if(inputConfirm.length < 12 && inputConfirm !== input) {
+    //     document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
+    //     inputConfirmErrorMsg.textContent = `Please match ${box} start input and input a 12 digit tracking number` 
+    //   }
+    //   else if(inputConfirm.length < 12){
+    //     document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
+    //     inputConfirmErrorMsg.textContent = "Please input a 12 digit tracking number"
+    //   }
+    //   else if(input !== inputConfirm && input !== "" && inputConfirm !== "") {
+    //     // add invalid red border
+    //     document.getElementById(box+"trackingId").classList.add("invalid")
+    //     document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
+    //     inputConfirmErrorMsg.textContent = "Please match " + box + " start input"
+    //     inputErrorMsg.textContent = "Please match " + box + " confirm input"
+    //   } else if (input === inputConfirm && inputConfirm.length >= 12) {
+    //     // remove invalid
+    //     document.getElementById(box+"trackingId").classList.remove("invalid")
+    //     document.getElementById(box+"trackingIdConfirm").classList.remove("invalid")
+    //     inputErrorMsg.textContent = ""
+    //     inputConfirmErrorMsg.textContent = ""
+    //   }
+    // })
+  // })
+
+  /* 
+  Steps Check - On Load
+  Check if input is 12 digits - ???
+  Check if input confirm matches input - ???
+  */
   boxes.forEach(box => {
     let input = document.getElementById(box+"trackingId").value.trim()
     let inputConfirm = document.getElementById(box+"trackingIdConfirm").value.trim()
+    let inputTest = document.getElementById(box+"trackingId").value
+    let inputConfirmTest = document.getElementById(box+"trackingIdConfirm").value
     let inputErrorMsg = document.getElementById(box+"trackingIdErrorMsg")
     let inputConfirmErrorMsg = document.getElementById(box+"trackingIdConfirmErrorMsg")
-    if(input.length > 0 && input.length < 12) {
+
+    console.log(`input trim val: ${input}, input no trim val: ${inputTest}`)
+    console.log(`input confirm trim val: ${inputConfirm}, input confirm no trim val: ${inputConfirmTest}`)
+
+    if(input.length == 12) {
+      console.log("input field does not equal 12")
       document.getElementById(box+"trackingId").classList.add("invalid")
-      inputErrorMsg.textContent = `Please input a 12 digit tracking number`
+      inputErrorMsg.textContent = `Tracking number must be 12 digits`
     }
-    if(inputConfirm.length > 0 && inputConfirm.length < 12) {
+    if(inputConfirm !== input ) {
+      console.log(`inputConfirm does not match input`)
       document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
-      inputConfirmErrorMsg.textContent = `Please input a 12 digit tracking number`
-    }
-    if(input !== inputConfirm && input.length > 0 && input.length < 12 && inputConfirm.length > 0 && inputConfirm.length < 12) {
-      document.getElementById(box+"trackingId").classList.add("invalid")
-      document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
-      inputErrorMsg.textContent = `Please match ${box} confirm input and input a 12 digit tracking number` 
-      inputConfirmErrorMsg.textContent = `Please match ${box} start input and input a 12 digit tracking number` 
-    }
-    else if(input !== inputConfirm) {
-      document.getElementById(box+"trackingId").classList.add("invalid")
-      document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
-      inputConfirmErrorMsg.textContent = "Please match " + box + " start input"
-      inputErrorMsg.textContent = "Please match " + box + " confirm input"
+      inputConfirmErrorMsg.textContent = `Tracking numbers must match`
     }
   })
 
-  boxes.forEach(box => {
-    document.getElementById(box+"trackingId").addEventListener("input", e => {
-      let input = document.getElementById(box+"trackingId").value.trim()
-      let inputConfirm = document.getElementById(box+"trackingIdConfirm").value.trim()
-      let inputErrorMsg = document.getElementById(box+"trackingIdErrorMsg")
-      let inputConfirmErrorMsg = document.getElementById(box+"trackingIdConfirmErrorMsg")
-
-      
-      if(input.length < 12 && input !== inputConfirm) {
-        document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
-        inputErrorMsg.textContent = `Please match ${box} confirm input and input a 12 digit tracking number` 
-      }
-      else if(input.length < 12) {
-        document.getElementById(box+"trackingId").classList.add("invalid")
-        inputErrorMsg.textContent = `Please input a 12 digit tracking number`
-      }
-      else if(input !== inputConfirm && input !== "" && inputConfirm !== "") {
-        // add invalid red border
-        document.getElementById(box+"trackingId").classList.add("invalid")
-        document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
-        inputConfirmErrorMsg.textContent = "Please match " + box + " start input"
-        inputErrorMsg.textContent = "Please match " + box + " confirm input"
-      } 
-      else if (input === inputConfirm && input.length >= 12) {
-        // remove invalid
-        document.getElementById(box+"trackingId").classList.remove("invalid")
-        document.getElementById(box+"trackingIdConfirm").classList.remove("invalid")
-        inputErrorMsg.textContent = ""
-        inputConfirmErrorMsg.textContent = ""
-      }
-    })
-
-    document.getElementById(box+"trackingIdConfirm").addEventListener("input",e => {
-      let input = document.getElementById(box+"trackingId").value.trim()
-      let inputConfirm = document.getElementById(box+"trackingIdConfirm").value.trim()
-      let inputErrorMsg = document.getElementById(box+"trackingIdErrorMsg")
-      let inputConfirmErrorMsg = document.getElementById(box+"trackingIdConfirmErrorMsg")
-
-      if(inputConfirm.length < 12 && inputConfirm !== input) {
-        document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
-        inputConfirmErrorMsg.textContent = `Please match ${box} start input and input a 12 digit tracking number` 
-      }
-      else if(inputConfirm.length < 12){
-        document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
-        inputConfirmErrorMsg.textContent = "Please input a 12 digit tracking number"
-      }
-      else if(input !== inputConfirm && input !== "" && inputConfirm !== "") {
-        // add invalid red border
-        document.getElementById(box+"trackingId").classList.add("invalid")
-        document.getElementById(box+"trackingIdConfirm").classList.add("invalid")
-        inputConfirmErrorMsg.textContent = "Please match " + box + " start input"
-        inputErrorMsg.textContent = "Please match " + box + " confirm input"
-      } else if (input === inputConfirm && inputConfirm.length >= 12) {
-        // remove invalid
-        document.getElementById(box+"trackingId").classList.remove("invalid")
-        document.getElementById(box+"trackingIdConfirm").classList.remove("invalid")
-        inputErrorMsg.textContent = ""
-        inputConfirmErrorMsg.textContent = ""
-      }
-    })
-  })
 }
 
 export const populateSelectLocationList = async () => {

--- a/src/pages/shipping.js
+++ b/src/pages/shipping.js
@@ -1,5 +1,5 @@
 import { userAuthorization, removeActiveClass, addEventBarCodeScanner, storeBox, getBoxes, getAllBoxes, getBoxesByLocation, hideAnimation, showAnimation, showNotifications, getPage, siteContactInformation, shippingPrintManifestReminder} from "./../shared.js"
-import { addEventSearchForm1, addEventBackToSearch, addEventSearchForm2, addEventSearchForm3, addEventSearchForm4, addEventAddSpecimenToBox, addEventNavBarSpecimenSearch, populateSpecimensList, addEventNavBarShipment, addEventNavBarBoxManifest, populateBoxManifestTable, populateBoxManifestHeader, populateSaveTable, populateShippingManifestBody,populateShippingManifestHeader, addEventNavBarShippingManifest, populateTrackingQuery, addEventCompleteButton, populateFinalCheck, populateBoxSelectList, addEventBoxSelectListChanged, populateModalSelect, addEventCompleteShippingButton, populateSelectLocationList, addEventChangeLocationSelect, addEventModalAddBox, populateTempNotification, populateTempCheck, populateTempSelect, addEventNavBarTracking, addEventReturnToReviewShipmentContents, populateCourierBox, addEventSaveButton, addEventTrimTrackingNums, addEventCheckValidTrackInputs, addEventPreventTrackNumPaste, addEventSaveContinue, addEventShipPrintManifest} from "./../events.js";
+import { addEventSearchForm1, addEventBackToSearch, addEventSearchForm2, addEventSearchForm3, addEventSearchForm4, addEventAddSpecimenToBox, addEventNavBarSpecimenSearch, populateSpecimensList, addEventNavBarShipment, addEventNavBarBoxManifest, populateBoxManifestTable, populateBoxManifestHeader, populateSaveTable, populateShippingManifestBody,populateShippingManifestHeader, addEventNavBarShippingManifest, populateTrackingQuery, addEventCompleteButton, populateFinalCheck, populateBoxSelectList, addEventBoxSelectListChanged, populateModalSelect, addEventCompleteShippingButton, populateSelectLocationList, addEventChangeLocationSelect, addEventModalAddBox, populateTempNotification, populateTempCheck, populateTempSelect, addEventNavBarTracking, addEventReturnToReviewShipmentContents, populateCourierBox, addEventSaveButton, addEventTrimTrackingNums, addEventCheckValidTrackInputs, addEventPreventTrackingConfirmPaste, addEventSaveContinue, addEventShipPrintManifest, } from "./../events.js";
 import { homeNavBar, bodyNavBar, shippingNavBar} from '../navbar.js';
 
 const conversion = {
@@ -529,7 +529,7 @@ export const shipmentTracking = async (hiddenJSON, userName, tempCheckChecked) =
     addEventReturnToReviewShipmentContents('navBarReviewShipmentContents', hiddenJSON, userName, tempCheckChecked)
     await populateTrackingQuery(hiddenJSON);
     addEventTrimTrackingNums()
-    addEventPreventTrackNumPaste()
+    addEventPreventTrackingConfirmPaste()
     addEventCheckValidTrackInputs(hiddenJSON)
     addEventSaveButton(hiddenJSON);
     addEventCompleteButton(hiddenJSON, userName, tempCheckChecked);

--- a/src/shared.js
+++ b/src/shared.js
@@ -359,6 +359,35 @@ export const shippingDuplicateMessage = () => {
         </div>`;
 }
 
+export const shippingNonAlphaNumericStrMessage = () => {
+  const button = document.createElement('button');
+    button.dataset.target = '#biospecimenModal';
+    button.dataset.toggle = 'modal';
+
+    document.getElementById('root').appendChild(button);
+    button.click();
+    document.getElementById('root').removeChild(button);
+    const header = document.getElementById('biospecimenModalHeader');
+    const body = document.getElementById('biospecimenModalBody');
+    header.style.borderBottom = 0;
+    header.innerHTML = `<h5 class="modal-title"></h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close" style="font-size:2rem;">
+                            <span aria-hidden="true">&times;</span>
+                        </button>`;
+    body.innerHTML = `
+        <div class="row">
+            <div class="col">
+                <div style="display:flex; justify-content:center; margin-bottom:1rem;">
+                  <i class="fas fa fa-times-circle fa-6x" style="color:#d9534f"></i>
+                </div>
+                <p style="text-align:center; font-size:1.4rem; margin-bottom:1.2rem; "><span style="display:block; font-weight:600;font-size:1.8rem; margin-bottom: 0.5rem;">Invalid Input:</span> Please enter only alphanumeric characters</p>
+            </div>
+        </div>
+        <div class="row" style="display:flex; justify-content:center;">
+          <button id="shipManifestConfirm" type="button" class="btn btn-secondary" data-dismiss="modal" aria-label="Close" style="margin-right:4%; padding:6px 25px;">Close</button>
+        </div>`;
+}
+
 export const removeAllErrors = () => {
     const elements = document.getElementsByClassName('form-error');
     Array.from(elements).forEach(element => {
@@ -1321,4 +1350,16 @@ export const checkFedexShipDuplicate = (boxes) => {
   boxes.forEach(boxId => arr.push(document.getElementById(`${boxId}trackingId`).value))
   let filteredArr = new Set(arr)
   return arr.length !== filteredArr.size
+}
+
+export const checkNonAlphanumericStr = (boxes) => {
+  let regExp = /^[a-z0-9]+$/i
+  let arr = []
+  boxes.forEach(boxId => arr.push(document.getElementById(`${boxId}trackingId`).value))
+  for (let i = 0; i< arr.length; i++) {
+    //check if str is not alphanumeric
+    if(!regExp.test(arr[i])) {
+      return true
+    }
+  }
 }


### PR DESCRIPTION
[issue#475](https://github.com/episphere/connect/issues/475)

- Add regular expression to prevent user from moving to finalize shipment screen with non-alphanumeric characters
- Assign tracking input with one text error message: Tracking number must be 12 digits
- Assign tracking confirm with one text error message: Tracking numbers must match