### PR TITLE
BPTL Dashboard: Added BPTL Restricitons

### DIFF
--- a/src/navbar.js
+++ b/src/navbar.js
@@ -75,18 +75,18 @@ export const userNavBar = (name) => {
     `;
 }
 
-export const nonUserNavBar = (name) => {
+export const nonUserNavBar = (name, isBPTLUser) => {
     return `
         <div class="navbar-nav current-page">
             <li class="nav-item">
                 <a class="nav-link" href="#welcome" id="welcome" title="Home"><i class="fas fa-home"></i> Home</a>
             </li>
         </div>
-        <div class="navbar-nav">
+        ${isBPTLUser === true ? `<div class="navbar-nav">
             <li class="nav-item">
                 <a class="nav-link" href="#bptl" id="bptl" title="Home"><i class="fa fa-id-badge"></i> BPTL</a>
             </li>
-        </div>
+        </div>` : ``}
         <div class="navbar-nav ml-auto">
             <div class="grid-elements dropdown">
                 <button class="nav-link nav-menu-links dropdown-toggle dropdown-btn"  title="Welcome, ${name}!" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/src/pages/bptl.js
+++ b/src/pages/bptl.js
@@ -16,12 +16,19 @@ export const bptlScreen = async (auth, route) => {
   showAnimation();
   const response = await validateUser();
   hideAnimation();
-  if (response.code !== 200) {
+  if (response.code !== 200 ) {
     document.getElementById("contentBody").innerHTML =
       "Authorization failed you lack permissions to use this dashboard!";
     document.getElementById("navbarNavAltMarkup").innerHTML =
       unAuthorizedUser();
     return;
+  }
+  else if ( response.data.isBPTLUser === false ) {
+    document.getElementById("contentBody").innerHTML =
+    "Authorization failed you lack permissions to use this dashboard!";
+  document.getElementById("navbarNavAltMarkup").innerHTML =
+    unAuthorizedUser();
+  return;
   }
   bptlScreenTemplate(name, response.data, auth, route);
   redirectPageToLocation();

--- a/src/pages/welcome.js
+++ b/src/pages/welcome.js
@@ -55,7 +55,7 @@ const welcomeScreenTemplate = (name, data, auth, route) => {
             </div>
         </div>
     `;
-    document.getElementById('navbarNavAltMarkup').innerHTML = nonUserNavBar(name);
+    document.getElementById('navbarNavAltMarkup').innerHTML = nonUserNavBar(name, data.isBPTLUser);
     document.getElementById('contentBody').innerHTML = template;
     document.getElementById('contentBody').dataset.siteAcronym = data.siteAcronym;
     document.getElementById('contentBody').dataset.siteCode = data.siteCode;


### PR DESCRIPTION
This PR addresses following issue:
BIospecimen SSO ensures BPTL dashboard is only available for BPTL user

Checklist:
- [x] Code cleanup
- [ ] Check for ES Lint warnings
- [x] Verify test cases
- [x] Check for GIT conflicts
- [ ] Verified unit tests pass with current changes
- [ ] Any dependencies or modules added 
- [x] Attach PoC
- [ ] Notes added

Test Case:
1.) Check for BPTL dashboard availability for non BPTL user and BPTL user:
Non BPTL User:
<img width="1705" alt="Screen Shot 2022-03-18 at 4 13 59 PM" src="https://user-images.githubusercontent.com/30497847/159077013-2728a978-38e2-4786-bf3a-b6959a37c6c1.png">
BPTL User:
<img width="1709" alt="Screen Shot 2022-03-18 at 4 14 37 PM" src="https://user-images.githubusercontent.com/30497847/159077086-04c05a6d-f4f9-4931-94f5-8d2946ae2740.png">

