### PR TITLE
Bptl fix package receipts page

### DIFF
--- a/src/fieldToConceptIdMapping.js
+++ b/src/fieldToConceptIdMapping.js
@@ -25,36 +25,7 @@ export default {
     shippedByLastName: 885486943,
 
     shippingShipDate: 656548982,
-    packageCondition: 421016519,
-    coldPacksNone: 694392646,
-    coldPacksInsufficient: 665883282,
-    coldPacksWarm: 669336526,
-    damagedContainer: 659684779,
-    damagedVials: 958386677,
-    improperPackaging: 967674331,
-    manifestNotProvided: 352744555,
-    manifestDoNotMatch: 229360386,
-    noPreNotification: 188332319,
-    participantRefusal: 470977257,
-    shipmentDelay: 200647000,
-    vialsEmpty: 790986868,
-    vialsIncorrectMaterialType: 564936650,
-    vialsMissingLabels: 242271549,
-    other: 121720893,
-    packageGood: 123456789,
-    crushed: 121149986,
-    siteShipmentComments: 869218574,
-    siteShipmentDateReceived: 259439191,
-    siteShipmentReceived: 434049748,
-    tempProbe: 105891443,
-    yes: 353358909,
-    no: 104430631,
-
-    // CURRENT BPTL Concepts  - update replace with Old
-
-    /*    
-    shippingShipDate: 656548982,
-    packageCondition: 421016519,
+    packageCondition: 238268405,
     coldPacksNone: 405513630,
     coldPacksInsufficient: 909529446,
     coldPacksWarm: 595987358,
@@ -72,16 +43,15 @@ export default {
     other: 933646000,
     packageGood: 679749262,
     crushed: 121149986,
-    materialThawed: '???', 
-    noRefrigerant: '???',
-
-    
+    materialThawed: 289322354, 
+    noRefrigerant: 613022284,
     siteShipmentComments: 870456401,
     siteShipmentDateReceived: 926457119,
     siteShipmentReceived: 333524031,
     tempProbe: 105891443,
-    */  
-
+    yes: 353358909,
+    no: 104430631,
+    
     // collection id
     collectionId: 825582494,
     dateReceived: 259439191,

--- a/src/fieldToConceptIdMapping.js
+++ b/src/fieldToConceptIdMapping.js
@@ -76,9 +76,9 @@ export default {
     noRefrigerant: '???',
 
     
-    siteShipmentComments: 869218574,
-    siteShipmentDateReceived: 259439191,
-    siteShipmentReceived: 434049748,
+    siteShipmentComments: 870456401,
+    siteShipmentDateReceived: 926457119,
+    siteShipmentReceived: 333524031,
     tempProbe: 105891443,
     */  
 

--- a/src/fieldToConceptIdMapping.js
+++ b/src/fieldToConceptIdMapping.js
@@ -42,12 +42,45 @@ export default {
     vialsMissingLabels: 242271549,
     other: 121720893,
     packageGood: 123456789,
+    crushed: 121149986,
     siteShipmentComments: 869218574,
     siteShipmentDateReceived: 259439191,
     siteShipmentReceived: 434049748,
     tempProbe: 105891443,
     yes: 353358909,
     no: 104430631,
+
+    // CURRENT BPTL Concepts  - update replace with Old
+
+    /*    
+    shippingShipDate: 656548982,
+    packageCondition: 421016519,
+    coldPacksNone: 405513630,
+    coldPacksInsufficient: 909529446,
+    coldPacksWarm: 595987358,
+    damagedContainer: 678483571,
+    damagedVials: 387564837,
+    improperPackaging: 847410060,
+    manifestNotProvided: 853876696,
+    manifestDoNotMatch: 922995819,
+    noPreNotification: 842171722,
+    participantRefusal: 442684673,
+    shipmentDelay: 958000780,
+    vialsEmpty: 631290535,
+    vialsIncorrectMaterialType: 200183516,
+    vialsMissingLabels: 399948893,
+    other: 933646000,
+    packageGood: 679749262,
+    crushed: 121149986,
+    materialThawed: '???', 
+    noRefrigerant: '???',
+
+    
+    siteShipmentComments: 869218574,
+    siteShipmentDateReceived: 259439191,
+    siteShipmentReceived: 434049748,
+    tempProbe: 105891443,
+    */  
 
     // collection id
     collectionId: 825582494,

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -13,13 +13,13 @@ export const packageReceiptScreen = async (auth, route) => {
   const user = auth.currentUser;
   if (!user) return;
   const username = user.displayName ? user.displayName : user.email;
-  packageReceiptTemplate(username, auth, route); // revisit later?
+  packageReceiptTemplate(username, auth, route);
   addDefaultDateReceived(getCurrentDate);
   checkAndDisplayCourierType();
   checkCardIncluded();
   disableCollectionCardFields();
   enableCollectionCardFields();
-  formSubmit(); // Current
+  formSubmit(); 
   targetAnchorTagEl();
   addListenersOnPageLoad();
   dropdownTrigger();
@@ -68,13 +68,13 @@ const packageReceiptTemplate = async (name, auth, route) => {
                                     <option id="select-participantRefusal" value=${fieldMapping.participantRefusal}>Participant Refusal</option>
                                     <option id="select-crushed" value=${fieldMapping.crushed}>Crushed</option>
                                     <option id="select-damagedContainer" value=${fieldMapping.damagedContainer}>Damaged Container (outer and inner)</option>
-                                    <option id="select-materialThawed" value=${fieldMapping.other}>Material Thawed</option>
+                                    <option id="select-materialThawed" value=${fieldMapping.materialThawed}>Material Thawed</option>
                                     <option id="select-insufficientIce" value=${fieldMapping.coldPacksInsufficient}>Insufficient Ice</option>
                                     <option id="select-improperPackaging" value=${fieldMapping.improperPackaging}>Improper Packaging</option>
                                     <option id="select-damagedVials" value=${fieldMapping.damagedVials}>Damaged Vials</option>
                                     <option id="select-other" value=${fieldMapping.other}>Other</option>
                                     <option id="select-noPreNotification" value=${fieldMapping.noPreNotification}>No Pre-notification</option>
-                                    <option id="select-noRefrigerant" value=${fieldMapping.other}>No Refrigerant</option>
+                                    <option id="select-noRefrigerant" value=${fieldMapping.noRefrigerant}>No Refrigerant</option>
                                     <option id="select-infoDoNotMatch" value=${fieldMapping.manifestDoNotMatch}>Manifest/Vial/Paperwork info do not match</option>
                                     <option id="select-shipmentDelay" value=${fieldMapping.shipmentDelay}>Shipment Delay</option>
                                     <option id="select-noManifestProvided" value=${fieldMapping.manifestNotProvided}>No Manifest provided</option>
@@ -273,11 +273,10 @@ const formSubmit = () => {
       }
       window.removeEventListener("beforeunload",beforeUnloadMessage)
       targetAnchorTagEl()
-      //[POST] - request
-      // const receiptStatus = storePackageReceipt(obj);
-      console.log(obj)
-      // check what is being passed into 
+      const receiptStatus = storePackageReceipt(obj);
+    
       if (receiptStatus) {
+        const clearButtonEl = document.getElementById("clearForm");
         document.getElementById("courierType").innerHTML = ``;
         document.getElementById("scannedBarcode").value = "";
         document.getElementById("packageCondition").value = "";
@@ -291,6 +290,7 @@ const formSubmit = () => {
         document.getElementById("packageCondition").setAttribute("data-selected","[]")
         targetAnchorTagEl()
         clearButtonEl !== undefined ? clearButtonEl.removeEventListener("click",cancelConfirm) : ``
+        
         window.removeEventListener("beforeunload",beforeUnloadMessage)
       
       if (document.getElementById("collectionId").value) {

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -59,14 +59,14 @@ const packageReceiptTemplate = async (name, auth, route) => {
                              <div style="display:inline-block; max-width:90%;"> 
                                 <select required class="col form-control" id="packageCondition" style="width:100%" multiple="multiple" data-selected="[]">
                                     <option id="select-dashboard" value="">-- Select Package Condition --</option>
-                                    <option id="select-noIcePack" value=${fieldMapping.packageGood}>Package in good condition</option>
+                                    <option id="select-packageGoodCondition" value=${fieldMapping.packageGood}>Package in good condition</option>
                                     <option id="select-noIcePack" value=${fieldMapping.coldPacksNone}>No Ice Pack</option>
                                     <option id="select-warmIcePack" value=${fieldMapping.coldPacksWarm}>Warm Ice Pack</option>
                                     <option id="select-incorrectMaterialTypeSent" value=${fieldMapping.vialsIncorrectMaterialType}>Vials - Incorrect Material Type Sent</option>
                                     <option id="select-noLabelonVials" value=${fieldMapping.vialsMissingLabels}>No Label on Vials</option>
                                     <option id="select-returnedEmptyVials" value=${fieldMapping.vialsEmpty}>Returned Empty Vials</option>
                                     <option id="select-participantRefusal" value=${fieldMapping.participantRefusal}>Participant Refusal</option>
-                                    <option id="select-crushed" value=${fieldMapping.other}>Crushed</option>
+                                    <option id="select-crushed" value=${fieldMapping.crushed}>Crushed</option>
                                     <option id="select-damagedContainer" value=${fieldMapping.damagedContainer}>Damaged Container (outer and inner)</option>
                                     <option id="select-materialThawed" value=${fieldMapping.other}>Material Thawed</option>
                                     <option id="select-insufficientIce" value=${fieldMapping.coldPacksInsufficient}>Insufficient Ice</option>
@@ -326,7 +326,7 @@ const storeDateReceivedinISO = (date) => { // ("YYYY-MM-DD" to ISO format DateTi
 const storePackageReceipt = async (data) => {
     showAnimation();
     const idToken = await getIdToken();
-    const response = await await fetch(
+    const response = await fetch(
         `https://us-central1-nih-nci-dceg-connect-dev.cloudfunctions.net/biospecimen?api=storeReceipt`,
         {
             method: "POST",

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -219,7 +219,7 @@ const triggerErrorModal = () => {
 }
 
 const checkCardIncluded = () => {
-  const a = document.getElementById('collectionCheckBox') // TODO: make this checkbox bigger
+  const a = document.getElementById('collectionCheckBox')
   if (a) {
     a.addEventListener("change", () => {
       a.checked ? disableCollectionCardFields() : enableCollectionCardFields()

--- a/src/pages/receipts/packagesInTransit.js
+++ b/src/pages/receipts/packagesInTransit.js
@@ -284,7 +284,6 @@ const groupSamplesArr = (bagsArr) => {
 const groupScannedByArr = (bagsArr, fieldToConceptIdMapping) => {
     const arrNames = [];
     const { scannedByFirstName, scannedByLastName } = fieldToConceptIdMapping;
-    console.log(scannedByFirstName,scannedByLastName)
     bagsArr.forEach((bag) => {
         //DETERMINE IF ARRAY IS EMPTY, IF NOT KEEP LOOPING INSIDE, ELSE PUSH 0 VALUE***
         if (Object.keys(bag).length) {
@@ -331,7 +330,6 @@ const groupShippedByArr = (allBoxes) => {
   // check if each box has first name and last name concept with length
   // check length of last name and sanitize using trim 
   allBoxes.forEach(box => {
-    console.log(box)
     let shippedByFirstName = box[fieldToConceptIdMapping.shippedByFirstName].trim()
     let shippedByLastName = box[fieldToConceptIdMapping.shippedByLastName]?.trim() ?? ''
     if(shippedByFirstName.length > 0 && shippedByLastName > 0) {

--- a/src/shared.js
+++ b/src/shared.js
@@ -784,7 +784,7 @@ export const searchSpecimenInstitute = async () => {
 
     let a = await response.json();
     /* Filter collections with ShipFlag value yes */
-    let data = a.data.filter(item => item[410912345] === 353358909);    
+    let data = a.data.filter(item => item[410912345] === 353358909);
     
     const conversion = {
         "299553921":"0001",


### PR DESCRIPTION
The following PR addresses the following:
- Update BPTL concept Ids in fieldToConceptIdMapping.js
- Modify HTML string template's package condition option elements
- Update crushed, materialThawed and noRefrigerant concept Id mapping
- Update eventListener for Scan USPS/Fedex Barcode input and conditional, trim fedex barcode to last 12 digits if 34 characters long