### PR TITLE
Use tubeID to decide bagID

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -496,9 +496,9 @@ export const addEventAddSpecimensToListModalButton = (bagid, tableIndex, isOrpha
 
             if (!isOrphan) {
                 if (tubeID === '0007') {
-                    bagid = collectionID + '0009';
+                    bagid = collectionID + ' 0009';
                 } else {
-                    bagid = collectionID + '0008';
+                    bagid = collectionID + ' 0008';
                 }
             }
 

--- a/src/events.js
+++ b/src/events.js
@@ -492,7 +492,7 @@ export const addEventAddSpecimensToListModalButton = (bagid, tableIndex, isOrpha
             // data-full-specimen-id (Ex. "CXA444444 0007")
             let toAddId = checkedSpecimensArr[i].getAttribute("data-full-specimen-id")
             const [collectionID, tubeID] = toAddId.split(/\s+/);
-            toDelete.push(toAddId.split(/\s+/)[1]);
+            toDelete.push(tubeID);
 
             if (!isOrphan) {
                 if (tubeID === '0007') {

--- a/src/events.js
+++ b/src/events.js
@@ -477,7 +477,7 @@ export const addEventAddSpecimensToListModalButton = (bagid, tableIndex, isOrpha
         let numRows = tubeTable.rows.length;
         let bagSplit = bagid.split(/\s+/);
         let boxId = document.getElementById('shippingModalChooseBox').value;
-        let nameSplit = userName.split(' ');
+        let nameSplit = userName.split(/\s+/);
         let firstName = nameSplit[0] ? nameSplit[0] : '';
         let lastName = nameSplit[1] ? nameSplit[1] : '';
         let checkedSpecimensArr = Array.from(document.getElementsByClassName("samplePresentCheckbox")).filter(item => item.checked)
@@ -491,7 +491,16 @@ export const addEventAddSpecimensToListModalButton = (bagid, tableIndex, isOrpha
         for (let i = 0; i < checkedSpecimensArr.length; i++) {
             // data-full-specimen-id (Ex. "CXA444444 0007")
             let toAddId = checkedSpecimensArr[i].getAttribute("data-full-specimen-id")
+            const [collectionID, tubeID] = toAddId.split(/\s+/);
             toDelete.push(toAddId.split(/\s+/)[1]);
+
+            if (!isOrphan) {
+                if (tubeID === '0007') {
+                    bagid = collectionID + '0009';
+                } else {
+                    bagid = collectionID + '0008';
+                }
+            }
 
             if (boxObjects.hasOwnProperty(boxId)) {
                 if (boxObjects[boxId].hasOwnProperty(bagid)) {


### PR DESCRIPTION
This PR is to solve issue #530 (https://github.com/episphere/connect/issues/530).
The following steps are used to decide bag ID for each tube:
- Orphan tubes are put in an orphan bag in a box
- If a tube is not orphan: if the tube contains mouthwash (0007), put it in mouthwash bag (0009); else put it in blood/urine bag (0008)