### PR TITLE
issue#545 - add tracking number to shipping report page manifest

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -1108,7 +1108,6 @@ export const populateTempCheck = async () => {
 }
 
 export const populateShippingManifestHeader = (hiddenJSON, userName, locationNumber, siteAcronym, currShippingLocationNumber) => {
-  console.log("populateShippingManifestHeader locationNumber, siteAcronym, currShippingLocationNumber", locationNumber, siteAcronym,currShippingLocationNumber) // REMOVE - After Site Dev Test
     let column1 = document.getElementById("boxManifestCol1")
     let column2 = document.getElementById("boxManifestCol3")
     const currContactInfo = locationConceptIDToLocationMap[currShippingLocationNumber]["contactInfo"][siteAcronym]
@@ -3234,7 +3233,6 @@ export const populateBoxTable = async (page, filter) => {
         currRow.insertCell(6).innerHTML = receivedDate;
         currRow.insertCell(7).innerHTML = convertNumsToCondition(packagedCondition, packageConversion);
         currRow.insertCell(8).innerHTML = currPage.hasOwnProperty('870456401') ? currPage['870456401'] : '' ;
-        console.log("populateBoxTable currPage",currPage) // REMOVE - After Site Dev Test
         addEventViewManifestButton('reportsViewManifest' + i, currPage);
 
     }
@@ -3250,7 +3248,6 @@ export const addEventViewManifestButton = (buttonId, currPage) => {
 
 
 export const populateReportManifestHeader = (currPage) => {
-    console.log("populateReportManifestHeader currPage",currPage) // REMOVE - After Site Dev Test
     let column1 = document.getElementById("boxManifestCol1")
     let column2 = document.getElementById("boxManifestCol3")
     let siteAcronym = currPage["siteAcronym"]
@@ -3261,6 +3258,7 @@ export const populateReportManifestHeader = (currPage) => {
     let newDiv = document.createElement("div")
     let newP = document.createElement("p");
     newP.innerHTML = currPage['132929440'] + " Manifest";
+    newP.setAttribute("style", "font-size: 1.5rem; font-weight:bold;")
     document.getElementById('boxManifestCol1').appendChild(newP);
 
     let toInsertDateStarted = ''

--- a/src/pages/reportsQuery.js
+++ b/src/pages/reportsQuery.js
@@ -87,6 +87,7 @@ export const showReportsManifest = async (currPage) => {
             <div style="float:left;width: 33%;" id="boxManifestCol3">
                 <p>Site: ` + currPage['siteAcronym'] + `</p>
                 <p>Location: ` + conceptIdToSiteSpecificLocation[currPage['560975149']] + `</p>
+                <p>Tracking Number: ${currPage['959708259'] ? currPage['959708259'] : ""} </p>
             </div>
         </div>
         <div class="row">


### PR DESCRIPTION
[Issue#545](https://github.com/episphere/connect/issues/545)

The pull request addresses the following:

Main focus
- added tracking number to shipping report manifest page

Styling/Other
- styled Box# header
- remove previous print statements