### PR TITLE
modified code for select shipping location option

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -153,6 +153,11 @@ export const addEventAddSpecimenToBox = (userName) => {
     form.addEventListener('submit', async e => {
         e.preventDefault();
         const masterSpecimenId = document.getElementById('masterSpecimenId').value;
+        const shippingLocationValue = document.getElementById('selectLocationList').value;
+        if(shippingLocationValue === 'none') {
+          showNotifications({ title: 'Shipping Location Not Selected', body: 'Please select a shipping location from the dropdown.' }, true)
+          return
+        }
         if (masterSpecimenId == '') {
             showNotifications({ title: 'Not found', body: 'The submited bag or tube could not be found!' }, true)
             return
@@ -1649,7 +1654,13 @@ export const addEventChangeLocationSelect = (userName) => {
                 boxObjects[box['132929440']] = box['bags']
             }
 
-            await populateBoxSelectList(boxObjects, userName)
+            await populateBoxSelectList(boxObjects, userName);
+            hideAnimation();
+        }
+        else {
+            showAnimation();
+            let boxObjects = {};
+            await populateBoxSelectList(boxObjects, userName);
             hideAnimation();
         }
     })


### PR DESCRIPTION
This pull request addresses the following:
Reference [Issue#544b](https://github.com/episphere/biospecimen/pull/323)

Handle Select Shipping Location from dropdown when searching for specimen bag id or full specimen id 
- prevented specimen verification modal from appearing when user scans a specimen bag id and no shipping location is selected from the dropdown
- emptied shipping box contents when "select shipping location option" is selected from dropdown

![Screen Shot 2022-06-24 at 12 08 33 PM](https://user-images.githubusercontent.com/33293205/175574658-ec88b38e-935e-4489-ace9-58b703c9ee2d.png)