### PR TITLE
Remove extra split method

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -3503,7 +3503,7 @@ export const populateBoxTable = async (page, filter) => {
 
         if(currPage.hasOwnProperty('926457119')) {
             let isoFormat = currPage['926457119']
-            receivedDate = retrieveDateFromIsoString(isoFormat).split(',')[0]
+            receivedDate = retrieveDateFromIsoString(isoFormat)
         }
 
         if(currPage.hasOwnProperty('238268405')) {


### PR DESCRIPTION
Removed extra split method from "retrieveDateFromIsoString(isoFormat)" function.