### PR TITLE
Fix multiple email notifications for clinical biospecimen survey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ static/.DS_Store
 static/images/.DS_Store
 scratch.js
 /tmp
+.hintrc

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 </head>
 <body>
     <nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
-        <a class="navbar-brand" href="#"><img height="45px" width="140px" src="./static/images/NCI-LOGO-FA-Color-Blue.png"></a> 
+        <a class="navbar-brand" href="#"><img height="45px" width="140px" alt="Connect blue logo" src="./static/images/NCI-LOGO-FA-Color-Blue.png"></a> 
         <button class="navbar-toggler collapsed" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
@@ -113,7 +113,6 @@
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/js/bootstrap.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@ericblade/quagga2/dist/quagga.min.js"></script>
-    <!-- <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/quagga/0.12.1/quagga.min.js"></script> -->
     <script src="https://www.gstatic.com/firebasejs/7.14.2/firebase-app.js"></script>
     <script src="https://www.gstatic.com/firebasejs/7.14.2/firebase-auth.js"></script>
     <script src="https://cdn.firebase.com/libs/firebaseui/3.5.2/firebaseui.js"></script>

--- a/src/events.js
+++ b/src/events.js
@@ -1753,20 +1753,16 @@ export const addGoToCheckInEvent = () => {
 };
 
 export const addGoToSpecimenLinkEvent = () => {
-    const workflow = getWorkflow();
+    const specimenLinkButtons = document.querySelectorAll('button[data-specimen-link-connect-id]');
 
-    if (workflow === 'research' || workflow === 'clinical') {
-        const specimenLinkButtons = document.querySelectorAll('button[data-specimen-link-connect-id]');
+    for (const btn of specimenLinkButtons) {
+        btn.addEventListener('click', async () => {
+        let query = `connectId=${parseInt(btn.dataset.specimenLinkConnectId)}`;
+        const response = await findParticipant(query);
+        const data = response.data[0];
 
-        for (const btn of specimenLinkButtons) {
-            btn.addEventListener('click', async () => {
-            let query = `connectId=${parseInt(btn.dataset.specimenLinkConnectId)}`;
-            const response = await findParticipant(query);
-            const data = response.data[0];
-    
-            specimenTemplate(data);
-            });
-        }
+        specimenTemplate(data);
+        });
     }
 };
 

--- a/src/events.js
+++ b/src/events.js
@@ -1,4 +1,4 @@
-import { performSearch, showAnimation, addBiospecimenUsers, hideAnimation, showNotifications, biospecimenUsers, removeBiospecimenUsers, findParticipant, errorMessage, removeAllErrors, storeSpecimen, updateSpecimen, searchSpecimen, generateBarCode, searchSpecimenInstitute, addBox, updateBox, getBoxes, ship, getLocationsInstitute, getBoxesByLocation, disableInput, allStates, removeBag, removeMissingSpecimen, getAllBoxes, getNextTempCheck, updateNewTempDate, getSiteTubesLists, getWorflow, collectionSettings, getSiteCouriers, getPage, getNumPages, allTubesCollected, removeSingleError, updateParticipant, displayContactInformation, checkShipForage, checkAlertState, sortBiospecimensList, retrieveDateFromIsoString, convertConceptIdToPackageCondition, checkFedexShipDuplicate, shippingDuplicateMessage, checkInParticipant, checkOutParticipant, getCheckedInVisit, shippingPrintManifestReminder, checkNonAlphanumericStr, shippingNonAlphaNumericStrMessage, visitType, getParticipantCollections, updateBaselineData, getUpdatedParticipantData, siteSpecificLocation, siteSpecificLocationToConceptId, conceptIdToSiteSpecificLocation, locationConceptIDToLocationMap, siteFullNames, updateCollectionSettingData, convertToOldBox, translateNumToType, getCollectionsByVisit, getUserProfile, checkDuplicateTrackingIdFromDb, getAllBoxesWithoutConversion,  bagConceptIdList, checkAccessionId, checkSurveyEmailTrigger, packageConditonConversion, checkDerivedVariables } from './shared.js';
+import { performSearch, showAnimation, addBiospecimenUsers, hideAnimation, showNotifications, biospecimenUsers, removeBiospecimenUsers, findParticipant, errorMessage, removeAllErrors, storeSpecimen, updateSpecimen, searchSpecimen, generateBarCode, searchSpecimenInstitute, addBox, updateBox, getBoxes, ship, getLocationsInstitute, getBoxesByLocation, disableInput, allStates, removeBag, removeMissingSpecimen, getAllBoxes, getNextTempCheck, updateNewTempDate, getSiteTubesLists, getWorkflow, collectionSettings, getSiteCouriers, getPage, getNumPages, allTubesCollected, removeSingleError, updateParticipant, displayContactInformation, checkShipForage, checkAlertState, sortBiospecimensList, retrieveDateFromIsoString, convertConceptIdToPackageCondition, checkFedexShipDuplicate, shippingDuplicateMessage, checkInParticipant, checkOutParticipant, getCheckedInVisit, shippingPrintManifestReminder, checkNonAlphanumericStr, shippingNonAlphaNumericStrMessage, visitType, getParticipantCollections, updateBaselineData, getUpdatedParticipantData, siteSpecificLocation, siteSpecificLocationToConceptId, conceptIdToSiteSpecificLocation, locationConceptIDToLocationMap, siteFullNames, updateCollectionSettingData, convertToOldBox, translateNumToType, getCollectionsByVisit, getUserProfile, checkDuplicateTrackingIdFromDb, getAllBoxesWithoutConversion,  bagConceptIdList, checkAccessionId, checkSurveyEmailTrigger, packageConditonConversion, checkDerivedVariables } from './shared.js';
 import { searchTemplate, searchBiospecimenTemplate } from './pages/dashboard.js';
 import { showReportsManifest, startReport } from './pages/reportsQuery.js';
 import { startShipping, boxManifest, shippingManifest, finalShipmentTracking, shipmentTracking } from './pages/shipping.js';
@@ -119,7 +119,7 @@ export const addEventsearchSpecimen = () => {
         }
         const biospecimenData = biospecimen.data;
 
-        if(getWorflow() === 'research') {
+        if(getWorkflow() === 'research') {
             if(biospecimenData['650516960'] != 534621077) {
                 hideAnimation();
                 showNotifications({ title: 'Incorrect Dashboard', body: 'Clinical Collections cannot be viewed on Research Dashboard' }, true);
@@ -1753,33 +1753,21 @@ export const addGoToCheckInEvent = () => {
 };
 
 export const addGoToSpecimenLinkEvent = () => {
-    // For research
-    const researchSpecimenLinkButtons = document.querySelectorAll('[data-specimen-link-connect-id]');
-    Array.from(researchSpecimenLinkButtons).forEach((btn) => {
-        btn.addEventListener('click', async () => {
+    const workflow = getWorkflow();
 
+    if (workflow === 'research' || workflow === 'clinical') {
+        const specimenLinkButtons = document.querySelectorAll('button[data-specimen-link-connect-id]');
+
+        for (const btn of specimenLinkButtons) {
+            btn.addEventListener('click', async () => {
             let query = `connectId=${parseInt(btn.dataset.specimenLinkConnectId)}`;
-        
             const response = await findParticipant(query);
             const data = response.data[0];
     
             specimenTemplate(data);
-        });
-    });
-
-    //For Clinical
-    const clinicalSpecimenLinkButtons = document.querySelectorAll('[data-clinical-specimen-link-connect-id]');
-    Array.from(clinicalSpecimenLinkButtons).forEach((btn) => {
-        btn.addEventListener('click', async () => {
-
-            let query = `connectId=${parseInt(btn.dataset.clinicalSpecimenLinkConnectId)}`;
-        
-            const response = await findParticipant(query);
-            const data = response.data[0];
-    
-            specimenTemplate(data);
-        });
-    });
+            });
+        }
+    }
 };
 
 export const addEventCheckInCompleteForm = (isCheckedIn) => {
@@ -1927,7 +1915,7 @@ export const addEventClinicalSpecimenLinkForm = (formData) => {
 
 export const addEventClinicalSpecimenLinkForm2 = (formData) => {
     const form = document.getElementById('clinicalSpecimenContinueTwo');
-    const connectId = document.getElementById('clinicalSpecimenContinueTwo').dataset.connectId;
+    const connectId = form.dataset.connectId;
     
     form.addEventListener('click', async (e) => {
         e.preventDefault();
@@ -1965,6 +1953,12 @@ const existingCollectionAlert = async (collections, connectId, formData) => {
     }
 }
 
+// todo: this function handles tangled situations. Needs to be refactored
+/**
+ * Handles events after collection ID is scanned and "Submit" is clicked
+ * @param {string} connectId 
+ * @param {*} formData 
+ */
 const btnsClicked = async (connectId, formData) => { 
     removeAllErrors();
 
@@ -2013,7 +2007,7 @@ const btnsClicked = async (connectId, formData) => {
         confirmVal = await swal({
             title: "Confirm Collection ID",
             icon: "info",
-            text: `Collection ID: ${collectionID}\n Confirm ID is correct for participant: ${n || ""}`,
+            text: `Collection ID: ${collectionID}\n Confirm ID is correct for participant: ${n}`,
             buttons: {
                 cancel: {
                     text: "Cancel",
@@ -2043,18 +2037,10 @@ const btnsClicked = async (connectId, formData) => {
     if (confirmVal === "cancel") return;
 
     formData['820476880'] = collectionID;
-    formData['650516960'] = getWorflow() === 'research' ? 534621077 : 664882224;
+    formData['650516960'] = getWorkflow() === 'research' ? 534621077 : 664882224;
     formData['Connect_ID'] = parseInt(document.getElementById('specimenLinkForm').dataset.connectId);
     formData['token'] = document.getElementById('specimenLinkForm').dataset.participantToken;
     
-    let bloodAccessionId = formData?.['646899796'];
-    if (bloodAccessionId) {
-        formData['646899796'] = bloodAccessionId;
-    }
-    let urineAccessionId = formData?.['928693120'];
-    if (urineAccessionId) {
-        formData['928693120'] = urineAccessionId;
-    }
     let query = `connectId=${parseInt(connectId)}`;
 
     showAnimation();
@@ -2063,12 +2049,12 @@ const btnsClicked = async (connectId, formData) => {
     let specimenData;
     
     if (!formData?.collectionId) {
-        specimenData = (await searchSpecimen(formData['820476880'])).data;
+        specimenData = (await searchSpecimen(formData['820476880'])).data; // search by collection ID (820476880)
     }
     hideAnimation();
 
-    if (specimenData && specimenData.Connect_ID && parseInt(specimenData.Connect_ID) !== data.Connect_ID && !formData?.collectionId) {
-        showNotifications({ title: 'Collection ID Duplication', body: 'Entered Collection ID is already associated with a different connect ID.' }, true)
+    if (specimenData?.Connect_ID && parseInt(specimenData.Connect_ID) !== data.Connect_ID) {
+        showNotifications({ title: 'Collection ID Duplication', body: 'Entered Collection ID is already associated with a different Connect ID.' }, true)
         return;
     }
 
@@ -2087,7 +2073,8 @@ const btnsClicked = async (connectId, formData) => {
     const biospecimenData = (await searchSpecimen(formData?.collectionId || formData['820476880'])).data;
     await createTubesForCollection(formData, biospecimenData);
     
-    if(formData['650516960'] === 664882224) {
+    // if 'clinical' and no existing collection ID, check email trigger
+    if (formData['650516960'] === 664882224 && !formData?.collectionId) {
         await checkSurveyEmailTrigger(data, formData['331584571']);
     }
 
@@ -2100,6 +2087,10 @@ const btnsClicked = async (connectId, formData) => {
     }
 }
 
+/**
+ * Check accession number inputs after clicking 'Submit' button
+ * @param {*} formData 
+ */
 const clinicalBtnsClicked = async (formData) => { 
 
     removeAllErrors();
@@ -2257,12 +2248,12 @@ const confirmationModal = (accessionID2, accessionID4, participantName, selected
 
     const yesBtn = document.getElementById('proceedNextPage');
     yesBtn.addEventListener("click", async e => {
-        (accessionID2.value) ? await proccedToSpecimenPage(accessionID2, accessionID4, selectedVisit, formData, connectId) :
+        (accessionID2.value) ? await proceedToSpecimenPage(accessionID2, accessionID4, selectedVisit, formData, connectId) :
         await redirectSpecimenPage(accessionID2, accessionID4, selectedVisit, formData, connectId)
     }) 
 }
 
-const proccedToSpecimenPage = async (accessionID1, accessionID3, selectedVisit, formData, connectId) => {
+const proceedToSpecimenPage = async (accessionID1, accessionID3, selectedVisit, formData, connectId) => {
     const bloodAccessionId = await checkAccessionId({accessionId: +accessionID1.value, accessionIdType: '646899796'});
     if (bloodAccessionId.code == 200) {
         if (bloodAccessionId.data) {
@@ -2294,6 +2285,8 @@ const proccedToSpecimenPage = async (accessionID1, accessionID3, selectedVisit, 
             const yesBtn = document.getElementById('addCollection');
             yesBtn.addEventListener("click", async e => {
                 formData.collectionId = bloodAccessionId?.data?.[820476880];
+                formData['331584571'] =  selectedVisit;
+                
                 btnsClicked(connectId, formData); // needs code reformat/enhancement
                 await redirectSpecimenPage(accessionID1, accessionID3, selectedVisit, formData, connectId)
                 return
@@ -2340,12 +2333,12 @@ export const addEventBiospecimenCollectionFormToggles = () => {
 
         collected.addEventListener('change', () => {
             
-            if(getWorflow() === 'research' && reason) reason.disabled = collected.checked;
+            if(getWorkflow() === 'research' && reason) reason.disabled = collected.checked;
             if(deviated) deviated.disabled = !collected.checked;
             specimenId.disabled = !collected.checked;
             
             if(collected.checked) {
-                if(getWorflow() === 'research' && reason) reason.value = '';
+                if(getWorkflow() === 'research' && reason) reason.value = '';
             }
             else {
                 const event = new CustomEvent('change');
@@ -2359,14 +2352,14 @@ export const addEventBiospecimenCollectionFormToggles = () => {
                 }
             }
             
-            if (getWorflow() === 'research' && collected.id === '223999569') {
+            if (getWorkflow() === 'research' && collected.id === '223999569') {
                 const mouthwashContainer = document.getElementById(`143615646Id`);
                 if (!mouthwashContainer.value && collected.checked) {
                     specimenId.disabled = true;
                 }
             }
 
-            if (getWorflow() === 'research' && collected.id === '143615646') {
+            if (getWorkflow() === 'research' && collected.id === '143615646') {
                 const mouthwashBagChkb = document.getElementById(`223999569`);
                 const mouthwashBagText = document.getElementById(`223999569Id`);
                 if (collected.checked) {
@@ -2375,7 +2368,7 @@ export const addEventBiospecimenCollectionFormToggles = () => {
                 }
             }
             
-            const selectionData = workflows[getWorflow()].filter(tube => tube.concept === collected.id)[0];
+            const selectionData = workflows[getWorkflow()].filter(tube => tube.concept === collected.id)[0];
 
             if (selectionData.tubeType === 'Blood tube' || selectionData.tubeType === 'Urine') {
                 const biohazardBagChkb = document.getElementById(`787237543`);
@@ -2501,8 +2494,8 @@ export const addEventBiospecimenCollectionFormText = (dt, biospecimenData) => {
 
 export const createTubesForCollection = async (formData, biospecimenData) => {
     
-    if(getWorflow() === 'research' && biospecimenData['678166505'] === undefined) biospecimenData['678166505'] = new Date().toISOString();
-    if(getWorflow() === 'clinical' && biospecimenData['915838974'] === undefined) biospecimenData['915838974'] = new Date().toISOString();
+    if(getWorkflow() === 'research' && biospecimenData['678166505'] === undefined) biospecimenData['678166505'] = new Date().toISOString();
+    if(getWorkflow() === 'clinical' && biospecimenData['915838974'] === undefined) biospecimenData['915838974'] = new Date().toISOString();
     let siteTubesList = getSiteTubesLists(formData);
 
     siteTubesList.forEach((dt) => {
@@ -2524,7 +2517,7 @@ export const createTubesForCollection = async (formData, biospecimenData) => {
 const collectionSubmission = async (formData, biospecimenData, cntd) => {
     removeAllErrors();
 
-    if (getWorflow() === 'research' && biospecimenData['678166505'] === undefined) biospecimenData['678166505'] = new Date().toISOString();
+    if (getWorkflow() === 'research' && biospecimenData['678166505'] === undefined) biospecimenData['678166505'] = new Date().toISOString();
 
     const inputFields = Array.from(document.getElementsByClassName('input-barcode-id'));
     const siteTubesList = getSiteTubesLists(biospecimenData);
@@ -2647,7 +2640,7 @@ const collectionSubmission = async (formData, biospecimenData, cntd) => {
     biospecimenData['338570265'] = document.getElementById('collectionAdditionalNotes').value;
 
     if (cntd) {
-        if (getWorflow() === 'clinical') {
+        if (getWorkflow() === 'clinical') {
             if (biospecimenData['915838974'] === undefined) biospecimenData['915838974'] = new Date().toISOString();
         }
     }

--- a/src/navbar.js
+++ b/src/navbar.js
@@ -1,4 +1,4 @@
-import { getWorflow } from "./shared.js";
+import { getWorkflow } from "./shared.js";
 
 export const homeNavBar = () => {
     return `
@@ -126,7 +126,7 @@ export const adminNavBar = (name) => {
 }
 
 export const bodyNavBar = () => {
-    const workflow = getWorflow();
+    const workflow = getWorkflow();
     let template = `
         <ul class="nav nav-tabs row">
             <li class="nav-item">

--- a/src/pages/collectProcess.js
+++ b/src/pages/collectProcess.js
@@ -1,5 +1,5 @@
 import { addEventSelectAllCollection, addEventBiospecimenCollectionForm, addEventBiospecimenCollectionFormToggles, addEventBackToSearch, addEventBiospecimenCollectionFormEdit, addEventBiospecimenCollectionFormEditAll, addEventBiospecimenCollectionFormText } from './../events.js'
-import { removeActiveClass, generateBarCode, addEventBarCodeScanner, visitType, getSiteTubesLists, getWorflow, getCheckedInVisit, findParticipant, checkedIn } from '../shared.js';
+import { removeActiveClass, generateBarCode, addEventBarCodeScanner, visitType, getSiteTubesLists, getWorkflow, getCheckedInVisit, findParticipant, checkedIn } from '../shared.js';
 import { checkInTemplate } from './checkIn.js';
 
 export const tubeCollectedTemplate = (data, formData) => {
@@ -16,7 +16,7 @@ export const tubeCollectedTemplate = (data, formData) => {
                 <div class="row"><h5>${data['996038075']}, ${data['399159511']}</h5></div>
                 <div class="row">Connect ID: <svg id="connectIdBarCode"></svg></div>
                 <div class="row">Collection ID: ${formData['820476880']}</div>
-                <div class="row">Collection ID Link Date/Time: ${getWorflow() === 'research' ? new Date(formData['678166505']).toLocaleString(): new Date(formData['915838974']).toLocaleString()}</div>
+                <div class="row">Collection ID Link Date/Time: ${getWorkflow() === 'research' ? new Date(formData['678166505']).toLocaleString(): new Date(formData['915838974']).toLocaleString()}</div>
             </div>
             ${formData['331584571'] ? `
                 <div class="ml-auto form-group">
@@ -36,7 +36,7 @@ export const tubeCollectedTemplate = (data, formData) => {
                                 <input class="custom-checkbox-size" type="checkbox" id="selectAllCollection">
                                 <label for="selectAllCollection">&nbsp;Check All</label>
                             </th>
-                            ${getWorflow() === 'research' ? `<th class="align-left">Reason Not Collected</th>` : ''}
+                            ${getWorkflow() === 'research' ? `<th class="align-left">Reason Not Collected</th>` : ''}
                             <th class="align-left">Scan Full Specimen ID</th> 
                             <th class="align-left">Select For Deviation</th>
                             <th class="align-left">Deviation Type</th> 
@@ -80,7 +80,7 @@ export const tubeCollectedTemplate = (data, formData) => {
                                     :``}
                                 </td>`
 
-                                if(getWorflow() === 'research') {
+                                if(getWorkflow() === 'research') {
 
                                     template += 
                                 

--- a/src/pages/dashboard.js
+++ b/src/pages/dashboard.js
@@ -1,4 +1,4 @@
-import { userAuthorization, removeActiveClass, validateUser, addEventBarCodeScanner, allStates, getWorflow, isDeviceMobile, replaceDateInputWithMaskedInput, checkedIn, verificationConversion } from "./../shared.js"
+import { userAuthorization, removeActiveClass, validateUser, addEventBarCodeScanner, allStates, getWorkflow, isDeviceMobile, replaceDateInputWithMaskedInput, checkedIn, verificationConversion } from "./../shared.js"
 import {  addGoToCheckInEvent, addGoToSpecimenLinkEvent, addEventSearchForm1, addEventBackToSearch, addEventSearchForm2, addEventSearchForm3, addEventSearchForm4, addEventsearchSpecimen, addEventNavBarSpecimenSearch, addEventNavBarShipment, addEventClearAll } from "./../events.js";
 import { homeNavBar, bodyNavBar, unAuthorizedUser } from '../navbar.js';
 
@@ -70,9 +70,8 @@ export const searchTemplate = (goToSpecimenSearch) => {
                         </div>
                     </form>
                 </div>
-                ${contentBody.dataset.workflow && contentBody.dataset.workflow === 'clinical' ? `
-                    
-                `:`
+                ${contentBody.dataset.workflow && contentBody.dataset.workflow === 'clinical' ? ``
+                :`
                     <div class="row form-row">
                         <form id="search2" method="POST">
                             <div class="form-group">
@@ -170,26 +169,31 @@ export const searchResults = (result) => {
                         <th>Verification Status</th>
                         <th>Participation Status</th>
                         <th></th>
-                        ${getWorflow() === 'research' ? '<th></th>' : ''}
+                        ${getWorkflow() === 'research' ? '<th></th>' : ''}
                         <th></th>
                     </tr>
                 </thead>
                 <tbody>`
+
     result.forEach(data => {
 
         if(data['821247024'] === 922622075) return;
+
+        let tdTemplate=`
+            <td>${data['996038075']}</td>
+            <td>${data['399159511']}</td>
+            <td>${data['231676651']}</td>
+            <td>${data['564964481']}/${data['795827569']}/${data['544150384']}</td>
+            <td>${data['521824358']} ${data['442166669'] ? data['442166669'] : ''}</br>${data['703385619']} ${data['634434746']} ${data['892050548']}</td>
+            <td>${data.Connect_ID}</td>
+            <td>${verificationConversion[[data['821247024']]]}</td>
+            <td>${data['912301837'] === 208325815 || data['912301837'] === 622008261 || data['912301837'] === 458508122 ? `<i class="fas fa-2x fa-check"></i>` :  `<i class="fas fa-2x fa-times"></i>`}</td>`;
+
         const isCheckedIn = checkedIn(data);
-        if (getWorflow() === 'research') {
+        if (getWorkflow() === 'research') {
         template += `
             <tr>
-                <td>${data['996038075']}</td>
-                <td>${data['399159511']}</td>
-                <td>${data['231676651']}</td>
-                <td>${data['564964481']}/${data['795827569']}/${data['544150384']}</td>
-                <td>${data['521824358']} ${data['442166669'] ? data['442166669'] : ''}</br>${data['703385619']} ${data['634434746']} ${data['892050548']}</td>
-                <td>${data.Connect_ID}</td>
-                <td>${verificationConversion[[data['821247024']]]}</td>
-                <td>${data['912301837'] === 208325815 || data['912301837'] === 622008261 || data['912301837'] === 458508122 ? `<i class="fas fa-2x fa-check"></i>` :  `<i class="fas fa-2x fa-times"></i>`}</td>
+                ${tdTemplate}
                 <td>
                     <button class="btn btn-outline-primary text-nowrap" data-check-in-btn-connect-id=${data.Connect_ID} data-check-in-btn-uid=${data.state.uid}>${!isCheckedIn ? `Go to Check-In` : `Go to Check-Out`}</button>
                 </td>
@@ -198,19 +202,12 @@ export const searchResults = (result) => {
                 </td>
             </tr>
         `
-        } else if (getWorflow() === 'clinical') {
+        } else if (getWorkflow() === 'clinical') {
             template += `
             <tr>
-                <td>${data['996038075']}</td>
-                <td>${data['399159511']}</td>
-                <td>${data['231676651']}</td>
-                <td>${data['564964481']}/${data['795827569']}/${data['544150384']}</td>
-                <td>${data['521824358']} ${data['442166669'] ? data['442166669'] : ''}</br>${data['703385619']} ${data['634434746']} ${data['892050548']}</td>
-                <td>${data.Connect_ID}</td>
-                <td>${verificationConversion[[data['821247024']]]}</td>
-                <td>${data['912301837'] === 208325815 || data['912301837'] === 622008261 || data['912301837'] === 458508122 ? `<i class="fas fa-2x fa-check"></i>` :  `<i class="fas fa-2x fa-times"></i>`}</td>
+                ${tdTemplate}
                 <td>
-                    <button class="btn btn-outline-primary text-nowrap" data-clinical-specimen-link-connect-id=${data.Connect_ID}>Specimen Link</button>
+                    <button class="btn btn-outline-primary text-nowrap" data-specimen-link-connect-id=${data.Connect_ID}>Specimen Link</button>
                 </td>
             </tr>
         ` 

--- a/src/pages/finalize.js
+++ b/src/pages/finalize.js
@@ -1,4 +1,4 @@
-import { removeActiveClass, generateBarCode, visitType, getSiteTubesLists, getWorflow, getCheckedInVisit, updateSpecimen } from "./../shared.js";
+import { removeActiveClass, generateBarCode, visitType, getSiteTubesLists, getWorkflow, getCheckedInVisit, updateSpecimen } from "./../shared.js";
 import { addEventFinalizeForm, addEventFinalizeFormCntd, addEventReturnToCollectProcess } from "./../events.js";
 import {searchTemplate} from "./dashboard.js";
 
@@ -19,7 +19,7 @@ export const finalizeTemplate = (data, specimenData) => {
                 <div class="row"><h5>${data['996038075']}, ${data['399159511']}</h5></div>
                 <div class="row">Connect ID: <svg id="connectIdBarCode"></svg></div>
                 <div class="row">Collection ID: ${specimenData['820476880']}</div>
-                <div class="row">Collection ID Link Date/Time: ${getWorflow() === 'research' ? new Date(specimenData['678166505']).toLocaleString(): new Date(specimenData['915838974']).toLocaleString()}</div>
+                <div class="row">Collection ID Link Date/Time: ${getWorkflow() === 'research' ? new Date(specimenData['678166505']).toLocaleString(): new Date(specimenData['915838974']).toLocaleString()}</div>
             </div>
             ${specimenData['331584571'] ? `
                 <div class="ml-auto form-group">
@@ -34,8 +34,8 @@ export const finalizeTemplate = (data, specimenData) => {
                 <thead>
                     <tr>
                         <th>Specimen Type</th>
-                        ${getWorflow() === 'clinical' ? `<th>Received</th>`:`<th>Collected</th>`}
-                        ${getWorflow() === 'research' ? `<th>Reason</th>` : ''}
+                        ${getWorkflow() === 'clinical' ? `<th>Received</th>`:`<th>Collected</th>`}
+                        ${getWorkflow() === 'research' ? `<th>Reason</th>` : ''}
                         <th>Full Specimen ID</th>
                         <th>Deviation</th>
                         <th>Deviation Type</th>
@@ -59,7 +59,7 @@ export const finalizeTemplate = (data, specimenData) => {
                         <tr>
                             <td>${obj.specimenType}</td>
                             <td>${obj.collectionChkBox === true ? `${specimenData[`${obj.concept}`]['593843561'] === 353358909 ? '<i class="fas fa-check"></i>' : '<i class="fas fa-times"></i>'}` : ``}</td>
-                            ${getWorflow() === 'research' ? `<td>${specimenData[`${obj.concept}`]['883732523'] ? notCollectedOptions.filter(option => option.concept == specimenData[`${obj.concept}`]['883732523'])[0].label : ''}</td>` : ''}
+                            ${getWorkflow() === 'research' ? `<td>${specimenData[`${obj.concept}`]['883732523'] ? notCollectedOptions.filter(option => option.concept == specimenData[`${obj.concept}`]['883732523'])[0].label : ''}</td>` : ''}
                             <td>${specimenData[`${obj.concept}`]['593843561'] === 353358909 && specimenData[`${obj.concept}`]['825582494'] ? `${specimenData[`${obj.concept}`]['825582494']}` : '' }</td>
                             <td>${obj.deviationChkBox === true ? `${specimenData[`${obj.concept}`]['678857215'] === 353358909 ? 'Yes' : 'No'}`: ``}</td>
                             <td class="deviation-comments-width">${deviationSelections ? deviationSelections : ''}</td>
@@ -82,7 +82,7 @@ export const finalizeTemplate = (data, specimenData) => {
                 </br>
                 <div class="form-group row">
                     <div class="col-auto">
-                        <button class="btn btn-outline-danger" type="button" data-connect-id="${data.Connect_ID}" id="returnToCollectProcess" data-master-specimen-id="${specimenData['820476880']}">${getWorflow() === 'research' ? 'Return to Collection Data Entry' : 'Return to Collection Data Entry'}</button>
+                        <button class="btn btn-outline-danger" type="button" data-connect-id="${data.Connect_ID}" id="returnToCollectProcess" data-master-specimen-id="${specimenData['820476880']}">${getWorkflow() === 'research' ? 'Return to Collection Data Entry' : 'Return to Collection Data Entry'}</button>
                     </div>
                     <div class="ml-auto">
                         <button class="btn btn-outline-warning" data-connect-id="${data.Connect_ID}" data-master-specimen-id="${specimenData['820476880']}" type="button" id="finalizedSaveExit">Exit</button>

--- a/src/pages/specimen.js
+++ b/src/pages/specimen.js
@@ -1,4 +1,4 @@
-import { addEventBarCodeScanner, collectionSettings, generateBarCode, getWorflow, removeActiveClass, siteLocations, visitType, getCheckedInVisit, getSiteAcronym, numericInputValidator, getSiteCode, searchSpecimen, collectionInputValidator, addSelectionEventListener } from "./../shared.js";
+import { addEventBarCodeScanner, collectionSettings, generateBarCode, getWorkflow, removeActiveClass, siteLocations, visitType, getCheckedInVisit, getSiteAcronym, numericInputValidator, getSiteCode, searchSpecimen, collectionInputValidator, addSelectionEventListener } from "./../shared.js";
 import { addEventSpecimenLinkForm, addEventClinicalSpecimenLinkForm, addEventClinicalSpecimenLinkForm2, addEventNavBarParticipantCheckIn, addEventBackToSearch } from "./../events.js";
 import { masterSpecimenIDRequirement } from "../tubeValidation.js";
 
@@ -9,13 +9,12 @@ export const specimenTemplate = async (data, formData) => {
     navBarBtn?.classList.remove('disabled');
     navBarBtn?.classList.add('active');
 
-    // get rid of all this
     const isSpecimenLinkForm2 = !!formData;
     formData = formData ? formData : {};
     formData['siteAcronym'] = getSiteAcronym();
     formData['827220437'] = parseInt(getSiteCode());
 
-    const workflow = getWorflow() ?? localStorage.getItem('workflow');
+    const workflow = getWorkflow();
     const locationSelection = JSON.parse(localStorage.getItem('selections'))?.specimenLink_location;
 
     let template = `
@@ -122,7 +121,7 @@ export const specimenTemplate = async (data, formData) => {
                 })
 
                 template += `</select>`;
-    template +=`</div>`
+        template += `</div>`;
         template += `
             <div class="form-group row">
                 <label class="col-md-4 col-form-label" for="accessionID1">Scan Blood Accession ID:</label>

--- a/src/shared.js
+++ b/src/shared.js
@@ -276,9 +276,16 @@ export const performSearch = async (query) => {
     hideAnimation();
     const verifiedParticipants = response.data.filter(dt => dt['821247024'] === 197316935);
 
-    if (response.code === 200 && verifiedParticipants.length > 0) {searchResults(verifiedParticipants);
+    if (response.code === 200 && verifiedParticipants.length > 0) {
+      searchResults(verifiedParticipants);
     } else if (response.code === 200 && verifiedParticipants.length === 0) {
-        showNotifications({title: 'Not found', body: 'The participant with entered search criteria not found!'}, true);
+      showNotifications(
+        {
+          title: 'Not found',
+          body: 'The participant with entered search criteria not found!'
+        },
+        true
+      );
     }
 }
 


### PR DESCRIPTION
This PR fixes issue #608(https://github.com/episphere/connect/issues/608). Below are the details:
- Fixed issue #608: possible of sending multiple notification emails for clinical biospecimen survey.
- Introduced a minimal state manager for easier track of the state data of the app.
- Removed some code that are either commented out or logically not used.
- Added documentation to functions for clarity.
- Renamed variable for clarity: getVerifiedParticipants -> `verifiedParticipants`
- Renamed functions for clarity: getWorflow -> `getWorkflow`, proccedToSpecimenPage -> `proceedToSpecimenPage`