### PR TITLE
BPTL Dashboard: Replaced default date format from 'en-CA' to 'yyyy-mm-dd'

### DIFF
--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -332,7 +332,6 @@ const storePackageReceipt = async (data) => {
         document.getElementById("packageCondition").value = "";
         document.getElementById("receivePackageComments").value = "";
         document.getElementById("dateReceived").value = getCurrentDate();
-        
         document.getElementById("collectionComments").value = "";
         document.getElementById("collectionId").value = "";
         enableCollectionCardFields()
@@ -646,8 +645,11 @@ const addDefaultDateReceived = (getCurrentDate) => {
   else dateReceivedEl.value = ""
 }
 
-// returns current date in english canada format ("YYYY-MM-DD")
-const getCurrentDate = () => new Date().toLocaleDateString('en-CA');
+// returns current date in default format ("YYYY-MM-DD")
+const getCurrentDate = () => {
+  const currentDate = new Date();
+  return currentDate.getFullYear() + "-" + currentDate.getMonth() + 1 + "-" + currentDate.getDate()
+}
 
 const uspsFirstThreeNumbersCheck = (input) => {
   const regExp = /^420[0-9]{31}$/

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -648,7 +648,12 @@ const addDefaultDateReceived = (getCurrentDate) => {
 // returns current date in default format ("YYYY-MM-DD")
 const getCurrentDate = () => {
   const currentDate = new Date();
-  return currentDate.getFullYear() + "-" + currentDate.getMonth() + 1 + "-" + currentDate.getDate()
+  return currentDate.getFullYear() + "-" + checkForPadding(parseInt(currentDate.getMonth() + 1)) + "-" + checkForPadding(currentDate.getDate())
+}
+
+const checkForPadding = (input) => { // adds 0 before single month & day to adhere to HTML date format
+  if (input < 10) return `0`+input.toString();
+  else return input;
 }
 
 const uspsFirstThreeNumbersCheck = (input) => {


### PR DESCRIPTION
This PR addresses following issue:
https://github.com/episphere/biospecimen/issues/484

-> Replaced default date format from 'en-CA' to 'yyyy-mm-dd'. Where 'en-ca' would
return date format:date.toLocaleDateString('en-CA');
→ "2012/12/19"

-> As the accepted default value for HTML date input attribute is  'yyyy-mm-dd'
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date

