### PR TITLE
Collection Data Entry Review Page Text Overlap

### DIFF
--- a/src/pages/finalize.js
+++ b/src/pages/finalize.js
@@ -38,7 +38,7 @@ export const finalizeTemplate = (data, specimenData) => {
         </br>
         <div class="row">
             <table id="finalizeTable" class="table-borderless collection-table">
-                <thead>
+                <thead style="margin-bottom: 1rem;">
                     <tr>
                         <th>Specimen Type</th>
                         ${getWorkflow() === 'clinical' ? `<th>Received</th>`:`<th>Collected</th>`}
@@ -61,15 +61,14 @@ export const finalizeTemplate = (data, specimenData) => {
                             if(specimenData[obj.concept]['248868659'][option.concept] === 353358909) deviationSelections.push(option.label);
                         });
                     }
-
                     template += `
-                        <tr>
+                        <tr style="vertical-align: top;">
                             <td>${obj.specimenType}</td>
                             <td>${obj.collectionChkBox === true ? `${specimenData[`${obj.concept}`]['593843561'] === 353358909 ? '<i class="fas fa-check"></i>' : '<i class="fas fa-times"></i>'}` : ``}</td>
                             ${getWorkflow() === 'research' ? `<td>${specimenData[`${obj.concept}`]['883732523'] ? notCollectedOptions.filter(option => option.concept == specimenData[`${obj.concept}`]['883732523'])[0].label : ''}</td>` : ''}
                             <td>${specimenData[`${obj.concept}`]['593843561'] === 353358909 && specimenData[`${obj.concept}`]['825582494'] ? `${specimenData[`${obj.concept}`]['825582494']}` : '' }</td>
                             <td>${obj.deviationChkBox === true ? `${specimenData[`${obj.concept}`]['678857215'] === 353358909 ? 'Yes' : 'No'}`: ``}</td>
-                            <td class="deviation-comments-width">${deviationSelections ? deviationSelections : ''}</td>
+                            <td class="deviation-type-width">${deviationSelections ? getDeviationSelections(deviationSelections) : ''}</td>
                             <td class="deviation-comments-width">${specimenData[`${obj.concept}`]['536710547'] ? specimenData[`${obj.concept}`]['536710547'] : specimenData[`${obj.concept}`]['338286049'] ? specimenData[`${obj.concept}`]['338286049'] : ''}</td>
                         </tr>
                     `
@@ -214,4 +213,12 @@ export const finalizeTemplate = (data, specimenData) => {
             openedModalId = null;
         }
     }  
+}
+
+const getDeviationSelections = (deviationSelectionsList) => {
+    let deviationsSelectionContent = "";
+    deviationSelectionsList.forEach( (deviationSelection, index) => {
+        deviationsSelectionContent += (index !== deviationSelectionsList.length - 1) ? `${deviationSelection} <br><br>` : `${deviationSelection}`;
+    })
+    return deviationsSelectionContent;
 }

--- a/src/pages/finalize.js
+++ b/src/pages/finalize.js
@@ -218,7 +218,7 @@ export const finalizeTemplate = (data, specimenData) => {
 const getDeviationSelections = (deviationSelectionsList) => {
     let deviationsSelectionContent = "";
     deviationSelectionsList.forEach( (deviationSelection, index) => {
-        deviationsSelectionContent += (index !== deviationSelectionsList.length - 1) ? `${deviationSelection} <br><br>` : `${deviationSelection}`;
+        deviationsSelectionContent += (index !== deviationSelectionsList.length - 1) ? `${deviationSelection}, <br>` : `${deviationSelection}`;
     })
     return deviationsSelectionContent;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -302,8 +302,14 @@ canvas.drawing, canvas.drawingBuffer {
     padding-bottom: 4px;
 }
 
-.deviation-comments-width {
+.deviation-comments-width,
+.deviation-type-width {
     max-width: 120px;
+    word-wrap: break-word;
+}
+
+#finalizeTable tr td {
+    padding: 1rem 0;
 }
 
 .active {


### PR DESCRIPTION
The following changes are for [issue#629](https://github.com/episphere/connect/issues/629):

- Removed text overlap by creating a `getDeviationSelections` function to add text with line breaks and keep commas
- Added inline css styling and added to external css file to add padding to Collection Data Entry Review Page table rows/cells

**Before Image**
![229123559-1a5f65e0-6b29-4321-abf4-1c65ad2be898](https://user-images.githubusercontent.com/33293205/229227643-a7ae02e3-9747-499e-ae48-c4de4e8f4e52.png)


**After Image**
<img width="1316" alt="Screenshot 2023-04-03 at 11 12 57 AM" src="https://user-images.githubusercontent.com/33293205/229577459-804d1675-6510-49e8-b740-bd58ae3b7988.png">

