### PR TITLE
Give Henry Ford access to Development Clinical Dashboard

### DIFF
--- a/src/pages/welcome.js
+++ b/src/pages/welcome.js
@@ -25,7 +25,7 @@ IMPORTANT - DO NOT PUSH THIS DEV CHANGE TO STAGE/PROD, HFHS SHOULD ONLY HAVE RES
 Removed 'HFHS' from researchSiteArray to give HFHS access to both research/clinical in dev only
 */ 
 const clinicalSiteArray = ['KPNW', 'KPCO', 'KPHI', 'KPGA'];
-const researchSiteArray = ['MFC', 'UCM', 'HP', 'HFHS', 'SFH'];
+const researchSiteArray = ['MFC', 'UCM', 'HP', 'SFH'];
 
 const welcomeScreenTemplate = (name, data, auth, route) => {
     let template = '';

--- a/src/pages/welcome.js
+++ b/src/pages/welcome.js
@@ -21,24 +21,17 @@ export const welcomeScreen = async (auth, route) => {
 }
 
 const clinicalSiteArray = ['KPNW', 'KPCO', 'KPHI', 'KPGA'];
-const researchSiteArray = ['MFC', 'UCM', 'HP', 'HFHS', 'SFH'];
+const researchSiteArray = ['MFC', 'UCM', 'HP', 'SFH'];
 
 const welcomeScreenTemplate = (name, data, auth, route) => {
     let template = '';
     let dashboardSelectionStr = '';
 
-    if (location.host !== urls.stage || location.host !== urls.prod) {
-        clinicalSiteArray.push('HFHS');
+    if (location.host === urls.stage || location.host === urls.prod) {
+        researchSiteArray.push('HFHS');
     }
     
-    if (clinicalSiteArray.includes(data.siteAcronym) && researchSiteArray.includes(data.siteAcronym) || !clinicalSiteArray.includes(data.siteAcronym) && !researchSiteArray.includes(data.siteAcronym)) {
-        dashboardSelectionStr = `
-            <select required class="col form-control" id="dashboardSelection">
-                <option value="">-- Select Dashboard --</option>
-                <option value="clinical">Clinical Dashboard</option>
-                <option value="research">Research Dashboard</option>
-            </select>`;
-    } else if (clinicalSiteArray.includes(data.siteAcronym)) {
+    if (clinicalSiteArray.includes(data.siteAcronym)) {
         dashboardSelectionStr = `                    
             <select required disabled class="col form-control" id="dashboardSelection">
                 <option selected value="clinical">Clinical Dashboard</option>
@@ -47,6 +40,13 @@ const welcomeScreenTemplate = (name, data, auth, route) => {
         dashboardSelectionStr = `
             <select required disabled class="col form-control" id="dashboardSelection">
                 <option selected value="research">Research Dashboard</option>
+            </select>`;
+    } else {
+        dashboardSelectionStr = `
+            <select required class="col form-control" id="dashboardSelection">
+                <option value="">-- Select Dashboard --</option>
+                <option value="clinical">Clinical Dashboard</option>
+                <option value="research">Research Dashboard</option>
             </select>`;
     }
 

--- a/src/pages/welcome.js
+++ b/src/pages/welcome.js
@@ -20,6 +20,10 @@ export const welcomeScreen = async (auth, route) => {
     welcomeScreenTemplate(name || response.data.email, response.data, auth, route);
 }
 
+/*
+IMPORTANT - DO NOT PUSH THIS DEV CHANGE TO STAGE/PROD, HFHS SHOULD ONLY HAVE RESEARCH DASHBOARD ACCESS IN STAGE/PROD
+Removed 'HFHS' from researchSiteArray to give HFHS access to both research/clinical in dev only
+*/ 
 const clinicalSiteArray = ['KPNW', 'KPCO', 'KPHI', 'KPGA'];
 const researchSiteArray = ['MFC', 'UCM', 'HP', 'HFHS', 'SFH'];
 

--- a/src/pages/welcome.js
+++ b/src/pages/welcome.js
@@ -27,7 +27,7 @@ const welcomeScreenTemplate = (name, data, auth, route) => {
     let template = '';
     let dashboardSelectionStr = '';
 
-    if(location.host !== urls.stage || location.host !== urls.prod) {
+    if (location.host !== urls.stage || location.host !== urls.prod) {
         clinicalSiteArray.push('HFHS');
     }
 

--- a/src/pages/welcome.js
+++ b/src/pages/welcome.js
@@ -27,11 +27,12 @@ const welcomeScreenTemplate = (name, data, auth, route) => {
     let template = '';
     let dashboardSelectionStr = '';
 
+    console.log("data", data)
     if (location.host !== urls.stage || location.host !== urls.prod) {
         clinicalSiteArray.push('HFHS');
     }
-
-    if (clinicalSiteArray.includes(data.siteAcronym) && researchSiteArray.includes(data.siteAcronym)) {
+    
+    if (clinicalSiteArray.includes(data.siteAcronym) && researchSiteArray.includes(data.siteAcronym) || !clinicalSiteArray.includes(data.siteAcronym) && !researchSiteArray.includes(data.siteAcronym)) {
         dashboardSelectionStr = `
             <select required class="col form-control" id="dashboardSelection">
                 <option value="">-- Select Dashboard --</option>
@@ -47,13 +48,6 @@ const welcomeScreenTemplate = (name, data, auth, route) => {
         dashboardSelectionStr = `
             <select required disabled class="col form-control" id="dashboardSelection">
                 <option selected value="research">Research Dashboard</option>
-            </select>`;
-    } else {
-        dashboardSelectionStr = `
-            <select required class="col form-control" id="dashboardSelection">
-                <option value="">-- Select Dashboard --</option>
-                <option value="clinical">Clinical Dashboard</option>
-                <option value="research">Research Dashboard</option>
             </select>`;
     }
 

--- a/src/pages/welcome.js
+++ b/src/pages/welcome.js
@@ -21,12 +21,12 @@ export const welcomeScreen = async (auth, route) => {
 }
 
 const clinicalSiteArray = ['KPNW', 'KPCO', 'KPHI', 'KPGA'];
-const researchSiteArray = ['MFC', 'UCM', 'HP', 'HFHS','SFH'];
+const researchSiteArray = ['MFC', 'UCM', 'HP', 'HFHS', 'SFH'];
 
 const welcomeScreenTemplate = (name, data, auth, route) => {
     let template = '';
     let dashboardSelectionStr = '';
-    
+
     if(location.host !== urls.stage || location.host !== urls.prod) {
         clinicalSiteArray.push('HFHS');
     }

--- a/src/pages/welcome.js
+++ b/src/pages/welcome.js
@@ -27,7 +27,6 @@ const welcomeScreenTemplate = (name, data, auth, route) => {
     let template = '';
     let dashboardSelectionStr = '';
 
-    console.log("data", data)
     if (location.host !== urls.stage || location.host !== urls.prod) {
         clinicalSiteArray.push('HFHS');
     }

--- a/src/pages/welcome.js
+++ b/src/pages/welcome.js
@@ -20,18 +20,25 @@ export const welcomeScreen = async (auth, route) => {
     welcomeScreenTemplate(name || response.data.email, response.data, auth, route);
 }
 
-/*
-IMPORTANT - DO NOT PUSH THIS DEV CHANGE TO STAGE/PROD, HFHS SHOULD ONLY HAVE RESEARCH DASHBOARD ACCESS IN STAGE/PROD
-Removed 'HFHS' from researchSiteArray to give HFHS access to both research/clinical in dev only
-*/ 
 const clinicalSiteArray = ['KPNW', 'KPCO', 'KPHI', 'KPGA'];
-const researchSiteArray = ['MFC', 'UCM', 'HP', 'SFH'];
+const researchSiteArray = ['MFC', 'UCM', 'HP', 'HFHS','SFH'];
 
 const welcomeScreenTemplate = (name, data, auth, route) => {
     let template = '';
     let dashboardSelectionStr = '';
+    
+    if(location.host !== urls.stage || location.host !== urls.prod) {
+        clinicalSiteArray.push('HFHS');
+    }
 
-    if (clinicalSiteArray.includes(data.siteAcronym)) {
+    if (clinicalSiteArray.includes(data.siteAcronym) && researchSiteArray.includes(data.siteAcronym)) {
+        dashboardSelectionStr = `
+            <select required class="col form-control" id="dashboardSelection">
+                <option value="">-- Select Dashboard --</option>
+                <option value="clinical">Clinical Dashboard</option>
+                <option value="research">Research Dashboard</option>
+            </select>`;
+    } else if (clinicalSiteArray.includes(data.siteAcronym)) {
         dashboardSelectionStr = `                    
             <select required disabled class="col form-control" id="dashboardSelection">
                 <option selected value="clinical">Clinical Dashboard</option>


### PR DESCRIPTION
Note: Related to prior merged [issue#485](https://github.com/episphere/biospecimen/pull/485)

This PR is related to [issue#627](https://github.com/episphere/connect/issues/627) and addresses the following:
- removed HFHS from `researchSiteArray`, allowing HFHS users in dev to fallback to default Research and Clinical dashboard options
- added url logic to push HFHS to `researchSiteArray` if HFHS user is in stage or prod


