### PR TITLE
Solve cache issue after index.html update

### DIFF
--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -47,5 +47,5 @@ registerRoute(
     'POST'
 );
 
-
-workbox.precaching.precacheAndRoute([{url: 'index.html', revision: `1`}]);
+const indexFileRevision = '20230421';
+workbox.precaching.precacheAndRoute([{url: 'index.html', revision: indexFileRevision}]);


### PR DESCRIPTION
This is to fix the cache issue after index.html changes. It's part of issue as described in [#624](https://github.com/episphere/connect/issues/624)