### PR TITLE
Change caching strategy for index.html

### DIFF
--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -47,5 +47,15 @@ registerRoute(
     'POST'
 );
 
-const indexFileRevision = '20230421';
-workbox.precaching.precacheAndRoute([{url: 'index.html', revision: indexFileRevision}]);
+registerRoute(
+  new RegExp('index.html'),
+  new NetworkFirst({
+    cacheName: 'index-html-cache',
+    plugins: [
+      new ExpirationPlugin({
+        maxEntries: 1,
+        maxAgeSeconds: 7 * 24 * 60 * 60,
+      }),
+    ],
+  })
+);

--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -48,7 +48,7 @@ registerRoute(
 );
 
 registerRoute(
-  new RegExp('index.html$'),
+  /index\.html$/,
   new NetworkFirst({
     cacheName: 'index-html-cache',
     plugins: [

--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -48,7 +48,7 @@ registerRoute(
 );
 
 registerRoute(
-  new RegExp('index.html'),
+  new RegExp('index.html$'),
   new NetworkFirst({
     cacheName: 'index-html-cache',
     plugins: [

--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -51,10 +51,10 @@ registerRoute(
   /index\.html$/,
   new NetworkFirst({
     cacheName: 'index-html-cache',
+    networkTimeoutSeconds: 3,
     plugins: [
-      new ExpirationPlugin({
-        maxEntries: 1,
-        maxAgeSeconds: 7 * 24 * 60 * 60,
+      new CacheableResponsePlugin({
+        statuses: [0, 200],
       }),
     ],
   })


### PR DESCRIPTION
This PR change index.html caching strategy to `NetworkFirst`, to fix the cache issue after index.html changes. It's part of issue as described in [#624](https://github.com/episphere/connect/issues/624)