### PR TITLE
add padding to deviation manifest cells

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -302,6 +302,11 @@ canvas.drawing, canvas.drawingBuffer {
     padding-bottom: 4px;
 }
 
+#finalizeTable .deviation-type-width,
+.deviation-type-cell {
+    padding-right: 1.5rem;
+}
+
 .deviation-comments-width,
 .deviation-type-width {
     max-width: 120px;


### PR DESCRIPTION
This PR is a follow-up to the [issue#629](https://github.com/episphere/connect/issues/629) and addresses the following:
- https://github.com/episphere/connect/issues/629#issuecomment-1527700366

- added padding to the right for all `Deviation Type` cells in the Collection Data Entry Review Page
- added padding to the right for all `Deviation Type` cells in the shipping box manifests, shipping reports manifest, BPTL/ Norma's manifest
- added selector `#finalizeTable .deviation-type-width` to styles.css file