### PR TITLE
Search specimen bptl click manifest

### DIFF
--- a/src/pages/receipts/packagesInTransit.js
+++ b/src/pages/receipts/packagesInTransit.js
@@ -236,7 +236,7 @@ const manifestButton = (allBoxesShippedBySiteAndNotReceived, dataObj, manifestMo
                 trackingNumber,
                 loginSite
             } = parsedModalData;
-            
+
             showAnimation()
             const searchSpecimenByRequestedSiteResponse = await searchSpecimenByRequestedSite(loginSite);
             const searchSpecimenInstituteArray = searchSpecimenByRequestedSiteResponse?.data ?? [];
@@ -286,9 +286,9 @@ const manifestButton = (allBoxesShippedBySiteAndNotReceived, dataObj, manifestMo
                     </div>
                 </div>
             </div>`;
-        manifestModalBodyEl.innerHTML = modalBody;
-        addManifestTableRows(boxNumber, bagIdArr, index, groupSamples, groupScannedBy, searchSpecimenInstituteArray);
-        hideAnimation()
+            manifestModalBodyEl.innerHTML = modalBody;
+            addManifestTableRows(boxNumber, bagIdArr, index, groupSamples, groupScannedBy, searchSpecimenInstituteArray);
+            hideAnimation()
         });
     });
 };

--- a/src/pages/receipts/packagesInTransit.js
+++ b/src/pages/receipts/packagesInTransit.js
@@ -91,7 +91,6 @@ const packagesInTransitTemplate = async (username, auth, route) => {
     // // Returns an array -->  array of siteLocation
     const groupByLoginSiteCidArr = groupByBoxLoginSiteCid(allBoxesShippedBySiteAndNotReceived);
 
-
     const dataObj = {
         sumSamplesArr,
         bagSamplesArr,
@@ -238,11 +237,9 @@ const manifestButton = (allBoxesShippedBySiteAndNotReceived, dataObj, manifestMo
                 loginSite
             } = parsedModalData;
             
-            
             showAnimation()
             const searchSpecimenByRequestedSiteResponse = await searchSpecimenByRequestedSite(loginSite);
             const searchSpecimenInstituteArray = searchSpecimenByRequestedSiteResponse?.data ?? [];
-
 
             modalBody = 
             `<div class="container-fluid">

--- a/src/pages/receipts/packagesInTransit.js
+++ b/src/pages/receipts/packagesInTransit.js
@@ -89,7 +89,7 @@ const packagesInTransitTemplate = async (username, auth, route) => {
     const trackingNumberArr = groupByTrackingNumber(allBoxesShippedBySiteAndNotReceived);
 
     // // Returns an array -->  array of siteLocation
-    const groupByLoginSiteCidArr = groupByBoxLoginSiteCid(allBoxesShippedBySiteAndNotReceived);
+    const groupByLoginSiteCidArr = groupByLoginSiteCid(allBoxesShippedBySiteAndNotReceived);
 
     const dataObj = {
         sumSamplesArr,
@@ -424,7 +424,7 @@ const groupByTrackingNumber = (allBoxesShippedBySiteAndNotReceived) => {
     return arrTrackingNums;
 }
 
-const groupByBoxLoginSiteCid = (allBoxesShippedBySiteAndNotReceived) => {
+const groupByLoginSiteCid = (allBoxesShippedBySiteAndNotReceived) => {
     const boxLoginSiteArr = [];
     allBoxesShippedBySiteAndNotReceived.forEach(box => {
         const boxLoginSite = box[fieldToConceptIdMapping["loginSite"]];

--- a/src/pages/receipts/packagesInTransit.js
+++ b/src/pages/receipts/packagesInTransit.js
@@ -39,11 +39,8 @@ const packagesInTransitTemplate = async (username, auth, route) => {
 
     appState.setState({packagesInTransitDataObject: packagesInTransitDataObject});
 
-
-
-    
     let template = '';
-
+    
     template += `
     ${receiptsNavbar()}
     <div class="container-fluid">
@@ -308,9 +305,6 @@ const groupSamplesArr = (bagsArr) => {
     return arrSamples;
 };
 
-// NESTED GROUP SCANNED BY INDEX***
-// // Returns an array -->  nested array of grouped scanned by names by index
-
 /**
  * Loops through each grouped bag and pushes the scanned by names in each bag to an array
  * @param {array} bagsArr - Array of grouped bags. Ex.[({CXA456873 0009: {…}}), {CXA458003 0008: {…}, CXA458003 0009: {…}}]
@@ -442,7 +436,7 @@ const addManifestTableRows = (boxNumber, bagIdArr, index, groupSamples, searchSp
                         let currTubeDeviationArrayCounter = 0;
 
                         const currFullSpecimenId = currFullSpecimenIdArray[rowIndex];
-                        const currSpecimenComments = getSpecimenComments(searchSpecimenInstituteArray, currFullSpecimenId)
+                        const currSpecimenComments = getSpecimenComments(searchSpecimenInstituteArray, currFullSpecimenId);
 
                         switch (headerName) {
 

--- a/src/pages/receipts/packagesInTransit.js
+++ b/src/pages/receipts/packagesInTransit.js
@@ -535,7 +535,6 @@ const savePackagesInTransitModalData = (packagesInTransitDataObject, index, allB
         date: "",
         location: "",
         boxNumber: "",
-        bagSamplesArr,
         groupSamples: "",
         groupShippedBy: "",
         trackingNumber: "",

--- a/src/shared.js
+++ b/src/shared.js
@@ -866,7 +866,7 @@ export const searchSpecimenInstitute = async () => {
 /**
  * Fetches biospecimen collection data from the database via login site number 
  * @param {number} login site number
- * @returns {object|array} returns a response object if response is 200 or an empty array
+ * @returns {object} returns a response object
  * 
  */
 export const searchSpecimenByRequestedSite = async (requestedSite) => {
@@ -883,7 +883,7 @@ export const searchSpecimenByRequestedSite = async (requestedSite) => {
     }
     else {
         console.error("getSpecimensByRequestedSite's responseObject status code not 200!");
-        return [];
+        return { data:[] };
     }
 }
 

--- a/src/shared.js
+++ b/src/shared.js
@@ -883,7 +883,7 @@ export const searchSpecimenByRequestedSite = async (requestedSite) => {
     }
     else {
         console.error("getSpecimensByRequestedSite's responseObject status code not 200!");
-        return { data:[] };
+        return {data:[]};
     }
 }
 

--- a/src/shared.js
+++ b/src/shared.js
@@ -864,20 +864,19 @@ export const searchSpecimenInstitute = async () => {
 }
 
 /**
- * Fetches biospecimen collection data from the database by site
- * @param {number}
+ * Fetches biospecimen collection data from the database via login site number 
+ * @param {number} login site number
  * @returns {object|array} returns a response object if response is 200 or an empty array
  * 
  */
-export const getSpecimensByRequestedSite = async (requestedSite) => {
+export const searchSpecimenByRequestedSite = async (requestedSite) => {
     const idToken = await getIdToken();
-    const response = await fetch(`${api}api=searchSpecimen&requestedSite=${siteCode}`, {
+    const response = await fetch(`${api}api=searchSpecimen&requestedSite=${requestedSite}`, {
     method: "GET",
     headers: {
         Authorization:"Bearer "+idToken
         }
     });
-
     if (response.status === 200) {
         const responseObject = await response.json();
         return responseObject;

--- a/src/shared.js
+++ b/src/shared.js
@@ -844,7 +844,7 @@ export const removeBag = async(boxId, bags) => {
  * @returns {object|array} returns a response object if response is 200 or an empty array
  * 
  */
-export const searchSpecimenInstitute = async() => {
+export const searchSpecimenInstitute = async () => {
     const idToken = await getIdToken();
     const response = await fetch(`${api}api=searchSpecimen`, {
     method: "GET",
@@ -859,6 +859,31 @@ export const searchSpecimenInstitute = async() => {
     }
     else {
         console.error("searchSpecimenInstitute's responseObject status code not 200!");
+        return [];
+    }
+}
+
+/**
+ * Fetches biospecimen collection data from the database by site
+ * @param {number}
+ * @returns {object|array} returns a response object if response is 200 or an empty array
+ * 
+ */
+export const getSpecimensByRequestedSite = async (requestedSite) => {
+    const idToken = await getIdToken();
+    const response = await fetch(`${api}api=searchSpecimen&requestedSite=${siteCode}`, {
+    method: "GET",
+    headers: {
+        Authorization:"Bearer "+idToken
+        }
+    });
+
+    if (response.status === 200) {
+        const responseObject = await response.json();
+        return responseObject;
+    }
+    else {
+        console.error("getSpecimensByRequestedSite's responseObject status code not 200!");
         return [];
     }
 }


### PR DESCRIPTION
This PR addresses [Add Deviations to Box Manifests - #609](https://github.com/episphere/connect/issues/609
) :

The PR changes will retrieve a JSON response from a requested login site via a button click. A bootstrap modal will render the deviation type and comments manifests for the matching login site of the box shipped.

The PR is linked to https://github.com/episphere/connectFaas/pull/351

Reference [biospecimenAPIs](https://github.com/episphere/connectFaas/pull/351/files#diff-c359139ac64daf8f5ece96e5f36b7847c5c63aae960815984bf13d414b8b76b6R210-R227) in connectFaas Repo

**Updates to the code:**

- created `searchSpecimenByRequestedSite` function for modified searchSpecimen cloud function
- assigned ` searchSpecimenInstituteArray` variable to searchSpecimenByRequestedSiteResponse
- moved `searchSpecimenInstituteArray` variable to button event listener
- added `groupByLoginSiteCid`  function to pass array of login site codes to data obj

**Updates from PR comments and more:**

- import `appState` to use state management
- Reference to some state management usage: 
[save packagesInTransitDataObject to state](https://github.com/episphere/biospecimen/pull/527/files#diff-3b1b3cdfa6b45cd7638f994ae8322d8e2b4e0e5b0b3732e282e7489a7711d5ceR104)
[save packagesInTransitDataModal to state](https://github.com/episphere/biospecimen/pull/527/files#diff-3b1b3cdfa6b45cd7638f994ae8322d8e2b4e0e5b0b3732e282e7489a7711d5ceR554)
[retrieve packagesInTransitDataModal to state](https://github.com/episphere/biospecimen/pull/527/files#diff-3b1b3cdfa6b45cd7638f994ae8322d8e2b4e0e5b0b3732e282e7489a7711d5ceR198)

- created new function [savePackagesInTransitModalData](https://github.com/episphere/biospecimen/pull/527/files#diff-3b1b3cdfa6b45cd7638f994ae8322d8e2b4e0e5b0b3732e282e7489a7711d5ceR522-R555) to move previously stored button data to state manager. 
- new function `savePackagesInTransitModalData` will update `packagesInTransitModalData` in state when button is clicked

- removed unnecessary keys from modal Data obj like `bagIdArr` and `groupScannedBy`
- [remove id attribute from buttons](https://github.com/episphere/biospecimen/pull/527/files#diff-3b1b3cdfa6b45cd7638f994ae8322d8e2b4e0e5b0b3732e282e7489a7711d5ceL170)
- indenting code lines and adding ";"


**More Changes**
- removed redundant Object.keys and reference value in a variable ([reference](https://github.com/episphere/biospecimen/pull/527/files#diff-3b1b3cdfa6b45cd7638f994ae8322d8e2b4e0e5b0b3732e282e7489a7711d5ceR275))
- Added comments to functions and did some refactoring: `groupAllBags`, `countSamplesArr`, `groupSamplesArr`, `groupScannedByArr`, `groupShippedByArr`, `groupBagIdArr`, `groupByTrackingNumber`, `groupByLoginSiteCid`
- Moved functions, packagesInTransitDataObject, and setState before template variable ([reference](https://github.com/episphere/biospecimen/pull/527/files#diff-3b1b3cdfa6b45cd7638f994ae8322d8e2b4e0e5b0b3732e282e7489a7711d5ceR22-R40))