### PR TITLE
remove conditional limiting HFHS dashboard access

### DIFF
--- a/src/pages/welcome.js
+++ b/src/pages/welcome.js
@@ -27,10 +27,6 @@ const welcomeScreenTemplate = (name, data, auth, route) => {
     let template = '';
     let dashboardSelectionStr = '';
 
-    if (location.host === urls.stage || location.host === urls.prod) {
-        researchSiteArray.push('HFHS');
-    }
-    
     if (clinicalSiteArray.includes(data.siteAcronym)) {
         dashboardSelectionStr = `                    
             <select required disabled class="col form-control" id="dashboardSelection">

--- a/src/pages/welcome.js
+++ b/src/pages/welcome.js
@@ -20,19 +20,19 @@ export const welcomeScreen = async (auth, route) => {
     welcomeScreenTemplate(name || response.data.email, response.data, auth, route);
 }
 
-const clinicalSiteArray = ['KPNW', 'KPCO', 'KPHI', 'KPGA'];
-const researchSiteArray = ['MFC', 'UCM', 'HP', 'SFH'];
+const clinicalOnlySiteArray = ['KPNW', 'KPCO', 'KPHI', 'KPGA'];
+const researchOnlySiteArray = ['MFC', 'UCM', 'HP', 'SFH'];
 
 const welcomeScreenTemplate = (name, data, auth, route) => {
     let template = '';
     let dashboardSelectionStr = '';
 
-    if (clinicalSiteArray.includes(data.siteAcronym)) {
+    if (clinicalOnlySiteArray.includes(data.siteAcronym)) {
         dashboardSelectionStr = `                    
             <select required disabled class="col form-control" id="dashboardSelection">
                 <option selected value="clinical">Clinical Dashboard</option>
             </select>`;
-    } else if (researchSiteArray.includes(data.siteAcronym)) {
+    } else if (researchOnlySiteArray.includes(data.siteAcronym)) {
         dashboardSelectionStr = `
             <select required disabled class="col form-control" id="dashboardSelection">
                 <option selected value="research">Research Dashboard</option>


### PR DESCRIPTION
This PR will give HFHS access to both Research and Clinical Dashboard. Previous PR locked HFHS from accessing both Research and Clinical in stage and prod environments.

Renamed variable names:
- from `clinicalSiteArray` to `clinicalOnlySiteArray`
- from `researchSiteArray` to `researchOnlySiteArray`

Related PR: https://github.com/episphere/biospecimen/pull/504

Related Issue: 
- https://github.com/episphere/connect/issues/627