### PR TITLE
Check empty data in response

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -129,7 +129,7 @@ export const addEventsearchSpecimen = () => {
         }
         showAnimation();
         const biospecimen = await searchSpecimen(masterSpecimenId);
-        if (biospecimen.code !== 200) {
+        if (biospecimen.code !== 200 || Object.keys(biospecimen.data).length === 0) {
             hideAnimation();
             showNotifications({ title: 'Not found', body: 'Specimen not found!' }, true)
             return


### PR DESCRIPTION
This PR address issue [#628](https://github.com/episphere/connect/issues/628). Below is detail:
- The update checks empty data in a search response

Note: this PR is related to updates in PR [#368](https://github.com/episphere/connectFaas/pull/368).