### PR TITLE
Issue#643 modify manifest deviation type row spacing

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -3089,7 +3089,7 @@ export const populateBoxManifestTable = (boxId, boxIdAndBagsObj, searchSpecimenI
     let rowCount = 1;
     for (let i = 0; i < bagList.length; i++) {
         let tubes = bagObjects[bagList[i]]['arrElements'];
-        
+
         for (let j = 0; j < tubes.length; j++) {
             const currTube = tubes[j];
             let currRow = currTable.insertRow(rowCount);
@@ -3655,7 +3655,6 @@ export const populateReportManifestTable = (currPage, searchSpecimenInstituteArr
             if (currBox[bags[i]].hasOwnProperty('618036638') && j == 0) {
                 fullScannerName += currBox[bags[i]]['618036638'];
             }
-            console.log("Current tubes length ---", tubes.length)
             addDeviationTypeCommentsContent(searchSpecimenInstituteArray, currTube, currRow, i);
             rowCount += 1;
         }
@@ -3859,7 +3858,7 @@ const addDeviationTypeCommentsContent = (searchSpecimenInstituteArray, currTube,
         deviationTypeCell.classList.add('deviation-type-cell');
         const commentCell = currRow.insertCell(4);
         commentCell.classList.add('comments-cell');
-        
+
         if (acceptedDeviationArray.length >= 1) {
             for (const deviationLabel of acceptedDeviationArray) {
                 deviationString += `${deviationLabel} <br>`;

--- a/src/events.js
+++ b/src/events.js
@@ -3087,17 +3087,18 @@ export const populateBoxManifestTable = (boxId, boxIdAndBagsObj, searchSpecimenI
     let bagObjects = boxIdAndBagsObj[boxId];
     let bagList = Object.keys(bagObjects);
     let rowCount = 1;
-
     for (let i = 0; i < bagList.length; i++) {
         let tubes = bagObjects[bagList[i]]['arrElements'];
-
+        let lastTube = tubes[tubes.length - 1];
+        // console.log("🚀 ~ file: events.js:3094 ~ populateBoxManifestTable ~ isLastTubesIndex:", isLastTubesIndex)
+        
         for (let j = 0; j < tubes.length; j++) {
             const currTube = tubes[j];
+            const isLastTubeIndex = (currTube === lastTube);
             let currRow = currTable.insertRow(rowCount);
             if (j == 0) {
                 currRow.insertCell(0).innerHTML = bagList[i];
-            }
-            else {
+            } else {
                 currRow.insertCell(0).innerHTML = '';
             }
             currRow.insertCell(1).innerHTML = tubes[j]
@@ -3116,7 +3117,7 @@ export const populateBoxManifestTable = (boxId, boxIdAndBagsObj, searchSpecimenI
             if (bagObjects[bagList[i]].hasOwnProperty('618036638') && j == 0) {
                 fullScannerName += bagObjects[bagList[i]]['618036638'];
             }
-            addDeviationTypeCommentsContent(searchSpecimenInstituteArray, currTube, currRow, i)
+            addDeviationTypeCommentsContent(searchSpecimenInstituteArray, currTube, currRow, i, isLastTubeIndex)
             rowCount += 1;
         }
     }
@@ -3630,18 +3631,22 @@ export const populateReportManifestHeader = (currPage) => {
 
 export const populateReportManifestTable = (currPage, searchSpecimenInstituteArray) => {
     const currTable = document.getElementById('boxManifestTable');
-    let bags = Object.keys(currPage['bags']);
-
+    let bags = Object.keys(currPage['bags']);    
     let rowCount = 1;
     for (let i = 0; i < bags.length; i++) {
+        // console.log("bags -----", i ,bags)
+        // let isLastSpecimenBagIndex = (i === bags.length - 1);
+        // console.log("🚀 ~ file: events.js:3641 ~ populateReportManifestTable ~ isLastTubesIndex:", i, isLastSpecimenBagIndex)
         let tubes = currPage['bags'][bags[i]]['arrElements'];
+        let lastTube = tubes[tubes.length - 1];
         for (let j = 0; j < tubes.length; j++) {
             const currTube = tubes[j]
+            const isLastTubeIndex = (currTube === lastTube);
+            // console.log("🚀 ~ file: events.js:3649 ~ populateReportManifestTable ~ isLastTubeIndex:",i, j, isLastTubeIndex, "---", currTube, "---", lastTube)
             let currRow = currTable.insertRow(rowCount);
             if (j == 0) {
                 currRow.insertCell(0).innerHTML = bags[i];
-            }
-            else {
+            } else {
                 currRow.insertCell(0).innerHTML = '';
             }
             currRow.insertCell(1).innerHTML = currTube;
@@ -3659,8 +3664,8 @@ export const populateReportManifestTable = (currPage, searchSpecimenInstituteArr
             if (currBox[bags[i]].hasOwnProperty('618036638') && j == 0) {
                 fullScannerName += currBox[bags[i]]['618036638'];
             }
-
-            addDeviationTypeCommentsContent(searchSpecimenInstituteArray, currTube, currRow, i);
+            console.log("Current tubes length ---", tubes.length)
+            addDeviationTypeCommentsContent(searchSpecimenInstituteArray, currTube, currRow, i, isLastTubeIndex);
             rowCount += 1;
         }
     }
@@ -3852,25 +3857,32 @@ export const getSpecimenComments = (searchSpecimenInstituteArray, currTube) => {
  * @param {string} currTube - current specimen tube id to filter searchSpecimenInstituteArray - Ex. 'CXA321789 0001'
  * @param {object} currRow - current row of the manifest table
  * @param {number} bagsArrayIndex - current index of the bags array
+ * @param {boolean} isLastTubeIndex - boolean to check if the current tube is the last tube in the bags array
 */
 
-const addDeviationTypeCommentsContent = (searchSpecimenInstituteArray, currTube, currRow, bagsArrayIndex) => {
+const addDeviationTypeCommentsContent = (searchSpecimenInstituteArray, currTube, currRow, bagsArrayIndex, isLastTubeIndex) => {
     if (currTube) {
         const acceptedDeviationArray = getSpecimenDeviation(searchSpecimenInstituteArray, currTube);
+        console.log("🚀 ~ file: events.js:3860 ~ addDeviationTypeCommentsContent ~ acceptedDeviationArray:", acceptedDeviationArray)
         const currTubeComments = getSpecimenComments(searchSpecimenInstituteArray, currTube);
         let deviationString = '';
         const deviationTypeCell = currRow.insertCell(3);
         deviationTypeCell.classList.add('deviation-type-cell');
         const commentCell = currRow.insertCell(4);
         commentCell.classList.add('comments-cell');
-
+        
         if (acceptedDeviationArray.length >= 1) {
             for (const deviationLabel of acceptedDeviationArray) {
-                deviationString += `${deviationLabel} <br><br>`;
+                if (isLastTubeIndex || (acceptedDeviationArray.length === 1)) { 
+                    console.log("TESTING -----", (acceptedDeviationArray.length === 1, isLastTubeIndex))
+                    deviationString += `${deviationLabel} <br>`;
+                } else {
+                    deviationString += `${deviationLabel} <br><br>`;
+                }
             }
             deviationTypeCell.innerHTML = deviationString;
         } else {
-            deviationTypeCell.innerHTML = `<br><br>`;
+            deviationTypeCell.innerHTML = `<br>`;
         }
         commentCell.innerHTML = currTubeComments;
     }

--- a/src/events.js
+++ b/src/events.js
@@ -3864,6 +3864,8 @@ const addDeviationTypeCommentsContent = (searchSpecimenInstituteArray, currTube,
     if (currTube) {
         const acceptedDeviationArray = getSpecimenDeviation(searchSpecimenInstituteArray, currTube);
         console.log("🚀 ~ file: events.js:3860 ~ addDeviationTypeCommentsContent ~ acceptedDeviationArray:", acceptedDeviationArray)
+        const lastAcceptedDeviation = acceptedDeviationArray[acceptedDeviationArray.length - 1];
+        console.log("🚀 ~ file: events.js:3868 ~ addDeviationTypeCommentsContent ~ lastAcceptedDeviation:", lastAcceptedDeviation)
         const currTubeComments = getSpecimenComments(searchSpecimenInstituteArray, currTube);
         let deviationString = '';
         const deviationTypeCell = currRow.insertCell(3);
@@ -3873,12 +3875,30 @@ const addDeviationTypeCommentsContent = (searchSpecimenInstituteArray, currTube,
         
         if (acceptedDeviationArray.length >= 1) {
             for (const deviationLabel of acceptedDeviationArray) {
-                if (isLastTubeIndex || (acceptedDeviationArray.length === 1)) { 
-                    console.log("TESTING -----", (acceptedDeviationArray.length === 1, isLastTubeIndex))
-                    deviationString += `${deviationLabel} <br>`;
-                } else {
-                    deviationString += `${deviationLabel} <br><br>`;
-                }
+                const isLastDeviation = (deviationLabel === lastAcceptedDeviation);
+                // if (isLastTubeIndex || (acceptedDeviationArray.length === 1)) { 
+                //     console.log("TESTING -----", (acceptedDeviationArray.length === 1, isLastTubeIndex))
+                //     deviationString += `${deviationLabel} <br>`;
+                // } else {
+                //     deviationString += `${deviationLabel} <br><br>`;
+                // }
+                
+                /*
+                only create a new line if the current tube is the last tube in the bags array and the current deviation is the last deviation in the accepted deviation array
+
+                isLastTubeIndex - boolean to check if the current tube is the last tube in the bags array
+                isLastDeviation - boolean to check if the current deviation is the last deviation in the accepted deviation array
+                */
+
+                // more than one deviation type, the last deviation type will have an extra line break, and the last tube will have no line break
+                // Full specimen Id has more than one deviation type, last deviation type row will have an extra line break (more spacing). Also cannot be the last tube in the Specimen Bag ID.
+                // if (!isLastTubeIndex && isLastDeviation && acceptedDeviationArray.length > 1) {
+                //     deviationString += `${deviationLabel} <br><br>`;
+                // } else {
+                //     deviationString += `${deviationLabel} <br>`;
+                // }
+
+                deviationString += `${deviationLabel} <br>`;
             }
             deviationTypeCell.innerHTML = deviationString;
         } else {
@@ -3886,7 +3906,7 @@ const addDeviationTypeCommentsContent = (searchSpecimenInstituteArray, currTube,
         }
         commentCell.innerHTML = currTubeComments;
     }
-    if (bagsArrayIndex % 2 == 0) {
+    if (bagsArrayIndex % 2 === 0) {
         currRow.style['background-color'] = 'lightgrey';
     }
 }

--- a/src/events.js
+++ b/src/events.js
@@ -3089,12 +3089,9 @@ export const populateBoxManifestTable = (boxId, boxIdAndBagsObj, searchSpecimenI
     let rowCount = 1;
     for (let i = 0; i < bagList.length; i++) {
         let tubes = bagObjects[bagList[i]]['arrElements'];
-        let lastTube = tubes[tubes.length - 1];
-        // console.log("🚀 ~ file: events.js:3094 ~ populateBoxManifestTable ~ isLastTubesIndex:", isLastTubesIndex)
         
         for (let j = 0; j < tubes.length; j++) {
             const currTube = tubes[j];
-            const isLastTubeIndex = (currTube === lastTube);
             let currRow = currTable.insertRow(rowCount);
             if (j == 0) {
                 currRow.insertCell(0).innerHTML = bagList[i];
@@ -3117,7 +3114,7 @@ export const populateBoxManifestTable = (boxId, boxIdAndBagsObj, searchSpecimenI
             if (bagObjects[bagList[i]].hasOwnProperty('618036638') && j == 0) {
                 fullScannerName += bagObjects[bagList[i]]['618036638'];
             }
-            addDeviationTypeCommentsContent(searchSpecimenInstituteArray, currTube, currRow, i, isLastTubeIndex)
+            addDeviationTypeCommentsContent(searchSpecimenInstituteArray, currTube, currRow, i)
             rowCount += 1;
         }
     }
@@ -3634,15 +3631,9 @@ export const populateReportManifestTable = (currPage, searchSpecimenInstituteArr
     let bags = Object.keys(currPage['bags']);    
     let rowCount = 1;
     for (let i = 0; i < bags.length; i++) {
-        // console.log("bags -----", i ,bags)
-        // let isLastSpecimenBagIndex = (i === bags.length - 1);
-        // console.log("🚀 ~ file: events.js:3641 ~ populateReportManifestTable ~ isLastTubesIndex:", i, isLastSpecimenBagIndex)
         let tubes = currPage['bags'][bags[i]]['arrElements'];
-        let lastTube = tubes[tubes.length - 1];
         for (let j = 0; j < tubes.length; j++) {
             const currTube = tubes[j]
-            const isLastTubeIndex = (currTube === lastTube);
-            // console.log("🚀 ~ file: events.js:3649 ~ populateReportManifestTable ~ isLastTubeIndex:",i, j, isLastTubeIndex, "---", currTube, "---", lastTube)
             let currRow = currTable.insertRow(rowCount);
             if (j == 0) {
                 currRow.insertCell(0).innerHTML = bags[i];
@@ -3665,7 +3656,7 @@ export const populateReportManifestTable = (currPage, searchSpecimenInstituteArr
                 fullScannerName += currBox[bags[i]]['618036638'];
             }
             console.log("Current tubes length ---", tubes.length)
-            addDeviationTypeCommentsContent(searchSpecimenInstituteArray, currTube, currRow, i, isLastTubeIndex);
+            addDeviationTypeCommentsContent(searchSpecimenInstituteArray, currTube, currRow, i);
             rowCount += 1;
         }
     }
@@ -3857,15 +3848,11 @@ export const getSpecimenComments = (searchSpecimenInstituteArray, currTube) => {
  * @param {string} currTube - current specimen tube id to filter searchSpecimenInstituteArray - Ex. 'CXA321789 0001'
  * @param {object} currRow - current row of the manifest table
  * @param {number} bagsArrayIndex - current index of the bags array
- * @param {boolean} isLastTubeIndex - boolean to check if the current tube is the last tube in the bags array
 */
 
-const addDeviationTypeCommentsContent = (searchSpecimenInstituteArray, currTube, currRow, bagsArrayIndex, isLastTubeIndex) => {
+const addDeviationTypeCommentsContent = (searchSpecimenInstituteArray, currTube, currRow, bagsArrayIndex) => {
     if (currTube) {
         const acceptedDeviationArray = getSpecimenDeviation(searchSpecimenInstituteArray, currTube);
-        console.log("🚀 ~ file: events.js:3860 ~ addDeviationTypeCommentsContent ~ acceptedDeviationArray:", acceptedDeviationArray)
-        const lastAcceptedDeviation = acceptedDeviationArray[acceptedDeviationArray.length - 1];
-        console.log("🚀 ~ file: events.js:3868 ~ addDeviationTypeCommentsContent ~ lastAcceptedDeviation:", lastAcceptedDeviation)
         const currTubeComments = getSpecimenComments(searchSpecimenInstituteArray, currTube);
         let deviationString = '';
         const deviationTypeCell = currRow.insertCell(3);
@@ -3875,29 +3862,6 @@ const addDeviationTypeCommentsContent = (searchSpecimenInstituteArray, currTube,
         
         if (acceptedDeviationArray.length >= 1) {
             for (const deviationLabel of acceptedDeviationArray) {
-                const isLastDeviation = (deviationLabel === lastAcceptedDeviation);
-                // if (isLastTubeIndex || (acceptedDeviationArray.length === 1)) { 
-                //     console.log("TESTING -----", (acceptedDeviationArray.length === 1, isLastTubeIndex))
-                //     deviationString += `${deviationLabel} <br>`;
-                // } else {
-                //     deviationString += `${deviationLabel} <br><br>`;
-                // }
-                
-                /*
-                only create a new line if the current tube is the last tube in the bags array and the current deviation is the last deviation in the accepted deviation array
-
-                isLastTubeIndex - boolean to check if the current tube is the last tube in the bags array
-                isLastDeviation - boolean to check if the current deviation is the last deviation in the accepted deviation array
-                */
-
-                // more than one deviation type, the last deviation type will have an extra line break, and the last tube will have no line break
-                // Full specimen Id has more than one deviation type, last deviation type row will have an extra line break (more spacing). Also cannot be the last tube in the Specimen Bag ID.
-                // if (!isLastTubeIndex && isLastDeviation && acceptedDeviationArray.length > 1) {
-                //     deviationString += `${deviationLabel} <br><br>`;
-                // } else {
-                //     deviationString += `${deviationLabel} <br>`;
-                // }
-
                 deviationString += `${deviationLabel} <br>`;
             }
             deviationTypeCell.innerHTML = deviationString;

--- a/src/pages/receipts/packagesInTransit.js
+++ b/src/pages/receipts/packagesInTransit.js
@@ -405,7 +405,6 @@ const addManifestTableRows = (boxNumber, bagIdArr, index, groupSamples, searchSp
         // currFullSpecimenIdArray - Ex. [CXA426800 0001, CXA426800 0002, ...]
         const currSpecimenBagId = currBagIdArray[i];
         const currFullSpecimenIdArray = groupSamples[i];
-        const lastCurrFullSpecimenId = currFullSpecimenIdArray[currFullSpecimenIdArray.length - 1];
         const fullSpecimenIdDeviationObj = {};
         
 
@@ -423,7 +422,6 @@ const addManifestTableRows = (boxNumber, bagIdArr, index, groupSamples, searchSp
                     const tableRowEl = document.createElement('tr');
                     if (i % 2 === 0) tableRowEl.style.backgroundColor = 'lightgrey';
                     const currFullSpecimenId = currFullSpecimenIdArray[rowIndex];
-                    const isLastTubeIndex = (currFullSpecimenId === lastCurrFullSpecimenId);
                     const currSpecimenComments = getSpecimenComments(searchSpecimenInstituteArray, currFullSpecimenId);
 
                     for (let tableModalHeaderIndex = 0; tableModalHeaderIndex < tableModalHeaderColumnNameArray.length; tableModalHeaderIndex++) { 

--- a/src/pages/receipts/packagesInTransit.js
+++ b/src/pages/receipts/packagesInTransit.js
@@ -465,11 +465,7 @@ const addManifestTableRows = (boxNumber, bagIdArr, index, groupSamples, searchSp
                                 if (currDeviationTypeArray.length > 0) {
                                     let deviationTextContent = '';
                                     for (const currDeviationType of currDeviationTypeArray) {
-                                        if (currDeviationTypeArray.length === 1 || isLastTubeIndex) {
-                                            deviationTextContent += `${currDeviationType} <br>`;
-                                        } else {
-                                            deviationTextContent += `${currDeviationType} <br><br>`;
-                                        }
+                                        deviationTextContent += `${currDeviationType} <br>`;
                                     }
                                     cellEl.classList.add("deviation-type-cell");
                                     cellEl.innerHTML = deviationTextContent;

--- a/src/pages/receipts/packagesInTransit.js
+++ b/src/pages/receipts/packagesInTransit.js
@@ -38,7 +38,6 @@ const packagesInTransitTemplate = async (username, auth, route) => {
     };
 
     appState.setState({packagesInTransitDataObject: packagesInTransitDataObject});
-
     let template = '';
     
     template += `
@@ -68,7 +67,7 @@ const packagesInTransitTemplate = async (username, auth, route) => {
     </div>
 
     <div class="modal fade" id="manifestModal" tabindex="-1" aria-labelledby="manifestModalLabel" aria-hidden="true">
-        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-dialog modal-xl modal-dialog-scrollable">
             <div class="modal-content">
                 <div>
                     <button style="font-size:2.5rem;padding:1rem;" type="button" class="close" data-dismiss="modal" aria-label="Close">
@@ -91,11 +90,11 @@ const packagesInTransitTemplate = async (username, auth, route) => {
 /**
  * Returns an array of shipped box items but not yet received and sorts the box items by most recent date
  * @param {array} boxes - array of all boxes from getAllBoxes(`bptl`) function
- * @returns 
+ * @returns sorted array of boxes by most recent date
  */
 export const getRecentBoxesShippedBySiteNotReceived = (boxes) => {
   // boxes are from searchBoxes endpoint
-    if(boxes.length === 0) return [];
+    if (boxes.length === 0) return [];
     const filteredBoxesBySubmitShipmentTimeAndNotReceived = boxes.filter(item => item[fieldToConceptIdMapping["shippingShipDate"]] && !item[fieldToConceptIdMapping["siteShipmentDateReceived"]])
     const sortBoxesBySubmitShipmentTime = filteredBoxesBySubmitShipmentTimeAndNotReceived.sort((a,b) => b[fieldToConceptIdMapping["shippingShipDate"]].localeCompare(a[fieldToConceptIdMapping["shippingShipDate"]]))
     return sortBoxesBySubmitShipmentTime;
@@ -167,7 +166,6 @@ const createPackagesInTransitRows = (boxes, sumSamplesArr) => {
 }
 
 const manifestButton = (allBoxesShippedBySiteAndNotReceived, bagIdArr, manifestModalBodyEl) => {
-
     const buttons = document.getElementsByClassName("manifest-button");
     const packagesInTransitDataObject = appState.getState().packagesInTransitDataObject;
 
@@ -254,7 +252,7 @@ const groupAllBags = (allBoxesShippedBySiteAndNotReceived) => {
     const arrBoxes = [];
     allBoxesShippedBySiteAndNotReceived.forEach((box) => {
         const specimenBags = Object.keys(box.bags);
-        if(specimenBags.length) {
+        if (specimenBags.length) {
             arrBoxes.push(box.bags);
         }
     });
@@ -282,7 +280,6 @@ const countSamplesArr = (bagsArr) => {
     return arrNumSamples;
 };
 
-// // Returns an array --> nested array of grouped samples by index
 /**
  * Loops through each grouped bag and pushes the samples/specimens in each bag to an array
  * @param {array} bagsArr - Array of grouped bags. Ex.[({CXA456873 0009: {…}}), {CXA458003 0008: {…}, CXA458003 0009: {…}}]
@@ -319,10 +316,9 @@ const groupScannedByArr = (bagsArr) => {
 
         bagKeys.forEach((bagKey) => {
             const currentBag = bag[bagKey];
-            if(currentBag[scannedByFirstName] && currentBag[scannedByLastName]) {
+            if (currentBag[scannedByFirstName] && currentBag[scannedByLastName]) {
                 groupNames.push(currentBag[scannedByFirstName] + " " + currentBag[scannedByLastName]);
-            }
-            else if(currentBag[scannedByFirstName]) {
+            } else if (currentBag[scannedByFirstName]) {
                 groupNames.push(currentBag[scannedByFirstName]);
             }
         });
@@ -344,13 +340,11 @@ const groupShippedByArr = (allBoxesShippedBySiteAndNotReceived) => {
     let shippedByLastName = box[fieldToConceptIdMapping.shippedByLastName]?.trim() ?? ''
     if (shippedByFirstName.length > 0 && shippedByLastName > 0) {
         arrShippedBy.push(shippedByFirstName + " " + shippedByLastName)
-    }
-    else if (shippedByFirstName.length > 0) {
+    } else if (shippedByFirstName.length > 0) {
         arrShippedBy.push(shippedByFirstName)
-    }
-    else arrShippedBy.push("");
+    } else arrShippedBy.push("");
     });
-    return arrShippedBy
+    return arrShippedBy;
 }
 
 /**
@@ -375,7 +369,7 @@ const groupBagIdArr = (bagsArr) => {
 const groupByTrackingNumber = (allBoxesShippedBySiteAndNotReceived) => {
     const arrTrackingNums = []
     allBoxesShippedBySiteAndNotReceived.forEach((box) => {
-        if(box[fieldToConceptIdMapping["shippingTrackingNumber"]]) {
+        if (box[fieldToConceptIdMapping["shippingTrackingNumber"]]) {
             let trackingNumber = box[fieldToConceptIdMapping["shippingTrackingNumber"]]
             arrTrackingNums.push(trackingNumber)
         }
@@ -406,13 +400,14 @@ const addManifestTableRows = (boxNumber, bagIdArr, index, groupSamples, searchSp
     // currBagIdArray - Ex. [CXA426800 0008, CXA426800 0009]
     const currBagIdArray =  bagIdArr[index];
 
-    if (!bagIdArr[index].length) return manifestBody;
-    
+    if (currBagIdArray.length === 0) return manifestBody;
     for (let i = 0; i < currBagIdArray.length; i++) {
         // currFullSpecimenIdArray - Ex. [CXA426800 0001, CXA426800 0002, ...]
-        const currFullSpecimenIdArray = groupSamples[i];
         const currSpecimenBagId = currBagIdArray[i];
+        const currFullSpecimenIdArray = groupSamples[i];
+        const lastCurrFullSpecimenId = currFullSpecimenIdArray[currFullSpecimenIdArray.length - 1];
         const fullSpecimenIdDeviationObj = {};
+        
 
         for (let j = 0; j < currFullSpecimenIdArray.length; j++) {
             const currTube = currFullSpecimenIdArray[j];
@@ -421,22 +416,21 @@ const addManifestTableRows = (boxNumber, bagIdArr, index, groupSamples, searchSp
             let currFullSpecimenIdArrayCounter = 0;
 
             fullSpecimenIdDeviationObj[currTube] = currAcceptedDeviationArray;
-
             if (j === currFullSpecimenIdArray.length - 1) {
                 const tableRowNumber = currFullSpecimenIdArrayLength;
 
                 for (let rowIndex = 0; rowIndex < tableRowNumber; rowIndex++) {
                     const tableRowEl = document.createElement('tr');
-                    if(i % 2 === 0) tableRowEl.style.backgroundColor = 'lightgrey'
-                    
+                    if (i % 2 === 0) tableRowEl.style.backgroundColor = 'lightgrey';
+                    const currFullSpecimenId = currFullSpecimenIdArray[rowIndex];
+                    const isLastTubeIndex = (currFullSpecimenId === lastCurrFullSpecimenId);
+                    const currSpecimenComments = getSpecimenComments(searchSpecimenInstituteArray, currFullSpecimenId);
+
                     for (let tableModalHeaderIndex = 0; tableModalHeaderIndex < tableModalHeaderColumnNameArray.length; tableModalHeaderIndex++) { 
                         const cellEl = document.createElement('td');
                         const headerName = tableModalHeaderColumnNameArray[tableModalHeaderIndex].textContent;
                         const currFullSpecimenIdArrayLength = currFullSpecimenIdArray.length;
                         let currTubeDeviationArrayCounter = 0;
-
-                        const currFullSpecimenId = currFullSpecimenIdArray[rowIndex];
-                        const currSpecimenComments = getSpecimenComments(searchSpecimenInstituteArray, currFullSpecimenId);
 
                         switch (headerName) {
 
@@ -459,8 +453,7 @@ const addManifestTableRows = (boxNumber, bagIdArr, index, groupSamples, searchSp
                                     const currFullSpecimenId = currFullSpecimenIdArray[currFullSpecimenIdArrayCounter];
                                     cellEl.textContent = currFullSpecimenId;
                                     currFullSpecimenIdArrayCounter += 1;
-                                }
-                                else {
+                                } else {
                                     cellEl.textContent = ''
                                 }
                                 break;
@@ -468,17 +461,20 @@ const addManifestTableRows = (boxNumber, bagIdArr, index, groupSamples, searchSp
                             case 'Deviation Type':
                                 const currFullSpecimenId = currFullSpecimenIdArray[rowIndex];
                                 // fullSpecimenIdDeviationObj Ex. { CXA854612 0001:['Hemolsysis Present'],... }
-                                const currDeviationTypeArray = fullSpecimenIdDeviationObj[currFullSpecimenId] ? fullSpecimenIdDeviationObj[currFullSpecimenId] : [];
-                                if (currDeviationTypeArray.length) {
+                                const currDeviationTypeArray = fullSpecimenIdDeviationObj[currFullSpecimenId] ?? [];
+                                if (currDeviationTypeArray.length > 0) {
                                     let deviationTextContent = '';
-                                    for(let currDeviationType of currDeviationTypeArray) {
-                                        deviationTextContent += `${currDeviationType} <br><br>`
+                                    for (const currDeviationType of currDeviationTypeArray) {
+                                        if (currDeviationTypeArray.length === 1 || isLastTubeIndex) {
+                                            deviationTextContent += `${currDeviationType} <br>`;
+                                        } else {
+                                            deviationTextContent += `${currDeviationType} <br><br>`;
+                                        }
                                     }
                                     cellEl.classList.add("deviation-type-cell");
                                     cellEl.innerHTML = deviationTextContent;
                                     currTubeDeviationArrayCounter += 1;
-                                }
-                                else {
+                                } else {
                                     cellEl.textContent = '';
                                 }
                                 break;
@@ -487,8 +483,7 @@ const addManifestTableRows = (boxNumber, bagIdArr, index, groupSamples, searchSp
                                 if (currFullSpecimenIdArrayCounter !== currFullSpecimenIdArrayLength + 1 && currSpecimenComments.length) {
                                     cellEl.classList.add("comments-cell");
                                     cellEl.textContent = currSpecimenComments;
-                                }
-                                else {
+                                } else {
                                     cellEl.textContent = ''
                                 }
                                 break;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -422,19 +422,19 @@ box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
         display: none;
     }
 }
-  .modal-wrapper.visible {
+.modal-wrapper.visible {
     visibility: visible;
     transform: scale(1);
-  }
-  
-  .modal-content {
-    border-radius: 5px;
-    box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
-  }
+}
 
 .modal-content {
-border-radius: 5px;
-box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
+    border-radius: 5px;
+    box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
+}
+
+.modal-content {
+    border-radius: 5px;
+    box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
 }
 
 #boxManifestTable tbody {
@@ -455,4 +455,5 @@ box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
     border-top: unset;
     text-align: center;
     vertical-align: top;
+    padding: 0 0.75rem;
 }


### PR DESCRIPTION
[Issue#643](https://github.com/episphere/connect/issues/643) addresses the following: 
- removed significant row spacing for Deviation Type text from 3 manifests (**BPTL's Packages In Transit**, **Shipping dashboard**, **Shipping Reports**)
- removed double `<br>` element logic that created more spacing than needed

Extra Changes :
- changed bootstrap modal from `lg` to `xl` for BPTL's packages in transit
- moved position of `else` in code
- added strict equality `===` ([Reference](https://github.com/episphere/biospecimen/compare/dev...issue%23643-modify-manifest-deviation-row-spacing?expand=1#diff-aa3209e98840e6d236562086e3c6942a28f0c6beef6897d036367d09cc313c59R3873))

Double line break (Current):
<img width="800" alt="Screenshot 2023-06-09 at 1 31 52 PM" src="https://github.com/episphere/biospecimen/assets/33293205/a6d96936-762f-4962-861f-360674efd97c">


Single line break (Upcoming Change):
<img width="800" alt="Screenshot 2023-06-09 at 1 31 14 PM" src="https://github.com/episphere/biospecimen/assets/33293205/61855720-1594-4753-a7ca-8d1f73d17d48">
