### PR TITLE
BPTL Dashboard: Home Page "BPTL" button not working for BPTL group

### DIFF
--- a/src/pages/welcome.js
+++ b/src/pages/welcome.js
@@ -187,7 +187,7 @@ const navbarThemesSettings = {
 function updateNavbarAfterDashboardSelection() {
   const dashboardSelectElement = document.getElementById('dashboardSelection');
 
-  dashboardSelectElement.addEventListener('change', (event) => {
+  dashboardSelectElement && dashboardSelectElement.addEventListener('change', (event) => {
     const selectedDashboard = event.target.value;
     appState.setState({ dashboardSelection: selectedDashboard });
 


### PR DESCRIPTION
Title^^

This PR addresses following issue: https://github.com/episphere/biospecimen/issues/530

BPTL users couldn't access the dashboard due to this line https://github.com/episphere/biospecimen/pull/508/files#diff-c846b9d20eea36ff9d755a6478845523c5ffd4cbc96b3d2a1a2eb020e7221b53R191. For BPTL users it would return null since they don't have access to Biospecimen dashboard. Added a condition to check if this element is present to prevent it from breaking.
