### PR TITLE
hide noreply emails in Participant Check In page

### DIFF
--- a/src/pages/checkIn.js
+++ b/src/pages/checkIn.js
@@ -45,7 +45,7 @@ export const checkInTemplate = async (data, checkOutFlag) => {
                 <div class="col-md-12">
                     <h5>${data['996038075']}, ${data['399159511']}</h5>
                     <h5>Login Method: ${data['995036844']}</h5>
-                    ${data['421823980'] ? `<h5>User Email: ${data['421823980']}</h5>` : ''}
+                    ${data['421823980'] && !data['421823980'].startsWith('noreply') ? `<h5>User Email: ${data['421823980']}</h5>` : ''}
                     ${data['348474836'] ? `<h5>User Phone: ${data['348474836']}</h5>`: '' }
                 </div>
             </div>


### PR DESCRIPTION
Multiple auth methods included an email workaround where removed login email addresses get written starting with the 'noreply' string. These 'noreply' emails were visible on the checkin screen (biospecimen dashboard). This update hides 'noreply' emails, so as not to cause confusion for users.

Issue:
<img width="1332" alt="Screenshot 2023-07-19 at 9 42 57 AM" src="https://github.com/episphere/biospecimen/assets/93854858/84b1c8c7-3f41-4e4c-b007-aef325713b50">

Fix:
<img width="1347" alt="Screenshot 2023-07-19 at 9 45 47 AM" src="https://github.com/episphere/biospecimen/assets/93854858/7eefa550-eb6b-4529-87b9-b499fad1ceb9">
