### PR TITLE
Biospecimen Dashboard: Replaced first name with preferred name in biospec survey reminders

### DIFF
--- a/src/emailTemplates.js
+++ b/src/emailTemplates.js
@@ -36,7 +36,7 @@ export const baselineEmailTemplate = (data, isClinical) => {
     }
 
     return `
-        Dear ${data['153211406'] !== '' ? data['153211406'] : data['399159511']},
+        Dear ${data['153211406'] || data['399159511']},
         <br/>
         <br/>
         Thank you for donating your samples for the Connect for Cancer Prevention Study! Next, please visit the <a href=${appLocation}>MyConnect app</a> to answer the ${isClinical ? 'Baseline Blood and Urine Sample Survey' : 'Baseline Blood, Urine, and Mouthwash Sample Survey'}. This short survey asks questions about the day that you donated samples, so it is important to complete it as soon as you can.

--- a/src/emailTemplates.js
+++ b/src/emailTemplates.js
@@ -36,7 +36,7 @@ export const baselineEmailTemplate = (data, isClinical) => {
     }
 
     return `
-        Dear ${data['399159511']},
+        Dear ${data['153211406'] !== '' ? data['153211406'] : data['399159511']},
         <br/>
         <br/>
         Thank you for donating your samples for the Connect for Cancer Prevention Study! Next, please visit the <a href=${appLocation}>MyConnect app</a> to answer the ${isClinical ? 'Baseline Blood and Urine Sample Survey' : 'Baseline Blood, Urine, and Mouthwash Sample Survey'}. This short survey asks questions about the day that you donated samples, so it is important to complete it as soon as you can.


### PR DESCRIPTION
Title^^
Note:
Cases where user has no preferred name than utilizes first name.

https://github.com/episphere/connectApp/issues/576

PoC:

Connect_ID: 2808118485
With no preferred name uses first name
![Screenshot 2023-07-21 at 1 11 39 PM](https://github.com/episphere/biospecimen/assets/30497847/16b671bb-2777-4d07-a5c1-2f5d8582b30e)
Email:
![Screenshot 2023-07-21 at 1 09 29 PM](https://github.com/episphere/biospecimen/assets/30497847/ea3cb529-2749-41cf-b816-f5fc081e45cf)

Connect_ID: 2808118485
With preferred name
![Screenshot 2023-07-21 at 1 20 19 PM](https://github.com/episphere/biospecimen/assets/30497847/3a3b87af-a2c3-415a-8be5-fd8438d60732)
Email:
![Screenshot 2023-07-21 at 1 18 42 PM](https://github.com/episphere/biospecimen/assets/30497847/9f7f808d-baad-424e-969d-026e696f39d6)
