### PR TITLE
BSD: Add daily reports page to Reports tab

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,8 @@ import { csvFileReceiptScreen } from "./src/pages/receipts/csvFileReceipt.js";
 import { kitReportsScreen } from "./src/pages/reports/kitReports.js";
 import { collectionIdSearchScreen } from "./src/pages/reports/collectionIdSearch.js";
 import { checkOutReportTemplate } from "./src/pages/checkOutReport.js";
+import { dailyReportTemplate } from "./src/pages/dailyReport.js";
+
 
 
 let auth = '';
@@ -102,6 +104,7 @@ const manageRoutes = async () => {
         else if (route === "#collectionidsearch") collectionIdSearchScreen(auth, route);
         else if (route === "#reports") reportsQuery(auth, route);
         else if (route === "#checkoutreport") checkOutReportTemplate(auth, route);
+        else if (route === "#dailyreport") dailyReportTemplate(auth, route);
         else if (route === "#manage_users") manageUsers(auth, route);
         else if (route === "#sign_out") signOut();
         else window.location.hash = "#welcome";

--- a/src/fieldToConceptIdMapping.js
+++ b/src/fieldToConceptIdMapping.js
@@ -209,6 +209,52 @@ export default {
 
     clinicalSite: {
         bloodCollected: 693370086
+    },
+
+    collectionLocationMapping: {
+        777644826 : 'UC-DCAM',
+        692275326 : 'Marshfield',
+        813701399 : 'Weston',
+        698283667 : 'Lake Hallie',
+        834825425 : 'HP Research Clinic',
+        736183094 : 'HFH K-13 Research Clinic',
+        886364332 : 'HFH Cancer Pavilion Research Clinic',
+        706927479 : 'HFH Livonia Research Clinic',
+        589224449 : 'Sioux Falls Imagenetics',
+        145191545 : 'Ingalls Harvey',
+        489380324 : 'River East',
+        120264574 : 'South Loop',
+        691714762 : 'Rice Lake',
+        487512085 : 'Wisconsin Rapids',
+        983848564 : 'Colby Abbotsford',
+        261931804 : 'Minocqua',
+        665277300 : 'Merrill',
+        111111111 : 'NIH/NCI',
+        807835037 : 'Other'
+    },
+
+    nameToKeyObj : {
+        'ucDcam': 777644826,
+        'marshfield': 692275326,
+        'weston': 813701399,
+        'lakeHallie': 698283667,
+        'hpRC': 834825425,
+        'hfhKRC': 736183094,
+        'hfhPRC': 886364332,
+        'hfhPRC': 706927479,
+        'sfImag': 589224449,
+        'ingHar': 145191545,
+        'rivEas': 489380324,
+        'soLo': 120264574,
+        'riLa': 691714762,
+        'wisRapids': 487512085,
+        'colAbb': 983848564,
+        'mino': 261931804,
+        'merr': 665277300,
+        'nci': 111111111,
+        'other': 807835037,
+        'all': 1000
+
     }
 };
 

--- a/src/navbar.js
+++ b/src/navbar.js
@@ -165,6 +165,9 @@ export const reportSideNavBar = () => {
             <li class="nav-item">
                 <a class="nav-link" href="#checkoutreport" id="navBarCheckoutReport">Check-Out Report</a>
             </li>
+            <li class="nav-item">
+                <a class="nav-link" href="#dailyreport" id="navBarDailyReport">Daily Review Report</a>
+            </li>
         </ul>`;
 }
 

--- a/src/pages/dailyReport.js
+++ b/src/pages/dailyReport.js
@@ -64,7 +64,7 @@ const renderCollectionLocationList = () => {
                     <li><a class="dropdown-item" data-siteKey="hpRC" id="hpRC">HP Research Clinic</a></li>
                     <li><a class="dropdown-item" data-siteKey="hfhKRC" id="hfhKRC">HFH K-13 Research Clinic</a></li>
                     <li><a class="dropdown-item" data-siteKey="hfhPRC" id="hfhPRC">HFH Cancer Pavilion Research Clinic</a></li>
-                    <li><a class="dropdown-item" data-siteKey="hfhPRC" id="hfhLRC">HFH Livonia Research Clinic</a></li>
+                    <li><a class="dropdown-item" data-siteKey="hfhLRC" id="hfhLRC">HFH Livonia Research Clinic</a></li>
                     <li><a class="dropdown-item" data-siteKey="sfImag" id="sfImag">Sioux Falls Imagenetics</a></li>
                     <li><a class="dropdown-item" data-siteKey="ingHar" id="ingHar">Ingalls Harvey</a></li>
                     <li><a class="dropdown-item" data-siteKey="rivEas" id="rivEas">River East</a></li>

--- a/src/pages/dailyReport.js
+++ b/src/pages/dailyReport.js
@@ -84,7 +84,7 @@ const renderCollectionLocationList = () => {
 
 const initializeDailyReportTable = async () => {
     showAnimation();
-    const dailyReportsData = await getDailyParticipant(`checkedIn=${true}`).then(res => res.data);
+    const dailyReportsData = await getDailyParticipant().then(res => res.data);
     appState.setState({dailyReportsData: dailyReportsData}); // store inital daily reports data
     populateDailyReportTable(`Filter by Collection Location`, dailyReportsData);
 }

--- a/src/pages/dailyReport.js
+++ b/src/pages/dailyReport.js
@@ -1,0 +1,152 @@
+import { userAuthorization, removeActiveClass, hideAnimation, showAnimation, getDailyParticipant, convertISODateTime, restrictNonBiospecimenUser, getDataAttributes, appState } from "./../shared.js"
+import { homeNavBar, reportSideNavBar } from '../navbar.js';
+import fieldToConceptIdMapping from "../fieldToConceptIdMapping.js";
+
+
+export const dailyReportTemplate = (auth, route) => {
+    auth.onAuthStateChanged(async user => {
+        if(user){
+            const response = await userAuthorization(route, user.displayName ? user.displayName : user.email);
+            if ( response.isBiospecimenUser === false ) {
+                restrictNonBiospecimenUser();
+                return;
+            }
+            if(!response.role) return;
+            renderDailyReport();
+        }
+        else {
+            document.getElementById('navbarNavAltMarkup').innerHTML = homeNavBar();
+            window.location.hash = '#';
+        }
+    });
+}
+
+
+export const renderDailyReport = async () => {  
+    let template = `
+            <div class="container">
+            <div class="row">
+                <div class="col-lg-2" style="margin-bottom:20px">
+                    <h2>Reports</h2>
+                    ${reportSideNavBar()}
+                </div>
+                <div class="col-lg-10">
+                    <div class="row">
+                    ${renderCollectionLocationList()}
+                        <div class="col-lg">
+                            <table id="populateDailyReportTable" class="table table-bordered">
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>`;
+    document.getElementById('contentBody').innerHTML = template;
+    removeActiveClass('nav-link', 'active');
+    const navBarBtn = document.getElementById('navBarDailyReport');
+    navBarBtn.classList.add('active');
+    initializeDailyReportTable();
+}
+
+const renderCollectionLocationList = () => {
+    let template = ``;
+    template += `       
+            <div style="margin-top:10px; padding:15px;" class="dropdown">
+                <button class="btn btn-secondary dropdown-toggle dropdown-toggle-sites" id="dropdownSites" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                Filter by Collection Location
+                </button>
+                <ul class="dropdown-menu scrollable-menu" id="dropdownMenuButtonSites" aria-labelledby="dropdownMenuButton">
+                    <li><a class="dropdown-item" data-siteKey="all" id="all">All</a></li>
+                    <li><a class="dropdown-item" data-siteKey="ucDcam" id="ucDcam">UC-DCAM</a></li>
+                    <li><a class="dropdown-item" data-siteKey="marshfield" id="marshfield">Marshfield</a></li>
+                    <li><a class="dropdown-item" data-siteKey="weston" id="weston">Weston</a></li>
+                    <li><a class="dropdown-item" data-siteKey="lakeHallie" id="lakeHallie">Lake Hallie</a></li>
+                    <li><a class="dropdown-item" data-siteKey="hpRC" id="hpRC">HP Research Clinic</a></li>
+                    <li><a class="dropdown-item" data-siteKey="hfhKRC" id="hfhKRC">HFH K-13 Research Clinic</a></li>
+                    <li><a class="dropdown-item" data-siteKey="hfhPRC" id="hfhPRC">HFH Cancer Pavilion Research Clinic</a></li>
+                    <li><a class="dropdown-item" data-siteKey="hfhPRC" id="hfhLRC">HFH Livonia Research Clinic</a></li>
+                    <li><a class="dropdown-item" data-siteKey="sfImag" id="sfImag">Sioux Falls Imagenetics</a></li>
+                    <li><a class="dropdown-item" data-siteKey="ingHar" id="ingHar">Ingalls Harvey</a></li>
+                    <li><a class="dropdown-item" data-siteKey="rivEas" id="rivEas">River East</a></li>
+                    <li><a class="dropdown-item" data-siteKey="soLo" id="soLo">South Loop</a></li>
+                    <li><a class="dropdown-item" data-siteKey="riLa" id="riLa">Rice Lake</a></li>
+                    <li><a class="dropdown-item" data-siteKey="wisRapids" id="wisRapids">Wisconsin Rapids</a></li>
+                    <li><a class="dropdown-item" data-siteKey="colAbb" id="colAbb">Colby Abbotsford</a></li>
+                    <li><a class="dropdown-item" data-siteKey="mino" id="mino">Minocqua</a></li>
+                    <li><a class="dropdown-item" data-siteKey="merr" id="merr">Merrill</a></li>
+                    <li><a class="dropdown-item" data-siteKey="nci" id="nci">NIH/NCI</a></li>
+                    <li><a class="dropdown-item" data-siteKey="other" id="other">Other</a></li>
+                </ul>
+            </div>
+            `
+    return template;
+}
+
+const initializeDailyReportTable = async () => {
+    showAnimation();
+    const dailyReportsData = await getDailyParticipant(`checkedIn=${true}`).then(res => res.data);
+    appState.setState({dailyReportsData: dailyReportsData}); // store inital daily reports data
+    populateDailyReportTable(`Filter by Collection Location`, dailyReportsData);
+}
+
+const populateDailyReportTable = (dropdownHeader, dailyReportsData) => {
+    const currTable = document.getElementById('populateDailyReportTable');
+    currTable.innerHTML = '';
+    
+    const headerRow = currTable.insertRow();
+    headerRow.innerHTML = `
+      <th><b>Collection Location</b></th>
+      <th><b>Connect ID</b></th>
+      <th><b>Last Name</b></th>
+      <th><b>First Name</b></th>
+      <th><b>Check-In Date/Time</b></th>
+      <th><b>Collection ID</b></th>
+      <th><b>Collection Finalized</b></th>
+      <th><b>Check-Out Date/Time</b></th>
+    `;
+    
+    for (const item of dailyReportsData) {
+      if (!item[fieldToConceptIdMapping.collection.selectedVisit]?.[fieldToConceptIdMapping.baseline.visitId]?.[fieldToConceptIdMapping.checkOutDateTime]) {
+        const newRow = currTable.insertRow();
+        newRow.innerHTML = `
+
+          <td>${fieldToConceptIdMapping.collectionLocationMapping[item[fieldToConceptIdMapping.collectionLocation]]}</td>
+          <td>${item['Connect_ID']}</td>
+          <td>${item[fieldToConceptIdMapping.lastName]}</td>
+          <td>${item[fieldToConceptIdMapping.firstName]}</td>
+          <td>${convertISODateTime(item[fieldToConceptIdMapping.checkInDateTime])}</td>
+          <td>${item[fieldToConceptIdMapping.collection.id]}</td>
+          <td>${item[fieldToConceptIdMapping.collection.shipTime] !== undefined ? convertISODateTime(item[fieldToConceptIdMapping.collection.shipTime]) : ``}</td>
+          <td>${item[fieldToConceptIdMapping.checkOutDateTime] !== undefined ? convertISODateTime(item[fieldToConceptIdMapping.checkOutDateTime]) : ``}</td>
+        `;
+      }
+    }
+    hideAnimation();
+    dropdownTrigger(dropdownHeader);
+}
+
+const reInitalizeDailyReportTable = async (dropdownText, siteKey, dailyData) => {
+    showAnimation();
+    let data = dailyData;
+    if (siteKey !== 'all') {
+        data = data.filter((dailyReportData) => dailyReportData[fieldToConceptIdMapping.collectionLocation] === fieldToConceptIdMapping.nameToKeyObj[siteKey]);
+    }
+    populateDailyReportTable(dropdownText, data)
+}
+
+
+const dropdownTrigger = (sitekeyName) => {
+    let a = document.getElementById('dropdownSites');
+    let dropdownMenuButton = document.getElementById('dropdownMenuButtonSites');
+    let tempSiteName = a.innerHTML = sitekeyName;
+    if (dropdownMenuButton) {
+        dropdownMenuButton.addEventListener('click', (e) => {
+            if (sitekeyName === `Filter by Collection Location` || sitekeyName === tempSiteName) {
+                a.innerHTML = e.target.textContent;
+                const sitekey = getDataAttributes(e.target)
+                const dailyReportsData = appState.getState().dailyReportsData;
+                reInitalizeDailyReportTable(e.target.textContent, sitekey, dailyReportsData);
+            }
+        })
+    }
+}

--- a/src/pages/receipts/csvFileReceipt.js
+++ b/src/pages/receipts/csvFileReceipt.js
@@ -315,7 +315,7 @@ const updateResultMappings = (filteredResult, vialMappings) => {
   filteredResult['Sample Collection Center'] = (filteredResult[fieldToConceptIdMapping.collectionType] === fieldToConceptIdMapping.clinical) 
               ? keyToNameObj[filteredResult[fieldToConceptIdMapping.healthcareProvider]] : keyToLocationObj[filteredResult[fieldToConceptIdMapping.collectionLocation]];
   filteredResult['Sample ID'] = filteredResult[fieldToConceptIdMapping.collectionId]?.split(' ')[0] || '';
-  filteredResult['Sequence #'] = filteredResult[fieldToConceptIdMapping.collectionId]?.split(' ')[1] || '';
+  filteredResult['Sequence'] = filteredResult[fieldToConceptIdMapping.collectionId]?.split(' ')[1] || '';
   filteredResult['BSI ID'] = filteredResult[fieldToConceptIdMapping.collectionId] || '';
   filteredResult['Subject ID'] = filteredResult['Connect_ID'];
   filteredResult['Date Received'] = formatISODateTime(filteredResult[fieldToConceptIdMapping.dateReceived]) || '';
@@ -347,7 +347,7 @@ const updateResultMappings = (filteredResult, vialMappings) => {
 
 const generateBSIqueryCSVData = (items) => {
   let csv = ``;
-  csv += `Study ID, Sample Collection Center, Sample ID, Sequence #, BSI ID, Subject ID, Date Received, Date Drawn, Vial Type, Additive/Preservative, Material Type, Volume, Volume Estimate, Volume Unit, Vial Warnings, Hemolyzed, Label Status, Visit\r\n`
+  csv += `Study ID, Sample Collection Center, Sample ID, Sequence, BSI ID, Subject ID, Date Received, Date Drawn, Vial Type, Additive/Preservative, Material Type, Volume, Volume Estimate, Volume Unit, Vial Warnings, Hemolyzed, Label Status, Visit\r\n`
   downloadCSVfile(items, csv, 'BSI-data-export')
 }
 
@@ -375,7 +375,7 @@ const downloadCSVfile = (items, csv, title) => {
 */ 
 
 const processInTransitXLSXData = (inTransitItems) => {
-  const header = ['Ship Date', 'Tracking Number', 'Shipped from Site', 'Shipped from Location', 'Shipped Date & Time', 'Expected Number of Samples', 'Temperature Monitor', 'Box Number', 'Specimen Bag ID Type', 'Full Specimen IDs', 'Material Type'];
+  const header = ['Ship Date', 'Tracking Number', 'Shipped from Site', 'Shipped from Location', 'Shipped Date & Time', 'Expected Number of Samples', 'Temperature Monitor', 'Box Number', 'Specimen Bag ID Type', 'BSI ID', 'Material Type'];
   const inTransitData = [header, ...inTransitItems.map(row => Object.values(row))];
   handleXLSXLibrary(inTransitData);
 };

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -305,7 +305,7 @@ const storeDateReceivedinISO = (date) => { // ("YYYY-MM-DD" to ISO format DateTi
 const storePackageReceipt = async (data) => {
     showAnimation();
     const idToken = await getIdToken();
-    const response = await fetch(`http://127.0.0.1:5001/nih-nci-dceg-connect-dev/us-central1/biospecimen?api=storeReceipt`,
+    const response = await fetch(`${baseAPI}api=storeReceipt`,
         {
             method: "POST",
             body: JSON.stringify(data),

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -305,7 +305,7 @@ const storeDateReceivedinISO = (date) => { // ("YYYY-MM-DD" to ISO format DateTi
 const storePackageReceipt = async (data) => {
     showAnimation();
     const idToken = await getIdToken();
-    const response = await fetch(`${baseAPI}api=storeReceipt`,
+    const response = await fetch(`http://127.0.0.1:5001/nih-nci-dceg-connect-dev/us-central1/biospecimen?api=storeReceipt`,
         {
             method: "POST",
             body: JSON.stringify(data),

--- a/src/shared.js
+++ b/src/shared.js
@@ -118,7 +118,7 @@ export const findParticipant = async (query) => {
 
 export const getDailyParticipant = async (query) => {
   const idToken = await getIdToken();
-  const response = await fetch(`http://127.0.0.1:5001/nih-nci-dceg-connect-dev/us-central1/biospecimen?api=getDailyReportParticipants`, {
+  const response = await fetch(`${api}api=getDailyReportParticipants`, {
       method: "GET",
       headers: {
           Authorization:"Bearer "+idToken

--- a/src/shared.js
+++ b/src/shared.js
@@ -116,7 +116,7 @@ export const findParticipant = async (query) => {
     return await response.json();
 }
 
-export const getDailyParticipant = async (query) => {
+export const getDailyParticipant = async () => {
   const idToken = await getIdToken();
   const response = await fetch(`${api}api=getDailyReportParticipants`, {
       method: "GET",

--- a/src/shared.js
+++ b/src/shared.js
@@ -118,7 +118,7 @@ export const findParticipant = async (query) => {
 
 export const getDailyParticipant = async () => {
   const idToken = await getIdToken();
-  const response = await fetch(`http://127.0.0.1:5001/nih-nci-dceg-connect-dev/us-central1/biospecimen?api=getDailyReportParticipants`, {
+  const response = await fetch(`${api}api=getDailyReportParticipants`, {
       method: "GET",
       headers: {
           Authorization:"Bearer "+idToken

--- a/src/shared.js
+++ b/src/shared.js
@@ -116,6 +116,19 @@ export const findParticipant = async (query) => {
     return await response.json();
 }
 
+export const getDailyParticipant = async (query) => {
+  const idToken = await getIdToken();
+  const response = await fetch(`http://127.0.0.1:5001/nih-nci-dceg-connect-dev/us-central1/biospecimen?api=getDailyReportParticipants`, {
+      method: "GET",
+      headers: {
+          Authorization:"Bearer "+idToken
+      }
+  });
+  return await response.json();
+}
+
+
+
 export const updateParticipant = async (dataObj) => {
     const idToken = await getIdToken();
     const response = await fetch(`${api}api=updateParticipantDataNotSite`, {
@@ -2434,3 +2447,5 @@ export const restrictNonBiospecimenUser = () => {
   document.getElementById("contentBody").innerHTML = "Authorization failed you lack permissions to use this dashboard!";
   document.getElementById("navbarNavAltMarkup").innerHTML = unAuthorizedUser();
 }
+
+export const getDataAttributes = (el) => { return el.getAttribute('data-sitekey'); }

--- a/src/shared.js
+++ b/src/shared.js
@@ -118,7 +118,7 @@ export const findParticipant = async (query) => {
 
 export const getDailyParticipant = async () => {
   const idToken = await getIdToken();
-  const response = await fetch(`${api}api=getDailyReportParticipants`, {
+  const response = await fetch(`http://127.0.0.1:5001/nih-nci-dceg-connect-dev/us-central1/biospecimen?api=getDailyReportParticipants`, {
       method: "GET",
       headers: {
           Authorization:"Bearer "+idToken

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -472,3 +472,9 @@ box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
 #reportTabs .nav-link:hover {
     background-color: #f8f9fa;
 }
+
+.scrollable-menu {
+    height: auto;
+    max-height: 200px;
+    overflow-x: hidden;
+}


### PR DESCRIPTION
This PR addresses following issue:
-> Table displays list of participants that have checked in & out
-> Participants record are removed from the table after 2 days of check-in
-> Used state management to keep track of API response
-> User can filter based on Collection Location
-> Optimized as required & re-used code
-> Changed "Full Specimen IDs" to "BSI ID" https://github.com/episphere/biospecimen/issues/562
-> Changed "Sequence #" to "Sequence" https://github.com/episphere/biospecimen/issues/563

https://github.com/episphere/connect/issues/631

Related PR: https://github.com/episphere/connectFaas/pull/398

Checklist:
- [X] Code cleanup
- [X] Check for ES Lint warnings
- [X] Verify test cases
- [X] Check for GIT conflicts 
- [ ] Verified unit tests pass with current changes [N/A]
- [ ] Any dependencies or modules  [N/A]
- [X] Attach PoC
- [ ] Add notes

Test Cases Verified with PoC attached: 

1.) On daily reports page, should display list of participants with essential information:
![Screenshot 2023-08-16 at 4 47 13 PM](https://github.com/episphere/biospecimen/assets/30497847/b00b18e0-2b01-4c7e-ba7e-b6e6597bdfd9)

2.) Filter on HP Research Clinic, should return a list of HP participants:
![Screenshot 2023-08-16 at 4 48 12 PM](https://github.com/episphere/biospecimen/assets/30497847/72c0ff79-dcb3-4e78-a37c-c9774e9ca0b6)

3.) Filter on ALL, should return a list of participants from all locations:
![Screenshot 2023-08-16 at 4 49 07 PM](https://github.com/episphere/biospecimen/assets/30497847/afa6f25b-64c5-4f55-877d-acd8db37e5f4)

4.) For testing purposes only, participant should be removed after 1hr:
Before:
![Screenshot 2023-08-16 at 3 40 44 PM](https://github.com/episphere/biospecimen/assets/30497847/1a665643-446b-45c0-952a-44693311762f)

After: Participant removed after 1hr:
![Screenshot 2023-08-16 at 3 45 57 PM](https://github.com/episphere/biospecimen/assets/30497847/01e782e7-dc35-47d9-adcf-17a760de97e3)

