### PR TITLE
Fix boxes to ship table & stray tube nuances

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -387,7 +387,7 @@ export const getInstituteSpecimensList = async (boxList) => {
             }
         }
 
-        if (tubesInBox.shipped.bloodUrine.length > 0 && tubesToAdd.bloodUrine.length > 0) {
+        if ((tubesInBox.shipped.bloodUrine.length > 0 || tubesInBox.notShipped.bloodUrine.length > 0) && tubesToAdd.bloodUrine.length > 0) {
             tubesToAdd.orphan=tubesToAdd.bloodUrine;
             tubesToAdd.bloodUrine=[];
         }

--- a/src/pages/shipping.js
+++ b/src/pages/shipping.js
@@ -89,7 +89,7 @@ const buildShippingInterface = async (userName, loadFromState, currBoxId) => {
 
     setAllShippingState(availableCollectionsObj, availableLocations, allBoxesList, finalizedSpecimenList, userName);
 
-    populateViewShippingBoxContentsList(currBoxId), // 'View Shipping Box Contents' section
+    populateViewShippingBoxContentsList(currBoxId); // 'View Shipping Box Contents' section
     populateBoxesToShipTable(); // 'Select boxes to ship' section
     addShippingEventListeners();
 

--- a/src/pages/shipping.js
+++ b/src/pages/shipping.js
@@ -1,4 +1,4 @@
-import { addBox, appState, conceptIdToSiteSpecificLocation, displayContactInformation, getAllBoxes, getLocationsInstitute, hideAnimation, locationConceptIDToLocationMap,
+import { addBox, appState, conceptIdToSiteSpecificLocation, displayContactInformation, getAllBoxes, getBoxes, getLocationsInstitute, hideAnimation, locationConceptIDToLocationMap,
         removeActiveClass, removeBag, removeMissingSpecimen, showAnimation, showNotifications, siteSpecificLocation, siteSpecificLocationToConceptId, sortBiospecimensList,
         translateNumToType, userAuthorization } from "../shared.js"
 import { addDeviationTypeCommentsContent, addEventAddSpecimenToBox, addEventBackToSearch, addEventBoxSelectListChanged, addEventCheckValidTrackInputs,
@@ -89,7 +89,7 @@ const buildShippingInterface = async (userName, loadFromState, currBoxId) => {
 
     setAllShippingState(availableCollectionsObj, availableLocations, allBoxesList, finalizedSpecimenList, userName);
 
-    populateViewShippingBoxContentsList(currBoxId); // 'View Shipping Box Contents' section
+    populateViewShippingBoxContentsList(currBoxId), // 'View Shipping Box Contents' section
     populateBoxesToShipTable(); // 'Select boxes to ship' section
     addShippingEventListeners();
 
@@ -214,7 +214,8 @@ const populateBoxesToShipTable = () => {
     
     if (Object.keys(detailedBoxes).length > 0) {
         const sortedBoxKeys = Object.keys(detailedBoxes).sort();
-        sortedBoxKeys.forEach((box, i) => {
+        let rowCount = 0;
+        sortedBoxKeys.forEach(box => {
             const currBox = detailedBoxes[box];
             const bagKeys = Object.keys(currBox).filter(key => key !== 'boxData' && key !== 'undefined').sort((a, b) => a.split(/\s+/)[1] - b.split(/\s+/)[1]);
             const boxStartedTimestamp = currBox.boxData[conceptIds.firstBagAddedToBoxTimestamp] ? formatTimestamp(Date.parse(currBox.boxData[conceptIds.firstBagAddedToBoxTimestamp])) : '';
@@ -222,15 +223,16 @@ const populateBoxesToShipTable = () => {
             const boxLocation = currBox.boxData[conceptIds.shippingLocation] ? locationConceptIDToLocationMap[currBox.boxData[conceptIds.shippingLocation]]["siteSpecificLocation"] : '';
             const numTubesInBox = bagKeys.reduce((total, bagKey) => total + currBox[bagKey]['arrElements'].length, 0);
 
-            const currRow = table.insertRow(i + 1);
-            currRow.style['background-color'] = i % 2 === 1 ? 'lightgrey' : '';
-            
-            if (numTubesInBox > 0) {
+            if (numTubesInBox > 0) {   
+                const currRow = table.insertRow(rowCount + 1);
+                currRow.style['background-color'] = rowCount % 2 === 1 ? 'lightgrey' : '';
                 currRow.innerHTML += renderBoxesToShipRow(boxStartedTimestamp, boxLastModifiedTimestamp, box, boxLocation, numTubesInBox);
                 const currBoxButton = currRow.cells[6].querySelector(".boxManifestButton");
                 currBoxButton.addEventListener("click", async () => {
-                generateBoxManifest(currBox);
-            });
+                    generateBoxManifest(currBox);
+                });
+
+                rowCount++; 
             }
         });
     }
@@ -304,7 +306,7 @@ const handleRemoveBagButton = (currDeleteButton, currTubes, currBoxId) => {
         hideAnimation();
 
         if (removeBagResponse.code === 200) {
-            updateShippingStateRemoveBagFromBox(currBoxId, bagsToRemove);
+            updateShippingStateRemoveBagFromBox(currBoxId, currBagId, bagsToRemove);
             startShipping(appState.getState().userName, true, currBoxId);
         } else {
             showNotifications({ title: 'Error removing bag', body: 'We experienced an error removing this bag. Please try again.' });
@@ -658,38 +660,14 @@ export const populateModalSelect = (detailedLocationBoxes) => {
     addToBoxButton.removeAttribute("disabled")
     
     const boxIds = Object.keys(detailedLocationBoxes).sort(compareBoxIds);
-    const options = boxIds.map(boxId => `<option>${boxId}</option>`).join(''); 
+    const boxOptions = boxIds.map(boxId => `<option>${boxId}</option>`).join(''); 
 
-    if (options == '') {
+    if (boxOptions == '') {
         addToBoxButton.setAttribute('disabled', 'true');
     }
 
-    boxSelectEle.innerHTML = options;
+    boxSelectEle.innerHTML = boxOptions;
     boxSelectEle.value = selectedBoxId;
-}
-
-export const populateTempSelect = (boxes) => {
-    const boxDiv = document.getElementById("tempCheckList");
-    boxDiv.style.display = "block";
-    boxDiv.style.marginTop = "10px";
-    boxDiv.innerHTML = `<p>Select the box that contains the temperature monitor</p>
-        <select name="tempBox" id="tempBox">
-        <option disabled value> -- select a box -- </option>
-        </select>`;
-
-    const toPopulate = document.getElementById('tempBox')
-
-    for (let i = 0; i < boxes.length; i++) {
-        
-        const opt = document.createElement("option");
-        opt.value = boxes[i];
-        opt.innerHTML = boxes[i];
-        if(i === 0){
-            opt.selected = true;
-        }
-        // then append it to the select element
-        toPopulate.appendChild(opt);
-    }
 }
 
 export const formatTimestamp = (timestamp) => {
@@ -752,9 +730,10 @@ const sortSpecimenKeys = (a, b) => {
  * @param {boolean} isTempMonitorIncluded
  * @param {number} currShippingLocationNumber
  */
-export const generateShippingManifest = (boxIdArray, userName, isTempMonitorIncluded, currShippingLocationNumber) => {
+export const generateShippingManifest = async (boxIdArray, userName, isTempMonitorIncluded, currShippingLocationNumber) => {
     showAnimation();
-    const boxArray = appState.getState().allBoxesList;
+    const response = await getBoxes();
+    const boxArray = response.data;
     let siteAcronym = '';
     let boxIdAndBagsObjToDisplay = {};
 

--- a/src/shared.js
+++ b/src/shared.js
@@ -380,7 +380,7 @@ export const shippingPrintManifestReminder = (boxesToShip, userName, tempCheckSt
 `;
   const shipManifestConfirmButton = document.getElementById("shipManifestConfirm")
   shipManifestConfirmButton.addEventListener("click", async () => {
-    generateShippingManifest(boxesToShip, userName, tempCheckStatus, currShippingLocationNumber);
+    await generateShippingManifest(boxesToShip, userName, tempCheckStatus, currShippingLocationNumber);
   })
 }
 

--- a/src/shippingState.js
+++ b/src/shippingState.js
@@ -1,5 +1,5 @@
 import { appState, siteSpecificLocationToConceptId } from './shared.js';
-import { specimenCollection, tubes } from './tubeValidation.js';
+import { specimenCollection } from './tubeValidation.js';
 import conceptIds from './fieldToConceptIdMapping.js';
 
 /**
@@ -88,9 +88,10 @@ const addBagToAvailableCollections = (boxId, bagId, bagsToMove) => {
         }
     }
     
-    appState.setState({
-        availableCollectionsObj: {...availableCollectionsObj},
-    });
+    appState.setState({ availableCollectionsObj });
+    // appState.setState({
+    //     availableCollectionsObj: {...availableCollectionsObj},
+    // });
 }
 
 // Remove the bag from the box when user has clicked 'remove bag' in the 'View Shipping Box Contents' table.
@@ -150,9 +151,13 @@ const addBagToBox = (boxId, bagId, boxToUpdate) => {
         availableCollectionsObj['unlabelled'].push(...strayTubesToAdd);
     }
 
+    // appState.setState({
+    //     allBoxesList: allBoxesList,
+    //     availableCollectionsObj: availableCollectionsObj
+    // });
     appState.setState({
-        allBoxesList: allBoxesList,
-        availableCollectionsObj: availableCollectionsObj
+        allBoxesList,
+        availableCollectionsObj
     });
 }
 

--- a/src/shippingState.js
+++ b/src/shippingState.js
@@ -118,7 +118,7 @@ const removeBagFromBox = (boxId, bagId, bagsToMove) => {
 const removeBagFromAvailableCollections = (bagId) => {
     const availableCollectionsObj = appState.getState().availableCollectionsObj;
 
-    if (availableCollectionsObj.hasOwnProperty(bagId)) {
+    if (bagId in availableCollectionsObj) {
         delete availableCollectionsObj[bagId];
     } else if (availableCollectionsObj['unlabelled'] && availableCollectionsObj['unlabelled'].includes(bagId)) {
         availableCollectionsObj['unlabelled'] = availableCollectionsObj['unlabelled'].filter(id => id !== bagId);

--- a/src/shippingState.js
+++ b/src/shippingState.js
@@ -89,9 +89,6 @@ const addBagToAvailableCollections = (boxId, bagId, bagsToMove) => {
     }
     
     appState.setState({ availableCollectionsObj });
-    // appState.setState({
-    //     availableCollectionsObj: {...availableCollectionsObj},
-    // });
 }
 
 // Remove the bag from the box when user has clicked 'remove bag' in the 'View Shipping Box Contents' table.
@@ -151,10 +148,6 @@ const addBagToBox = (boxId, bagId, boxToUpdate) => {
         availableCollectionsObj['unlabelled'].push(...strayTubesToAdd);
     }
 
-    // appState.setState({
-    //     allBoxesList: allBoxesList,
-    //     availableCollectionsObj: availableCollectionsObj
-    // });
     appState.setState({
         allBoxesList,
         availableCollectionsObj

--- a/src/shippingState.js
+++ b/src/shippingState.js
@@ -1,5 +1,5 @@
 import { appState, siteSpecificLocationToConceptId } from './shared.js';
-import { specimenCollection } from './tubeValidation.js';
+import { specimenCollection, tubes } from './tubeValidation.js';
 import conceptIds from './fieldToConceptIdMapping.js';
 
 /**
@@ -20,7 +20,7 @@ export const setAllShippingState = (availableCollectionsObj, availableLocations,
 
     appState.setState({
         allBoxesList: allBoxesList,
-        availableCollectionsObj: availableCollectionsObj,
+        availableCollectionsObj: availableCollectionsObj ?? {},
         availableLocations: availableLocations,
         boxesByLocationList: boxesByLocationList,
         detailedLocationBoxes: detailedLocationBoxes,
@@ -42,12 +42,13 @@ export const updateShippingStateSelectedLocation = (selectedLocation) => {
 /**
  * Update the state for allBoxesList and availableCollectionsObj.
  * Remove the bags from the box.
+ * Note: 'unlabelled' bags are stray tubes. They do not get added back to availableCollectionsObj.
  * @param {string} boxId - the box with the bag to be removed.
  * @param {array} bagsToMove - the bags to be removed from the box. 
  */
-export const updateShippingStateRemoveBagFromBox = (boxId, bagsToMove) => {
-    addBagToAvailableCollections(boxId, bagsToMove);
-    removeBagFromBox(boxId, bagsToMove);
+export const updateShippingStateRemoveBagFromBox = (boxId, bagId, bagsToMove) => {
+    addBagToAvailableCollections(boxId, bagId, bagsToMove);
+    removeBagFromBox(boxId, bagId, bagsToMove);
 }
 
 /**
@@ -58,7 +59,7 @@ export const updateShippingStateRemoveBagFromBox = (boxId, bagsToMove) => {
  * @param {object} boxToUpdate - the box object to be updated
  */
 export const updateShippingStateAddBagToBox = (boxId, bagId, boxToUpdate) => {
-    addBagToBox(boxId, boxToUpdate);
+    addBagToBox(boxId, bagId, boxToUpdate);
     removeBagFromAvailableCollections(bagId);
 }
 
@@ -67,34 +68,44 @@ export const updateShippingStateAddBagToBox = (boxId, bagId, boxToUpdate) => {
  * Build the bag and specimen data from detailedProviderBoxes data: availableCollectionsObj[bagId]: ['tube1Id', 'tube2Id', 'tube3Id']
  * Isolate the last four digits of tubeId to match availableCollectionsObj format.
  * Move object into availableCollectionsObj
+ * If object is 'unlabelled', it is a stray and it belongs in the 'unlabelled' section of availableCollectionsObj.
  * @param {*} boxId - the box with the bag being removed 
  * @param {*} bagsToMove - the bags being removed from the box
  */
-const addBagToAvailableCollections = (boxId, bagsToMove) => {
+const addBagToAvailableCollections = (boxId, bagId, bagsToMove) => {
     const availableCollectionsObj = appState.getState().availableCollectionsObj;
     const detailedProviderBoxes = appState.getState().detailedProviderBoxes;
 
-    for (const bagId of bagsToMove) {
-        const collectionToMove = detailedProviderBoxes[boxId][bagId].arrElements;
-        const tubeIdArray = collectionToMove.map(tubeId => tubeId.slice(-4));
-
-        availableCollectionsObj[bagId] = tubeIdArray;
+    if (bagId === 'unlabelled') {
+        const collectionToMove = detailedProviderBoxes[boxId]['unlabelled'].arrElements;
+        availableCollectionsObj['unlabelled'].push(...collectionToMove);
+    } else {
+        for (const bagLabel of bagsToMove) {
+            const collectionToMove = detailedProviderBoxes[boxId][bagLabel].arrElements;
+            const tubeIdArray = collectionToMove.map(tubeId => tubeId.slice(-4));
+    
+            availableCollectionsObj[bagLabel] = tubeIdArray;
+        }
     }
-
+    
     appState.setState({
         availableCollectionsObj: {...availableCollectionsObj},
     });
 }
 
 // Remove the bag from the box when user has clicked 'remove bag' in the 'View Shipping Box Contents' table.
-const removeBagFromBox = (boxId, bagsToMove) => {
+const removeBagFromBox = (boxId, bagId, bagsToMove) => {
     const allBoxesList = appState.getState().allBoxesList;
     const boxIndex = allBoxesList.findIndex(box => box[conceptIds.shippingBoxId] === boxId);
 
     if (boxIndex !== -1) { 
-        for (const bagId of bagsToMove) {
-            delete allBoxesList[boxIndex].bags[bagId];
+        if (bagId === 'unlabelled') {
+            bagsToMove = ['unlabelled'];
         }
+
+        bagsToMove.forEach(bagLabel => {
+            delete allBoxesList[boxIndex].bags[bagLabel];
+        });
 
         appState.setState({
             allBoxesList: [...allBoxesList],
@@ -103,17 +114,24 @@ const removeBagFromBox = (boxId, bagsToMove) => {
 }
 
 // Remove the bag from the availableCollectionsObj when it has been added to a box.
+// Check if bagId is a direct key in availableCollectionsObj. If not, check if it's and element in the 'unlabelled' array.
 const removeBagFromAvailableCollections = (bagId) => {
     const availableCollectionsObj = appState.getState().availableCollectionsObj;
-    delete availableCollectionsObj[bagId];
+
+    if (availableCollectionsObj.hasOwnProperty(bagId)) {
+        delete availableCollectionsObj[bagId];
+    } else if (availableCollectionsObj['unlabelled'] && availableCollectionsObj['unlabelled'].includes(bagId)) {
+        availableCollectionsObj['unlabelled'] = availableCollectionsObj['unlabelled'].filter(id => id !== bagId);
+    }
 
     appState.setState({ availableCollectionsObj: availableCollectionsObj });
 }
 
 // Replace the previous box with the updated box when a bag is added.
 // If an existing box is not found, add it to the list.
-const addBagToBox = (boxId, boxToUpdate) => {
+const addBagToBox = (boxId, bagId, boxToUpdate) => {
     let allBoxesList = [...appState.getState().allBoxesList];
+    const availableCollectionsObj = appState.getState().availableCollectionsObj;
 
     allBoxesList = allBoxesList.map(box => 
         box[conceptIds.shippingBoxId] === boxId ? boxToUpdate : box
@@ -123,7 +141,28 @@ const addBagToBox = (boxId, boxToUpdate) => {
         allBoxesList.push(boxToUpdate);
     }
 
-    appState.setState({ allBoxesList: allBoxesList });
+    const strayTubesToAdd = getStrayTubesFromUncheckedModalBoxes(boxToUpdate, bagId);
+
+    if (strayTubesToAdd.length > 0) {
+        if (!availableCollectionsObj['unlabelled']) {
+            availableCollectionsObj['unlabelled'] = [];
+        }
+        availableCollectionsObj['unlabelled'].push(...strayTubesToAdd);
+    }
+
+    appState.setState({
+        allBoxesList: allBoxesList,
+        availableCollectionsObj: availableCollectionsObj
+    });
+}
+
+const getStrayTubesFromUncheckedModalBoxes = (boxToUpdate, bagId) => {
+    const availableCollectionsObj = appState.getState().availableCollectionsObj;
+    const tubesInBoxArray = (boxToUpdate.bags[bagId]?.arrElements ?? []).map(tubeId => tubeId.slice(-4));
+    if (tubesInBoxArray.length === 0) return [];
+    const tubesInAvailableCollectionsList = availableCollectionsObj[bagId];
+    const strayTubesForCurrentCollection = tubesInAvailableCollectionsList.filter(tube => !tubesInBoxArray.includes(tube));
+    return [...strayTubesForCurrentCollection.map(tubeId => `${bagId.split(' ')[0]} ${tubeId}`)];
 }
 
 export const updateShippingStateCreateBox = (boxToAdd) => {


### PR DESCRIPTION
Related: https://github.com/episphere/connect/issues/685

This updates PR: https://github.com/episphere/biospecimen/pull/568

-Update the way boxes to ship table is built to support empty box handling.

-Fetch shippingManifest data from Firestore. We made this decision to fetch data from firestore over using state management concepts: this forces a sync between the database and the user’s session. This is inconsequential for solo users, but important in a team environment where multiple team members may be updating the shipping data at the same time.

-Update handling of stray tubes in state management. Now ‘unlabelled’ bags can be added and removed freely.

-Update handling of unchecked tubes when adding to bag. Unchecked tubes are now available to add to other boxes prior to shipment and without removing the parent bags from the boxes.