### PR TITLE
Add box error handling

### DIFF
--- a/src/pages/shipping.js
+++ b/src/pages/shipping.js
@@ -332,7 +332,11 @@ export const addNewBox = async () => {
 
     if (largestBoxIndexAtLocation == -1 || shouldUpdateBoxModal) {
         const boxToAdd = await createNewBox(boxList, siteLocationConversion, siteCode, largestBoxId, shouldUpdateBoxModal);
-        if (!boxToAdd) return false;
+        if (!boxToAdd) {
+            showNotifications({ title: 'ERROR ADDING BOX - PLEASE REFRESH YOUR BROWSER', body: 'Error: This box already exists. A member of your team may have recently created this box. Please refresh your browser and try again.' });
+            return false;
+        }
+
         updateShippingStateCreateBox(boxToAdd);
         return true;
     } else {
@@ -353,7 +357,10 @@ const createNewBox = async (boxList, pageLocationConversion, siteCode, largestBo
     };
 
     try {
-        await addBox(boxToAdd);
+        const addBoxResponse = await addBox(boxToAdd);
+        if (addBoxResponse.message !== 'Success!') {
+            return null;
+        }
     } catch (e) {
         console.error('Error adding box', e);
         return null;


### PR DESCRIPTION
Related: https://github.com/episphere/connect/issues/685

Add error handling to createNewBox. This avoids duplicate box creation by users at different locations when working concurrently.

<img width="441" alt="Screenshot 2023-08-30 at 12 40 16 PM" src="https://github.com/episphere/biospecimen/assets/93854858/f27602c5-9f3a-406b-8c7c-0c1e31cf5b77">
