### PR TITLE
Open Clinical Dashboard for Health Partners

### DIFF
--- a/src/pages/welcome.js
+++ b/src/pages/welcome.js
@@ -21,11 +21,15 @@ export const welcomeScreen = async (auth, route) => {
 }
 
 const clinicalOnlySiteArray = ['KPNW', 'KPCO', 'KPHI', 'KPGA'];
-const researchOnlySiteArray = ['MFC', 'UCM', 'HP', 'SFH'];
+const researchOnlySiteArray = ['MFC', 'UCM', 'SFH'];
 
 const welcomeScreenTemplate = (name, data, auth, route) => {
     let template = '';
     let dashboardSelectionStr = '';
+
+    if (location.host === urls.stage || location.host === urls.prod) { 
+        researchOnlySiteArray.push('HP')
+    }
 
     if (clinicalOnlySiteArray.includes(data.siteAcronym)) {
         dashboardSelectionStr = `                    


### PR DESCRIPTION
Related issue: [issue#697](https://github.com/episphere/connect/issues/697)

The PR addresses the following:
- Currently HP has access only to the Research Dashboard in **Dev**, **Stage**, and **Prod** environments
- Allow Health Partners (HP) to have access to both the Research and the Clinical Dashboard (**Dev only**)
- In dev HP can now select either research or clinical dashboard from the dropdown and access to the respective dashboard
- Remove 'HP' string from `researchOnlySiteArray`, push 'HP' string to `researchOnlySiteArray` in stage and prod if `location.host` string matches either stage or prod `urls`

HP Dashboard Environment Access:  
- Dev (Research and Clinical Dashboard)
- Stage & Prod (Research Dashboard)



