### PR TITLE
BPTL's packages in transit manifest slow loading

### DIFF
--- a/src/pages/receipts/csvFileReceipt.js
+++ b/src/pages/receipts/csvFileReceipt.js
@@ -103,7 +103,7 @@ const confirmFileSelection = () => {
       const radioVal = radio.value;
       document.getElementById('modalShowMoreData').querySelector('#closeModal').click(); // closes modal
       showAnimation();
-      const response = await getAllBoxes(`bptl`);
+      const response = await getAllBoxes(`bptlPackagesInTransit`);
       hideAnimation();
       const allBoxesShippedBySiteAndNotReceived = getRecentBoxesShippedBySiteNotReceived(response.data);
       let modifiedTransitResults = updateInTransitMapping(allBoxesShippedBySiteAndNotReceived);

--- a/src/pages/receipts/packagesInTransit.js
+++ b/src/pages/receipts/packagesInTransit.js
@@ -1,4 +1,4 @@
-import { showAnimation, hideAnimation, getAllBoxes, conceptIdToSiteSpecificLocation, searchSpecimenByRequestedSite, appState } from "../../shared.js";
+import { showAnimation, hideAnimation, getAllBoxes, conceptIdToSiteSpecificLocation, searchSpecimenByRequestedSiteAndBoxID, appState } from "../../shared.js";
 import fieldToConceptIdMapping from "../../fieldToConceptIdMapping.js";
 import { receiptsNavbar } from "./receiptsNavbar.js";
 import { nonUserNavBar, unAuthorizedUser } from "../../navbar.js";
@@ -15,7 +15,7 @@ export const packagesInTransitScreen = async (auth, route) => {
 
 const packagesInTransitTemplate = async (username, auth, route) => {
     showAnimation();
-    const response = await getAllBoxes(`bptl`);
+    const response = await getAllBoxes(`bptlPackagesInTransit`); 
     hideAnimation();
     
     const allBoxesShippedBySiteAndNotReceived = getRecentBoxesShippedBySiteNotReceived(response.data);
@@ -94,15 +94,7 @@ const packagesInTransitTemplate = async (username, auth, route) => {
 export const getRecentBoxesShippedBySiteNotReceived = (boxes) => {
     // boxes are from searchBoxes endpoint
     if (boxes.length === 0) return [];
-
-    const filteredBoxesBySubmitShipmentTimeAndNotReceived = boxes.filter(boxObj => {
-        const hasShippingShipDate = boxObj[fieldToConceptIdMapping.shippingShipDate];
-        const hasNoSiteShipmentDateReceivedKey = !boxObj[fieldToConceptIdMapping.siteShipmentDateReceived];
-        const hasNotReceivedSiteShipment = boxObj[fieldToConceptIdMapping.siteShipmentReceived] === fieldToConceptIdMapping.no;
-        return hasShippingShipDate && (hasNoSiteShipmentDateReceivedKey || hasNotReceivedSiteShipment);
-    });
-
-    return filteredBoxesBySubmitShipmentTimeAndNotReceived.sort((a,b) => {
+    return boxes.sort((a,b) => {
         const shipDateA = a[fieldToConceptIdMapping.shippingShipDate];
         const shipDateB = b[fieldToConceptIdMapping.shippingShipDate];
         return (shipDateA < shipDateB) ? 1 : -1;
@@ -196,8 +188,8 @@ const manifestButton = (allBoxesShippedBySiteAndNotReceived, bagIdArr, manifestM
             } = packagesInTransitModalData
 
             manifestModalBodyEl.innerHTML = modalBody;
-            showAnimation()
-            const searchSpecimenByRequestedSiteResponse = await searchSpecimenByRequestedSite(loginSite);
+            showAnimation();
+            const searchSpecimenByRequestedSiteResponse = await searchSpecimenByRequestedSiteAndBoxID(loginSite, boxNumber);
             const searchSpecimenInstituteArray = searchSpecimenByRequestedSiteResponse?.data ?? [];
 
             modalBody = 

--- a/src/pages/receipts/packagesInTransit.js
+++ b/src/pages/receipts/packagesInTransit.js
@@ -1,4 +1,4 @@
-import { showAnimation, hideAnimation, getAllBoxes, conceptIdToSiteSpecificLocation, searchSpecimenByRequestedSiteAndBoxID, appState } from "../../shared.js";
+import { showAnimation, hideAnimation, getAllBoxes, conceptIdToSiteSpecificLocation, searchSpecimenByRequestedSiteAndBoxId, appState } from "../../shared.js";
 import fieldToConceptIdMapping from "../../fieldToConceptIdMapping.js";
 import { receiptsNavbar } from "./receiptsNavbar.js";
 import { nonUserNavBar, unAuthorizedUser } from "../../navbar.js";
@@ -15,7 +15,7 @@ export const packagesInTransitScreen = async (auth, route) => {
 
 const packagesInTransitTemplate = async (username, auth, route) => {
     showAnimation();
-    const response = await getAllBoxes(`bptlPackagesInTransit`); 
+    const response = await getAllBoxes(`bptlPackagesInTransit`);
     hideAnimation();
     
     const allBoxesShippedBySiteAndNotReceived = getRecentBoxesShippedBySiteNotReceived(response.data);
@@ -189,7 +189,7 @@ const manifestButton = (allBoxesShippedBySiteAndNotReceived, bagIdArr, manifestM
 
             manifestModalBodyEl.innerHTML = modalBody;
             showAnimation();
-            const searchSpecimenByRequestedSiteResponse = await searchSpecimenByRequestedSiteAndBoxID(loginSite, boxNumber);
+            const searchSpecimenByRequestedSiteResponse = await searchSpecimenByRequestedSiteAndBoxId(loginSite, boxNumber);
             const searchSpecimenInstituteArray = searchSpecimenByRequestedSiteResponse?.data ?? [];
 
             modalBody = 

--- a/src/shared.js
+++ b/src/shared.js
@@ -871,8 +871,8 @@ export const searchSpecimenInstitute = async () => {
  * @returns {object} returns a response object
  * 
  */
-export const searchSpecimenByRequestedSiteAndBoxID = async (requestedSite, boxId) => {
-    logAPICallStartDev('searchSpecimenByRequestedSiteAndBoxID');
+export const searchSpecimenByRequestedSiteAndBoxId = async (requestedSite, boxId) => {
+    logAPICallStartDev('searchSpecimenByRequestedSiteAndBoxId');
     const idToken = await getIdToken();
     const response = await fetch(`${api}api=searchSpecimen&requestedSite=${requestedSite}&boxId=${boxId}`, {
     method: "GET",
@@ -880,7 +880,7 @@ export const searchSpecimenByRequestedSiteAndBoxID = async (requestedSite, boxId
         Authorization:"Bearer "+idToken
         }
     });
-    logAPICallEndDev('searchSpecimenByRequestedSiteAndBoxID');
+    logAPICallEndDev('searchSpecimenByRequestedSiteAndBoxId');
     if (response.status === 200) {
         const responseObject = await response.json();
         return responseObject;

--- a/src/shared.js
+++ b/src/shared.js
@@ -866,10 +866,10 @@ export const searchSpecimenInstitute = async () => {
 }
 
 /**
- * Fetches biospecimen collection data from the database via login site number 
- * @param {number} login site number
- * @returns {object} returns a response object
- * 
+ * Fetches biospecimen collection data from the database via healthcare provider number and boxId
+ * @param {number} requestedSite - healthcare provider/site's number
+ * @param {str} boxId - boxId of the box
+ * @returns {object} returns a response object of biospecimen documents with matching collection ids from healthcare provider's box id
  */
 export const searchSpecimenByRequestedSiteAndBoxId = async (requestedSite, boxId) => {
     logAPICallStartDev('searchSpecimenByRequestedSiteAndBoxId');

--- a/src/shared.js
+++ b/src/shared.js
@@ -764,20 +764,22 @@ export const getBoxes = async () => {
   return { data: boxesToReturn };
 };
 
-export const getAllBoxes = async (flag) => {
-  logAPICallStartDev('getAllBoxes');
-  const idToken = await getIdToken();
-  if (flag !== `bptl`) flag = ``
-  const response = await fetch(`${api}api=searchBoxes&source=${flag}`, {
-    method: 'GET',
-    headers: {
-      Authorization: 'Bearer ' + idToken,
-    }
-  });
-  let res = await response.json();
-  res.data = res.data.map(convertToOldBox);
-  logAPICallEndDev('getAllBoxes');
-  return res;
+export const getAllBoxes = async (flagValue) => {
+    logAPICallStartDev('getAllBoxes');
+    const idToken = await getIdToken()
+    let flag = ``;
+
+    if (flagValue === `bptl` || flagValue === `bptlPackagesInTransit`) flag = flagValue;
+    const response = await fetch(`${api}api=searchBoxes&source=${flag}`, {
+        method: 'GET',
+        headers: {
+        Authorization: 'Bearer ' + idToken,
+        }
+    });
+    let res = await response.json();
+    res.data = res.data.map(convertToOldBox);
+    logAPICallEndDev('getAllBoxes');
+    return res;
 };
 
 // searches boxes collection by login site (789843387) and Site-specific location id (560975149)
@@ -869,16 +871,16 @@ export const searchSpecimenInstitute = async () => {
  * @returns {object} returns a response object
  * 
  */
-export const searchSpecimenByRequestedSite = async (requestedSite) => {
-    logAPICallStartDev('searchSpecimenByRequestedSite');
+export const searchSpecimenByRequestedSiteAndBoxID = async (requestedSite, boxId) => {
+    logAPICallStartDev('searchSpecimenByRequestedSiteAndBoxID');
     const idToken = await getIdToken();
-    const response = await fetch(`${api}api=searchSpecimen&requestedSite=${requestedSite}`, {
+    const response = await fetch(`${api}api=searchSpecimen&requestedSite=${requestedSite}&boxId=${boxId}`, {
     method: "GET",
     headers: {
         Authorization:"Bearer "+idToken
         }
     });
-    logAPICallEndDev('searchSpecimenByRequestedSite');
+    logAPICallEndDev('searchSpecimenByRequestedSiteAndBoxID');
     if (response.status === 200) {
         const responseObject = await response.json();
         return responseObject;


### PR DESCRIPTION
Related Links: 
[Phase 2 Enhancements](https://github.com/episphere/connect/issues/708) 
[Issue#548](https://github.com/episphere/biospecimen/issues/548)
[Related connectFaas PR#431](https://github.com/episphere/connectFaas/pull/431)  

**This issue addresses the problems of the slow manifest loading page.** 

Changes were done to existing client side functions to return less documents.

**The following was done:**
- removed logic to filter out boxes that are shipped, has shipped timestamp and not received (backend query will replace logic)
- added `bptlPackagesInTransit` flag to req.query.source to get filtered return of boxes from all sites
- changed name from `searchSpecimenByRequestedSite` to `searchSpecimenByRequestedSiteAndBoxId` 