### PR TITLE
Biospecimen Dashboard: Shipping Report Bug

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -2305,33 +2305,19 @@ export const populateBoxTable = async (page, filter, source) => {
         for (let j = 0; j < keys.length; j++) {
             numTubes += currPage['bags'][keys[j]]['arrElements'].length;
         }
-        let shippedDate = ''
-        let receivedDate = ''
-        let packagedCondition = ''
-
-        if (currPage.hasOwnProperty('656548982')) {
-            const shippedDateStr = currPage['656548982'];
-            shippedDate = retrieveDateFromIsoString(shippedDateStr)
-        }
-
-        if(currPage.hasOwnProperty('926457119')) {
-            const receivedDateStr = currPage['926457119']
-            receivedDate = retrieveDateFromIsoString(receivedDateStr)
-        }
-
-        if(currPage.hasOwnProperty('238268405')) {
-          packagedCondition = currPage['238268405']
-        }
+        const shippedDate = currPage['656548982'] ? retrieveDateFromIsoString(currPage['656548982']) : '';
+        const receivedDate = currPage['926457119'] ? retrieveDateFromIsoString(currPage['926457119']) : '';
+        const packagedCondition = currPage['238268405'] || '';
 
         currRow.insertCell(0).innerHTML = currPage[conceptIds.shippingTrackingNumber] ?? '';
         currRow.insertCell(1).innerHTML = shippedDate;
         currRow.insertCell(2).innerHTML = conceptIdToSiteSpecificLocation[currPage['560975149']];
         currRow.insertCell(3).innerHTML = currPage['132929440'];
         currRow.insertCell(4).innerHTML = '<button type="button" class="button btn btn-info" id="reportsViewManifest' + i + '">View manifest</button>';
-        currRow.insertCell(5).innerHTML = currPage.hasOwnProperty('333524031') ? "Yes" : "No"
+        currRow.insertCell(5).innerHTML = currPage['333524031'] === 353358909 ? "Yes" : "No"
         currRow.insertCell(6).innerHTML = receivedDate;
         currRow.insertCell(7).innerHTML = convertConceptIdToPackageCondition(packagedCondition, packageConditonConversion);
-        currRow.insertCell(8).innerHTML = currPage.hasOwnProperty('870456401') ? currPage['870456401'] : '' ;
+        currRow.insertCell(8).innerHTML = currPage['870456401'] || '' ;
         addEventViewManifestButton('reportsViewManifest' + i, currPage, source);
 
     }


### PR DESCRIPTION
This PR addresses following issue:
When you search for Packages listed as in Transit they do come up as expected. But show they have been received. 
This is not expected behavior & the packages that are in Transit should not say yes for received.

https://github.com/episphere/biospecimen/pull/585

PoC:
![Screenshot 2023-09-27 at 12 39 34 PM](https://github.com/episphere/biospecimen/assets/30497847/382b708b-d036-4d7f-b5a7-553b3398a1ce)


