### PR TITLE
Rename array param to participantObjToken

### DIFF
--- a/src/shared.js
+++ b/src/shared.js
@@ -517,7 +517,7 @@ export const updateSpecimen = async (array) => {
     return response.json();
 }
 
-export const checkDerivedVariables = async (array) => {
+export const checkDerivedVariables = async (participantObjToken) => {
     const idToken = await getIdToken();
     let requestObj = {
         method: "POST",
@@ -525,7 +525,7 @@ export const checkDerivedVariables = async (array) => {
             Authorization:"Bearer "+idToken,
             "Content-Type": "application/json"
         },
-        body: JSON.stringify(array)
+        body: JSON.stringify(participantObjToken)
     }
     const response = await fetch(`${api}api=checkDerivedVariables`, requestObj);
     return response.json();


### PR DESCRIPTION
This PR is related to the following links:

Issue: 
- https://github.com/episphere/connect/issues/740

PR related: 
- https://github.com/episphere/connectFaas/pull/439

---
Issue#740 Problem: 
- University of Chicago Participants are currently excluded from 'NORC Incentive Eligible' at baseline.

Issue#740 Solution: 
- Refer to [ConnectFaas PR#439](https://github.com/episphere/connectFaas/pull/439)

---

Code change:
- Renamed `checkDerivedVariables` function's parameter

When `checkDerivedVariables` is called the argument is an object instead of an array. 
[Reference link function](https://github.com/episphere/biospecimen/blob/dev/src/events.js#L1571) --> `await checkDerivedVariables({"token": participantData["token"]});` 
