### PR TITLE
Remove clinical dashboard stage exclusion for HP

### DIFF
--- a/src/pages/welcome.js
+++ b/src/pages/welcome.js
@@ -27,7 +27,7 @@ const welcomeScreenTemplate = (name, data, auth, route) => {
     let template = '';
     let dashboardSelectionStr = '';
 
-    if (location.host === urls.stage || location.host === urls.prod) { 
+    if (location.host === urls.prod) { 
         researchOnlySiteArray.push('HP')
     }
 


### PR DESCRIPTION
Related Links

Issue:
- https://github.com/episphere/connect/issues/770

---
Problem/Solution

- Problem: Give HP access to Clinical Dashboard
- Solution: Removed HP Clinical Dashboard exclusion logic

---

Code Changes

- Removed `location.host === urls.stage` expression in condition