### PR TITLE
Give HP Access to Clinical Dashboard in Production

### DIFF
--- a/src/pages/welcome.js
+++ b/src/pages/welcome.js
@@ -27,10 +27,6 @@ const welcomeScreenTemplate = (name, data, auth, route) => {
     let template = '';
     let dashboardSelectionStr = '';
 
-    if (location.host === urls.prod) { 
-        researchOnlySiteArray.push('HP')
-    }
-
     if (clinicalOnlySiteArray.includes(data.siteAcronym)) {
         dashboardSelectionStr = `                    
             <select required disabled class="col form-control" id="dashboardSelection">


### PR DESCRIPTION
Related Links

Issue:

- https://github.com/episphere/connect/issues/808
- https://github.com/episphere/biospecimen/pull/601
---

Problem/Solution

Problem: Give HP access to Clinical Dashboard in Prod
Solution: Removed HP Clinical Dashboard exclusion logic

---
Code Changes

Removed if statement conditional `if (location.host === urls.prod)` 