### PR TITLE
streck tube missing placeholder data fix

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -1,6 +1,6 @@
 import { appState, performSearch, showAnimation, addBiospecimenUsers, getSpecimensByCollectionIds, hideAnimation, showNotifications, biospecimenUsers, removeBiospecimenUsers, findParticipant,
         errorMessage, removeAllErrors, storeSpecimen, updateSpecimen, searchSpecimen, generateBarCode, updateBox,
-        ship, disableInput, updateNewTempDate, getSiteTubesLists, getWorkflow, 
+        ship, disableInput, updateNewTempDate, getSiteTubesLists, getWorkflow, fixMissingTubeData,
         getSiteCouriers, getPage, getNumPages, removeSingleError, displayContactInformation, checkShipForage, checkAlertState, retrieveDateFromIsoString,
         convertConceptIdToPackageCondition, checkFedexShipDuplicate, shippingDuplicateMessage, checkInParticipant, checkOutParticipant, getCheckedInVisit, shippingPrintManifestReminder,
         checkNonAlphanumericStr, shippingNonAlphaNumericStrMessage, visitType, getParticipantCollections, updateBaselineData, getUpdatedParticipantData,
@@ -1343,6 +1343,12 @@ const collectionSubmission = async (participantData, biospecimenData, cntd) => {
 
     inputFields.forEach(input => {
         const tubes = siteTubesList.filter(tube => tube.concept === input.id.replace('Id', ''));
+        
+        const tubeConceptId = input.id.replace('Id', '');
+        if (biospecimenData[tubeConceptId] === undefined) {
+            const tubePlaceholderData = siteTubesList.find(stockTube => stockTube.concept === tubeConceptId);
+            fixMissingTubeData(tubePlaceholderData, biospecimenData[tubeConceptId] = {});
+        }
 
         let value = getValue(`${input.id}`).toUpperCase();
         const masterID = value.substr(0, masterSpecimenIDRequirement.length);
@@ -1377,7 +1383,7 @@ const collectionSubmission = async (participantData, biospecimenData, cntd) => {
             focus = false;
         }
 
-        if (input.required) biospecimenData[`${input.id.replace('Id', '')}`][conceptIds.collection.tube.scannedId] = `${masterID} ${tubeID}`.trim();
+        if (input.required) biospecimenData[tubeConceptId][conceptIds.collection.tube.scannedId] = `${masterID} ${tubeID}`.trim();
     });
 
     if ((hasError && cntd == true) || hasCntdError) return;

--- a/src/pages/collectProcess.js
+++ b/src/pages/collectProcess.js
@@ -1,5 +1,5 @@
 import { addEventSelectAllCollection, addEventBiospecimenCollectionForm, addEventBiospecimenCollectionFormToggles, addEventBackToSearch, addEventBiospecimenCollectionFormEdit, addEventBiospecimenCollectionFormEditAll, addEventBiospecimenCollectionFormText } from './../events.js'
-import { removeActiveClass, generateBarCode, addEventBarCodeScanner, visitType, getSiteTubesLists, getWorkflow, getCheckedInVisit, findParticipant, checkedIn } from '../shared.js';
+import { checkTubeDataConsistency, removeActiveClass, generateBarCode, visitType, getSiteTubesLists, getWorkflow, findParticipant, checkedIn } from '../shared.js';
 import { checkInTemplate } from './checkIn.js';
 import { conceptIds } from '../fieldToConceptIdMapping.js';
 
@@ -63,6 +63,8 @@ export const tubeCollectedTemplate = (participantData, biospecimenData) => {
                     <tbody>`
                     
                     let siteTubesList = getSiteTubesLists(biospecimenData);
+                    checkTubeDataConsistency(siteTubesList, biospecimenData);
+
                     const collectionFinalized = (biospecimenData[conceptIds.collection.isFinalized] === conceptIds.yes);
                     
                     if(!siteTubesList || siteTubesList?.length === 0) siteTubesList = [];


### PR DESCRIPTION
We've had intermittent issues with missing streck tube data on collection creation. This causes sites to be unable to save and finalize collections.

This update checks firestore collection data against expected data. If firestore data is missing a tube placeholder, we add that placeholder tube data. Then the save and finalize operations work as expected.