### PR TITLE
Add Accession ID information to Clinical Data Collection and Collection Summary screens 

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -145,7 +145,6 @@ export const addEventsearchSpecimen = () => {
             return
         }
         const biospecimenData = biospecimen.data;
-        console.log("🚀 ~ file: events.js:148 ~ addEventsearchSpecimen ~ biospecimenData:", biospecimenData)
 
         if(getWorkflow() === 'research') {
             if(biospecimenData[conceptIds.collection.collectionSetting] !== conceptIds.research) {

--- a/src/events.js
+++ b/src/events.js
@@ -145,6 +145,7 @@ export const addEventsearchSpecimen = () => {
             return
         }
         const biospecimenData = biospecimen.data;
+        console.log("🚀 ~ file: events.js:148 ~ addEventsearchSpecimen ~ biospecimenData:", biospecimenData)
 
         if(getWorkflow() === 'research') {
             if(biospecimenData[conceptIds.collection.collectionSetting] !== conceptIds.research) {
@@ -152,8 +153,7 @@ export const addEventsearchSpecimen = () => {
                 showNotifications({ title: 'Incorrect Dashboard', body: 'Clinical Collections cannot be viewed on Research Dashboard' });
                 return;
             }
-        }
-        else {
+        } else {
             if(biospecimenData[conceptIds.collection.collectionSetting] === conceptIds.research) {
                 hideAnimation();
                 showNotifications({ title: 'Incorrect Dashboard', body: 'Research Collections cannot be viewed on Clinical Dashboard' });

--- a/src/fieldToConceptIdMapping.js
+++ b/src/fieldToConceptIdMapping.js
@@ -79,6 +79,7 @@ export const conceptIds = {
         collectionTime: 678166505,
         scannedTime: 915838974,
         receivedDate: 926457119,
+        bloodAccessNumber: 646899796,
         urineAccessNumber: 928693120,
         reasonNotCollectedOther: 181769837,
         phlebotomistInitials: 719427591,

--- a/src/pages/collectProcess.js
+++ b/src/pages/collectProcess.js
@@ -14,8 +14,14 @@ export const tubeCollectedTemplate = (participantData, biospecimenData) => {
         </br>
         <div class="row">
             <div class="col">
-                <div class="row"><h5>${participantData[conceptIds.firstName]}, ${participantData[conceptIds.lastName]}</h5></div>
+                <div class="row"><h5>${participantData[conceptIds.lastName]}, ${participantData[conceptIds.firstName]}</h5></div>
                 <div class="row">Connect ID: <svg id="connectIdBarCode"></svg></div>
+                <div class="row">
+                    ${biospecimenData[conceptIds.collection.bloodAccessNumber] ? `Blood Accesion ID: ${biospecimenData[conceptIds.collection.bloodAccessNumber].toString()}` : ''}
+                </div>
+                <div class="row">
+                    ${biospecimenData[conceptIds.collection.urineAccessNumber] ? `Urine Accession ID: ${biospecimenData[conceptIds.collection.urineAccessNumber].toString()}` : ''}
+                </div>
                 <div class="row">Collection ID: ${biospecimenData[conceptIds.collection.id]}</div>
                 <div class="row">Collection ID Link Date/Time: ${getWorkflow() === 'research' ? new Date(biospecimenData[conceptIds.collection.collectionTime]).toLocaleString(): new Date(biospecimenData[conceptIds.collection.scannedTime]).toLocaleString()}</div>
                 ${getWorkflow() === 'research' ? `

--- a/src/pages/collectProcess.js
+++ b/src/pages/collectProcess.js
@@ -17,10 +17,10 @@ export const tubeCollectedTemplate = (participantData, biospecimenData) => {
                 <div class="row"><h5>${participantData[conceptIds.lastName]}, ${participantData[conceptIds.firstName]}</h5></div>
                 <div class="row">Connect ID: <svg id="connectIdBarCode"></svg></div>
                 <div class="row">
-                    ${biospecimenData[conceptIds.collection.bloodAccessNumber] ? `Blood Accesion ID: ${biospecimenData[conceptIds.collection.bloodAccessNumber].toString()}` : ''}
+                    ${biospecimenData[conceptIds.collection.bloodAccessNumber] ? `Blood Accesion ID: ${biospecimenData[conceptIds.collection.bloodAccessNumber]}` : ''}
                 </div>
                 <div class="row">
-                    ${biospecimenData[conceptIds.collection.urineAccessNumber] ? `Urine Accession ID: ${biospecimenData[conceptIds.collection.urineAccessNumber].toString()}` : ''}
+                    ${biospecimenData[conceptIds.collection.urineAccessNumber] ? `Urine Accession ID: ${biospecimenData[conceptIds.collection.urineAccessNumber]}` : ''}
                 </div>
                 <div class="row">Collection ID: ${biospecimenData[conceptIds.collection.id]}</div>
                 <div class="row">Collection ID Link Date/Time: ${getWorkflow() === 'research' ? new Date(biospecimenData[conceptIds.collection.collectionTime]).toLocaleString(): new Date(biospecimenData[conceptIds.collection.scannedTime]).toLocaleString()}</div>

--- a/src/pages/finalize.js
+++ b/src/pages/finalize.js
@@ -4,7 +4,7 @@ import {searchTemplate} from "./dashboard.js";
 import { collectionIdSearchScreenTemplate } from "./reports/collectionIdSearch.js";
 import { conceptIds } from "./../fieldToConceptIdMapping.js";
 
-export const finalizeTemplate = (data, specimenData, bptlCollectionFlag) => {
+export const finalizeTemplate = (participantData, specimenData, bptlCollectionFlag) => {
     removeActiveClass('navbar-btn', 'active')
     const navBarBtn = document.getElementById('navBarReview');
     navBarBtn?.classList.remove('disabled');
@@ -19,7 +19,7 @@ export const finalizeTemplate = (data, specimenData, bptlCollectionFlag) => {
         </br>
         <div class="row">
             <div class="col">
-                <div class="row"><h5>${data['996038075'] && data['996038075']}, ${data['399159511'] && data['399159511']}</h5></div>
+                <div class="row"><h5>${participantData[conceptIds.lastName] && participantData[conceptIds.lastName]}, ${participantData[conceptIds.firstName] && participantData[conceptIds.firstName]}</h5></div>
                 <div class="row">Connect ID: <svg id="connectIdBarCode"></svg></div>
                 <div class="row">
                     ${specimenData[conceptIds.collection.bloodAccessNumber] ? `Blood Accesion ID: ${specimenData[conceptIds.collection.bloodAccessNumber]}` : ''}
@@ -27,15 +27,15 @@ export const finalizeTemplate = (data, specimenData, bptlCollectionFlag) => {
                 <div class="row">
                     ${specimenData[conceptIds.collection.urineAccessNumber] ? `Urine Accession ID: ${specimenData[conceptIds.collection.urineAccessNumber]}` : ''}
                 </div>
-                <div class="row">Collection ID: ${specimenData['820476880']}</div>
-                <div class="row">Collection ID Link Date/Time: ${getWorkflow() === 'research' ? new Date(specimenData['678166505']).toLocaleString(): new Date(specimenData['915838974']).toLocaleString()}</div>
+                <div class="row">Collection ID: ${specimenData[conceptIds.collection.id]}</div>
+                <div class="row">Collection ID Link Date/Time: ${getWorkflow() === 'research' ? new Date(specimenData[conceptIds.collection.collectionTime]).toLocaleString(): new Date(specimenData[conceptIds.collection.scannedTime]).toLocaleString()}</div>
                 ${getWorkflow() === 'research' ? `
                 ${bptlCollectionFlag === true ? 
                     `<div class="row">
                         <div>Collection Setting: Research</div>
                 </div>` : ``}
                     <div class="row">
-                        <div>Collection Phlebotomist Initials: ${specimenData['719427591'] || ''}</div>
+                        <div>Collection Phlebotomist Initials: ${specimenData[conceptIds.collection.phlebotomistInitials] || ''}</div>
                     </div>` 
                     
                     : `<div class="row">
@@ -43,11 +43,11 @@ export const finalizeTemplate = (data, specimenData, bptlCollectionFlag) => {
                         <div>Collection Setting: Clinical</div>` : ``}
                     </div>`
                 }
-                ${bptlCollectionFlag === true ? `<div class="row"> Site: ${keyToNameObj[data['827220437']]} </div>` : ``}
+                ${bptlCollectionFlag === true ? `<div class="row"> Site: ${keyToNameObj[participantData[conceptIds.healthcareProvider]]} </div>` : ``}
             </div>
-            ${specimenData['331584571'] ? `
+            ${specimenData[conceptIds.collection.selectedVisit] ? `
                 <div class="ml-auto form-group">
-                    Visit: ${visitType.filter(visit => visit.concept == specimenData['331584571'])[0].visitType}
+                    Visit: ${visitType.filter(visit => visit.concept == specimenData[conceptIds.collection.selectedVisit])[0].visitType}
                 </div>
             ` : ``
             }
@@ -75,18 +75,18 @@ export const finalizeTemplate = (data, specimenData, bptlCollectionFlag) => {
 
                     if(obj.deviationOptions) {
                         obj.deviationOptions.forEach(option => {
-                            if(specimenData[obj.concept]['248868659'][option.concept] === 353358909) deviationSelections.push(option.label);
+                            if(specimenData[obj.concept][conceptIds.collection.tube.deviation][option.concept] === conceptIds.yes) deviationSelections.push(option.label);
                         });
                     }
                     template += `
                         <tr style="vertical-align: top;">
                             <td>${obj.specimenType}</td>
-                            <td>${obj.collectionChkBox === true ? `${specimenData[`${obj.concept}`]['593843561'] === 353358909 ? '<i class="fas fa-check"></i>' : '<i class="fas fa-times"></i>'}` : ``}</td>
-                            ${getWorkflow() === 'research' ? `<td>${specimenData[`${obj.concept}`]['883732523'] ? notCollectedOptions.filter(option => option.concept == specimenData[`${obj.concept}`]['883732523'])[0].label : ''}</td>` : ''}
-                            <td>${specimenData[`${obj.concept}`]['593843561'] === 353358909 && specimenData[`${obj.concept}`]['825582494'] ? `${specimenData[`${obj.concept}`]['825582494']}` : '' }</td>
-                            <td>${obj.deviationChkBox === true ? `${specimenData[`${obj.concept}`]['678857215'] === 353358909 ? 'Yes' : 'No'}`: ``}</td>
+                            <td>${obj.collectionChkBox === true ? `${specimenData[`${obj.concept}`][conceptIds.collection.tube.isCollected] === conceptIds.yes ? '<i class="fas fa-check"></i>' : '<i class="fas fa-times"></i>'}` : ``}</td>
+                            ${getWorkflow() === 'research' ? `<td>${specimenData[`${obj.concept}`][conceptIds.collection.tube.selectReasonNotCollected] ? notCollectedOptions.filter(option => option.concept == specimenData[`${obj.concept}`][conceptIds.collection.tube.selectReasonNotCollected])[0].label : ''}</td>` : ''}
+                            <td>${specimenData[`${obj.concept}`][conceptIds.collection.tube.isCollected] === conceptIds.yes && specimenData[`${obj.concept}`][conceptIds.collection.tube.scannedId] ? `${specimenData[`${obj.concept}`][conceptIds.collection.tube.scannedId]}` : '' }</td>
+                            <td>${obj.deviationChkBox === true ? `${specimenData[`${obj.concept}`][conceptIds.collection.tube.isDeviated] === conceptIds.yes ? 'Yes' : 'No'}`: ``}</td>
                             <td class="deviation-type-width">${deviationSelections ? getDeviationSelections(deviationSelections) : ''}</td>
-                            <td class="deviation-comments-width">${specimenData[`${obj.concept}`]['536710547'] ? specimenData[`${obj.concept}`]['536710547'] : specimenData[`${obj.concept}`]['338286049'] ? specimenData[`${obj.concept}`]['338286049'] : ''}</td>
+                            <td class="deviation-comments-width">${specimenData[`${obj.concept}`][conceptIds.collection.tube.deviationComments] ? specimenData[`${obj.concept}`][conceptIds.collection.tube.deviationComments] : specimenData[`${obj.concept}`][conceptIds.collection.tube.optionalNotCollectedDetails] ? specimenData[`${obj.concept}`][conceptIds.collection.tube.optionalNotCollectedDetails] : ''}</td>
                         </tr>
                     `
                 });
@@ -99,7 +99,7 @@ export const finalizeTemplate = (data, specimenData, bptlCollectionFlag) => {
                     <div class="col">
                         <label for="finalizedAdditionalNotes">Additional Notes (Optional)</label>
                         </br>
-                        <textarea rows=3 disabled class="form-control" id="finalizedAdditionalNotes">${specimenData['338570265'] ? `${specimenData['338570265']}` : ''}</textarea>
+                        <textarea rows=3 disabled class="form-control" id="finalizedAdditionalNotes">${specimenData[conceptIds.collection.note] ? `${specimenData[conceptIds.collection.note]}` : ''}</textarea>
                     </div>
                 </div>
                 </br>
@@ -111,13 +111,13 @@ export const finalizeTemplate = (data, specimenData, bptlCollectionFlag) => {
                     </div>
                     ` :`<div class="form-group row">
                 <div class="col-auto">
-                    <button class="btn btn-outline-danger" type="button" data-connect-id="${data.Connect_ID}" id="returnToCollectProcess" data-master-specimen-id="${specimenData['820476880']}">${getWorkflow() === 'research' ? 'Return to Collection Data Entry' : 'Return to Collection Data Entry'}</button>
+                    <button class="btn btn-outline-danger" type="button" data-connect-id="${participantData.Connect_ID}" id="returnToCollectProcess" data-master-specimen-id="${specimenData[conceptIds.collection.id]}">${getWorkflow() === 'research' ? 'Return to Collection Data Entry' : 'Return to Collection Data Entry'}</button>
                 </div>
                 <div class="ml-auto">
-                    <button class="btn btn-outline-warning" data-connect-id="${data.Connect_ID}" data-master-specimen-id="${specimenData['820476880']}" type="button" id="finalizedSaveExit">Exit</button>
+                    <button class="btn btn-outline-warning" data-connect-id="${participantData.Connect_ID}" data-master-specimen-id="${specimenData[conceptIds.collection.id]}" type="button" id="finalizedSaveExit">Exit</button>
                 </div>
                 <div class="col-auto">
-                    <button class="btn btn-outline-primary modal-open" data-modal-id="modal1" data-connect-id="${data.Connect_ID}" data-master-specimen-id="${specimenData['820476880']}" type="submit" id="finalizedContinue">Review Complete</button>
+                    <button class="btn btn-outline-primary modal-open" data-modal-id="modal1" data-connect-id="${participantData.Connect_ID}" data-master-specimen-id="${specimenData[conceptIds.collection.id]}" type="submit" id="finalizedContinue">Review Complete</button>
                 </div>
             </div>`}
             </form>
@@ -164,7 +164,7 @@ export const finalizeTemplate = (data, specimenData, bptlCollectionFlag) => {
         </div>
     `;
     document.getElementById('contentBody').innerHTML = template;
-    generateBarCode('connectIdBarCode', data.Connect_ID);
+    generateBarCode('connectIdBarCode', participantData.Connect_ID);
 
     document.getElementById('finalizedSaveExit') && document.getElementById('finalizedSaveExit').addEventListener('click', () => {
         searchTemplate();

--- a/src/pages/finalize.js
+++ b/src/pages/finalize.js
@@ -21,6 +21,12 @@ export const finalizeTemplate = (data, specimenData, bptlCollectionFlag) => {
             <div class="col">
                 <div class="row"><h5>${data['996038075'] && data['996038075']}, ${data['399159511'] && data['399159511']}</h5></div>
                 <div class="row">Connect ID: <svg id="connectIdBarCode"></svg></div>
+                <div class="row">
+                    ${specimenData[conceptIds.collection.bloodAccessNumber] ? `Blood Accesion ID: ${specimenData[conceptIds.collection.bloodAccessNumber]}` : ''}
+                </div>
+                <div class="row">
+                    ${specimenData[conceptIds.collection.urineAccessNumber] ? `Urine Accession ID: ${specimenData[conceptIds.collection.urineAccessNumber]}` : ''}
+                </div>
                 <div class="row">Collection ID: ${specimenData['820476880']}</div>
                 <div class="row">Collection ID Link Date/Time: ${getWorkflow() === 'research' ? new Date(specimenData['678166505']).toLocaleString(): new Date(specimenData['915838974']).toLocaleString()}</div>
                 ${getWorkflow() === 'research' ? `

--- a/src/pages/reports/collectionIdSearch.js
+++ b/src/pages/reports/collectionIdSearch.js
@@ -70,9 +70,9 @@ const searchSpecimenEvent = () => {
         const response = await findParticipant(query);
         hideAnimation();
         try {
-            const data = response.data[0];
+            const participantData = response.data[0];
             localStorage.setItem('workflow', biospecimenData[fieldToConceptIdMapping.collectionType] === fieldToConceptIdMapping.clinical ? `clinical` : `research`);
-            finalizeTemplate(data, biospecimenData, true); // Boolean flag: true; is passed down to finalizeTemplate & to distinguish collection id search from bptl and biospecimen."
+            finalizeTemplate(participantData, biospecimenData, true); // Boolean flag: true; is passed down to finalizeTemplate & to distinguish collection id search from bptl and biospecimen."
         }
         catch {
             showNotifications({ title: 'Not found', body: 'Participant not found!' })


### PR DESCRIPTION
Related Links

Issue: 
- https://github.com/episphere/connect/issues/589

Overview

- Accession ID information needs to be added to "Clinical Data Collection" and "Collection Summary"

---
Code Changes

Main:

Added logic to display urine or blood accession ids if they exist in the biospecimen document data that is pulled. 

Extra:
- Replaced hard coded concept ids.
- Renamed `data` to `participantData`
- Changed order "first name, last name" to "last name, first name"

Images:
![Screenshot 2023-12-08 at 1 39 07 PM](https://github.com/episphere/biospecimen/assets/33293205/19ee485b-6b5a-4070-b570-0de830c06d8f)
 
![Screenshot 2023-12-08 at 1 39 21 PM](https://github.com/episphere/biospecimen/assets/33293205/50eeffe3-de71-49db-9125-e9eec66d75a3)


