### PR TITLE
BPTL Dashboard: remove additional check on trigger errror modal

### DIFF
--- a/src/shared.js
+++ b/src/shared.js
@@ -3073,7 +3073,7 @@ export const addBoxAndUpdateSiteDetails = async (boxAndSiteData) => {
 
 export const triggerErrorModal = (message) => {
     const alertList = document.getElementById("alert_placeholder");
-    if (alertList && message) {
+    if (alertList) {
     alertList.innerHTML = `
         <div class="alert alert-warning alert-dismissible fade show" role="alert">
             ${message}


### PR DESCRIPTION
This PR addresses following issue:
https://github.com/episphere/connect/issues/855

Error modal gets triggers by default after success modal is triggered.