### PR TITLE
BPTL Dashboard: Unexpected Behavior in Kit Assignment Confirmation

### DIFF
--- a/src/pages/homeCollection/assignKits.js
+++ b/src/pages/homeCollection/assignKits.js
@@ -156,8 +156,9 @@ const confirmAssignment = () => {
           triggerErrorModal('Error while assigning a kit.')
           return;
         }
-      }
-      finally {
+      } catch (error) {
+        triggerErrorModal('An error occurred:', error);
+      } finally {
         confirmAssignmentInAction = false;
       }
     })


### PR DESCRIPTION
Title^^

This PR addresses following issue: https://github.com/episphere/connect/issues/865

Confirm assignment button is being propagated twice when clicked only once. This leads to double API calls being made, resulting in the success and error banners appearing one after the other.

- Used state management to track participants
- Used event prevent default & try/finally to prevent double propagation
- _confirmAssignment()_ function need not be declared more than once