### PR TITLE
PROMIS Survey Updates (Biospecimen Dashboard)

### DIFF
--- a/src/fieldToConceptIdMapping.js
+++ b/src/fieldToConceptIdMapping.js
@@ -206,6 +206,10 @@ export const conceptIds = {
         submitted: 231311385
     },
 
+    promisStatus: 320303124,
+    promisStartTime: 870643066,
+    promiseCompleteTime: 843688458,
+
     REASON_NOT_COLLECTED: 883732523,
     REASONS: {
         PARTICIPANT_REFUSAL: 681745422

--- a/src/pages/checkIn.js
+++ b/src/pages/checkIn.js
@@ -1,4 +1,4 @@
-import { generateBarCode, removeActiveClass, visitType, checkedIn, getCheckedInVisit, verificationConversion, participationConversion, surveyConversion, getCollectionsByVisit, getParticipantCollections, getSiteTubesLists } from "./../shared.js";
+import { generateBarCode, removeActiveClass, visitType, checkedIn, getCheckedInVisit, verificationConversion, participationConversion, surveyConversion, getParticipantCollections, getSiteTubesLists } from "./../shared.js";
 import { addEventContactInformationModal, addEventCheckInCompleteForm, addEventBackToSearch, addEventVisitSelection } from "./../events.js";
 import { conceptIds } from '../fieldToConceptIdMapping.js';
 
@@ -374,6 +374,30 @@ const participantStatus = (data, collections) => {
                     </div>
                     <div class="row">
                         <span class="full-width">${data['663265240'] === 615768760 ? data['452942800'] : data['663265240'] === 231311385 ? data['264644252'] : '<br>'}</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+            
+        <br/>
+
+        <div class="row">
+            <div class="col-md-12">
+                <h5>Other Surveys</h5>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-4">
+                <div class="col-md-12 info-box">
+                    <div class="row">
+                        <span class="full-width">Quality of Life Survey</span>
+                    </div>
+                    <div class="row">
+                        <span class="full-width">${surveyConversion[data[conceptIds.promisStatus]]}</span>
+                    </div>    
+                    <div class="row">
+                        <span class="full-width">${data[conceptIds.promisStatus] === conceptIds.modules.started ? data[conceptIds.promisStartTime] : data[conceptIds.promisStatus] === conceptIds.modules.submitted ? data[conceptIds.promiseCompleteTime] : '<br>'}</span>
                     </div>
                 </div>
             </div>

--- a/src/shared.js
+++ b/src/shared.js
@@ -2291,6 +2291,7 @@ export const participationConversion = {
 };
 
 export const surveyConversion = {
+    '789789789': 'Not Yet Eligible', //placeholder
     '972455046': 'Not Started',
     '615768760': 'Started',
     '231311385': 'Submitted'

--- a/src/shared.js
+++ b/src/shared.js
@@ -2291,7 +2291,7 @@ export const participationConversion = {
 };
 
 export const surveyConversion = {
-    '789467219': 'Not Yet Eligible', //placeholder
+    '789467219': 'Not Yet Eligible', 
     '972455046': 'Not Started',
     '615768760': 'Started',
     '231311385': 'Submitted'

--- a/src/shared.js
+++ b/src/shared.js
@@ -2291,7 +2291,7 @@ export const participationConversion = {
 };
 
 export const surveyConversion = {
-    '789789789': 'Not Yet Eligible', //placeholder
+    '789467219': 'Not Yet Eligible', //placeholder
     '972455046': 'Not Started',
     '615768760': 'Started',
     '231311385': 'Submitted'


### PR DESCRIPTION
This PR addresses the following Issue:
* https://github.com/episphere/connect/issues/878
-----
## Background Details
* With the new PROMIS QOL Survey being added to the study we need to display the status of the survey for each participant when they check in to their biospecimen appointments.
-----
## Technical Changes
* Added status, start time, and complete time Concept IDs to `fieldToConceptIdMapping.js`
* Added new survey status option to `surveyConversion` in `shared.js`
* Added HTML block for survey in `checkIn.js`
 