### PR TITLE
919 replacement mouthwash tube handling

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -290,7 +290,6 @@ export const addEventAddSpecimensToListModalButton = (bagId, tableIndex, isOrpha
             try {
                 const boxUpdateResponse = await updateBox(boxToUpdate);
                 hideAnimation();
-                console.log('boxUpdateResponse', boxUpdateResponse);
                 if (boxUpdateResponse.code === 200) {
                     updateShippingStateAddBagToBox(currBoxId, bagId, boxToUpdate, boxUpdateResponse.data);
                     await startShipping(appState.getState().userName, true, currBoxId);

--- a/src/events.js
+++ b/src/events.js
@@ -158,7 +158,7 @@ export const addEventSearchSpecimen = () => {
 
 // Add specimen to box using the allBoxesList from state.
 // Return early if (1) no shipping location selected, (2) if the input is empty, (3) if item is already shipped, (4) if item is already in a box.
-export const addEventAddSpecimenToBox = () => {
+export const addEventAddSpecimenToBox = (currBoxId) => {
     const form = document.getElementById('addSpecimenForm');
     form.addEventListener('submit', async e => {
         e.preventDefault();
@@ -212,10 +212,10 @@ export const addEventAddSpecimenToBox = () => {
         }
     });
 
-    addEventSubmitSpecimenBuildModal();
+    addEventSubmitSpecimenBuildModal(currBoxId);
 }
 
-const addEventSubmitSpecimenBuildModal = () => {
+const addEventSubmitSpecimenBuildModal = (currBoxId) => {
     const submitButtonSpecimen = document.getElementById('submitMasterSpecimenId');
     submitButtonSpecimen.addEventListener('click', async e => {
         e.preventDefault();
@@ -227,7 +227,7 @@ const addEventSubmitSpecimenBuildModal = () => {
         const biospecimensList = specimenTablesResult.biospecimensList;
         const tableIndex = specimenTablesResult.tableIndex;
 
-        if (biospecimensList.length == 0) {
+        if (biospecimensList.length === 0) {
             showNotifications({ title: 'Not found', body: 'The specimen with entered search criteria was not found!' });
             hideAnimation();
             const delay = ms => new Promise(res => setTimeout(res, ms));
@@ -238,7 +238,21 @@ const addEventSubmitSpecimenBuildModal = () => {
 
         createShippingModalBody(biospecimensList, masterSpecimenId, foundInOrphan);
         addEventAddSpecimensToListModalButton(masterSpecimenId, tableIndex, foundInOrphan);
+        addEventCancelAddSpecimenToListModalButton(currBoxId);
     })
+}
+
+/**
+ * Handle the cancel button click event in the modal.
+ * This refresh clears existing event listeners (duplicates existed prior to this handler).
+ * @param {String} currBoxId - the current box id in the shipping dashboard
+ */
+export const addEventCancelAddSpecimenToListModalButton = (currBoxId) => {
+    const cancelButton = document.getElementById('shippingModalCancel');
+    cancelButton && cancelButton.addEventListener('click', () => {
+        document.getElementById('shippingCloseButton').click();
+        startShipping(appState.getState().userName, true, currBoxId);
+    });
 }
 
 export const addEventAddSpecimensToListModalButton = (bagId, tableIndex, isOrphan) => {
@@ -276,6 +290,7 @@ export const addEventAddSpecimensToListModalButton = (bagId, tableIndex, isOrpha
             try {
                 const boxUpdateResponse = await updateBox(boxToUpdate);
                 hideAnimation();
+                console.log('boxUpdateResponse', boxUpdateResponse);
                 if (boxUpdateResponse.code === 200) {
                     updateShippingStateAddBagToBox(currBoxId, bagId, boxToUpdate, boxUpdateResponse.data);
                     await startShipping(appState.getState().userName, true, currBoxId);

--- a/src/pages/receipts/csvFileReceipt.js
+++ b/src/pages/receipts/csvFileReceipt.js
@@ -1,4 +1,4 @@
-import { showAnimation, hideAnimation, getIdToken, keyToNameAbbreviationObj, keyToLocationObj, baseAPI, keyToNameCSVObj, formatISODateTimeDateOnly, convertISODateTime, getAllBoxes, conceptIdToSiteSpecificLocation, showNotifications, getCurrentDate, triggerSuccessModal, getSpecimensInBoxes, findReplacementTubeLabels } from "../../shared.js";
+import { showAnimation, hideAnimation, getIdToken, keyToNameAbbreviationObj, keyToLocationObj, baseAPI, keyToNameCSVObj, formatISODateTimeDateOnly, convertISODateTime, getAllBoxes, conceptIdToSiteSpecificLocation, showNotifications, getCurrentDate, miscTubeIdSet, triggerSuccessModal, getSpecimensInBoxes, findReplacementTubeLabels } from "../../shared.js";
 import { conceptIds as fieldToConceptIdMapping } from "../../fieldToConceptIdMapping.js";
 import { receiptsNavbar } from "./receiptsNavbar.js";
 import { nonUserNavBar } from "../../navbar.js";
@@ -172,7 +172,6 @@ const getSpecimensByReceivedDate = async (dateFilter) => {
  * BPTL wants to know what the original ID label should be (Ex: 0001-0024, 0060, not 0050-0054).
  * These need to be mapped to the key in the specimen object
  */
-const miscTubeIdSet = new Set(['0050', '0051', '0052', '0053', '0054']);
 
 const modifyBSIQueryResults = (results) => {
     const csvDataArray = [];

--- a/src/pages/shipping.js
+++ b/src/pages/shipping.js
@@ -148,7 +148,7 @@ const getStoredLocationOnInit = () => {
  * Note: Orphan panel is currently hidden by request of the product team. Retain for future use.
  *       Future orphan panel use would require completed state management implementation in the 'currDeleteButton' event listener.
  */
-    const populateAvailableCollectionsList = async (availableCollectionsObj, loadFromState = false) => {
+const populateAvailableCollectionsList = async (availableCollectionsObj, loadFromState = false) => {
 
     if (loadFromState) {
         availableCollectionsObj = appState.getState().availableCollectionsObj ?? {};

--- a/src/pages/shipping.js
+++ b/src/pages/shipping.js
@@ -1,5 +1,5 @@
 import { addBoxAndUpdateSiteDetails, appState, conceptIdToSiteSpecificLocation, combineAvailableCollectionsObjects, displayManifestContactInfo, filterDuplicateSpecimensInList, getAllBoxes, getBoxes, getSpecimensInBoxes, getUnshippedBoxes, getLocationsInstitute, getSiteMostRecentBoxId, getSpecimensByBoxedStatus, hideAnimation, locationConceptIDToLocationMap,
-        removeActiveClass, removeBag, removeMissingSpecimen, showAnimation, showNotifications, siteSpecificLocation, siteSpecificLocationToConceptId, sortBiospecimensList,
+        miscTubeIdSet, removeActiveClass, removeBag, removeMissingSpecimen, showAnimation, showNotifications, siteSpecificLocation, siteSpecificLocationToConceptId, sortBiospecimensList,
         translateNumToType, userAuthorization, getSiteAcronym, findReplacementTubeLabels } from "../shared.js"
 import { addDeviationTypeCommentsContent, addEventAddSpecimenToBox, addEventBackToSearch, addEventBoxSelectListChanged, addEventCheckValidTrackInputs,
         addEventCompleteShippingButton, addEventModalAddBox, addEventNavBarBoxManifest, addEventNavBarShipment, addEventNavBarShippingManifest, addEventNavBarAssignTracking, addEventLocationSelect,
@@ -109,12 +109,12 @@ const buildShippingInterface = async (userName, loadFromState, currBoxId) => {
             availableCollectionsObj = combineAvailableCollectionsObjects(specimens.notBoxed.availableCollections, specimens.partiallyBoxed.availableCollections);
             replacementTubeLabelObj = findReplacementTubeLabels(finalizedSpecimenList);
         }
-
+        
         populateAvailableCollectionsList(availableCollectionsObj, loadFromState);
         setAllShippingState(availableCollectionsObj, availableLocations, allBoxesList, finalizedSpecimenList, userName, replacementTubeLabelObj);
         populateViewShippingBoxContentsList(currBoxId);
         populateBoxesToShipTable();
-        addShippingEventListeners();
+        addShippingEventListeners(currBoxId);
 
     } catch (error) {
         console.error("Error building shipping interface:", error);
@@ -124,14 +124,14 @@ const buildShippingInterface = async (userName, loadFromState, currBoxId) => {
     }
 };
 
-const addShippingEventListeners = () => {
+const addShippingEventListeners = (currBoxId) => {
     const userName = appState.getState().userName;
     addEventNavBarShipment("navBarShippingDash", userName);
     addEventNavBarShippingManifest(userName);
     addEventBoxSelectListChanged();
     addEventNavBarBoxManifest("navBarBoxManifest");
     addEventLocationSelect("selectLocationList", "shipping_location");
-    addEventAddSpecimenToBox();
+    addEventAddSpecimenToBox(currBoxId);
     addEventModalAddBox();
 }
 
@@ -610,13 +610,20 @@ export const createShippingModalBody = (biospecimensList, masterBiospecimenId, i
     populateModalSelect(boxIdAndBagsObj);
 
     if (isBagEmpty) {
-        showNotifications({ title: 'Not found', body: 'The participant with entered search criteria not found!' });
+        showNotifications({ title: 'Not found', body: 'The specimen with entered search criteria not found!' });
         document.getElementById('shippingCloseButton').click();
         hideAnimation();
     }
 }
 
 const shouldAddModalRow = (isOrphan, splitTubeIdArray, tubeId) => {
+    // If the tube has a replacement label, use the original tube Id to determine if it should be added to the modal.
+    if (miscTubeIdSet.has(tubeId)) {
+        const fullTubeIdToSearch = splitTubeIdArray[0] + ' ' + tubeId;
+        const replacementTubeLabelObj = appState.getState().replacementTubeLabelObj;
+        const standardTubeId = replacementTubeLabelObj[fullTubeIdToSearch];
+        tubeId = standardTubeId ? standardTubeId.split(' ')[1] : tubeId;
+    }
     if (isOrphan) return true;
     if (splitTubeIdArray.length >= 2 && splitTubeIdArray[1] == '0008') {
         //look for all non-mouthwash (0007)
@@ -737,6 +744,13 @@ const handleAvailableCollectionsTableRows = (tableIndex, tubesToDelete) => {
 }
 
 const assignBagId = (tubeId, collectionId) => {
+    // If the tube has a replacement label, use the original tube Id to assign the bag Id.
+    if (miscTubeIdSet.has(tubeId)) {
+        const fullTubeIdToSearch = collectionId + ' ' + tubeId;
+        const standardTubeId = appState.getState().replacementTubeLabelObj[fullTubeIdToSearch];
+        tubeId = standardTubeId ? standardTubeId.split(' ')[1] : tubeId;
+    }
+
     if (tubeId === '0007') {
         return collectionId + ' 0009';
     } else {


### PR DESCRIPTION
Related: https://github.com/episphere/connect/issues/919

(1) Fix tube sorting to handle mouthwash tubes with replacement IDs 0050-0054. This updates the way Available Collections are sorted and maintained.

(2) Fix duplicate event listener error that occured on closing 'Specimen Verification' modal when adding to box. This modal was leading to duplicate event listeners when that modal was closed, reopened, and something was 'added to bag.'
Note: this operation wasn't actually failing. It was succeeding, then being attempted a second time because of the duplicate event listener. That led to a successful outcome but a confusing error message for the user.
Resolution: Reload from state on that modal's 'cancel' click.
<img width="412" alt="Screenshot 2024-03-08 at 11 39 34 AM" src="https://github.com/episphere/biospecimen/assets/93854858/810e0254-311f-46ba-b199-75fb8f22df70">
