### PR TITLE
905+908 fix

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -3,7 +3,7 @@ import {
     errorMessage, removeAllErrors, storeSpecimen, updateSpecimen, searchSpecimen, generateBarCode, updateBox,
     ship, disableInput, updateNewTempDate, getSiteTubesLists, getWorkflow, fixMissingTubeData,
     getSiteCouriers, getPage, getNumPages, removeSingleError, displayManifestContactInfo, checkShipForage, checkAlertState, retrieveDateFromIsoString,
-    convertConceptIdToPackageCondition, checkFedexShipDuplicate, shippingDuplicateMessage, checkInParticipant, checkOutParticipant, getCheckedInVisit, shippingPrintManifestReminder,
+    convertConceptIdToPackageCondition, checkFedexShipDuplicate, shippingDuplicateMessage, checkInParticipant, checkOutParticipant, getCheckedInVisit, participantCanCheckIn, shippingPrintManifestReminder,
     checkNonAlphanumericStr, shippingNonAlphaNumericStrMessage, visitType, getParticipantCollections, updateBaselineData,
     siteSpecificLocationToConceptId, conceptIdToSiteSpecificLocation, locationConceptIDToLocationMap, updateCollectionSettingData, convertToOldBox, translateNumToType,
     getCollectionsByVisit, getSpecimenAndParticipant, getUserProfile, checkDuplicateTrackingIdFromDb, checkAccessionId, checkSurveyEmailTrigger, checkDerivedVariables, isDeviceMobile, replaceDateInputWithMaskedInput, bagConceptIdList, showModalNotification, showTimedNotifications, showNotificationsCancelOrContinue, validateSpecimenAndParticipantResponse, findReplacementTubeLabels,
@@ -646,10 +646,20 @@ export const addEventVisitSelection = () => {
 
     const visitSelection = document.getElementById('visit-select');
     if(visitSelection) {
-        visitSelection.addEventListener('change', () => {
+        visitSelection.addEventListener('change', async () => {
 
             const checkInButton = document.getElementById('checkInComplete');
-            checkInButton.disabled = !visitSelection.value;
+            
+            // This should only apply to users who have not revoked their participation
+            const form = document.getElementById('checkInCompleteForm');
+            let query = `connectId=${parseInt(form.dataset.connectId)}`;
+            
+            const response = await findParticipant(query);
+            const data = response.data[0];
+            let canCheckIn = participantCanCheckIn(data);
+            if(canCheckIn) {
+                checkInButton.disabled = !visitSelection.value;
+            }
         });
     }
 }

--- a/src/fieldToConceptIdMapping.js
+++ b/src/fieldToConceptIdMapping.js
@@ -67,6 +67,12 @@ export const conceptIds = {
         refusedAllFutureActivities: 458508122,
         deceased: 618686157
     },
+
+    // Individual yes/no properties on the data
+    withdrewConsent: 747006172,
+    revokedHIPAA: 773707518,
+    destroyData: 831041022,
+    dataDestroyed: 861639549,
     
     // collection id
     collectionId: 825582494, //TODO: this ref should be named objectId or similar. collectionId is 820476880. 

--- a/src/fieldToConceptIdMapping.js
+++ b/src/fieldToConceptIdMapping.js
@@ -53,6 +53,20 @@ export const conceptIds = {
     tempProbe: 105891443,
     yes: 353358909,
     no: 104430631,
+
+    // Participation status
+
+    participationStatus: 912301837,
+    participationStatusCodes: {
+        noRefusal: 208325815,
+        refusedSomeActivities: 622008261,
+        revokedHIPAA: 872012139,
+        withdrewConsent: 854021266,
+        destroyData: 241236037,
+        dataDestroyed: 884452262,
+        refusedAllFutureActivities: 458508122,
+        deceased: 618686157
+    },
     
     // collection id
     collectionId: 825582494, //TODO: this ref should be named objectId or similar. collectionId is 820476880. 

--- a/src/pages/checkIn.js
+++ b/src/pages/checkIn.js
@@ -1,4 +1,4 @@
-import { generateBarCode, removeActiveClass, visitType, checkedIn, getCheckedInVisit, verificationConversion, participationConversion, surveyConversion, getParticipantCollections, getSiteTubesLists } from "./../shared.js";
+import { generateBarCode, removeActiveClass, visitType, checkedIn, participantCanCheckIn, getCheckedInVisit, verificationConversion, participationConversion, surveyConversion, getParticipantCollections, getSiteTubesLists } from "./../shared.js";
 import { addEventContactInformationModal, addEventCheckInCompleteForm, addEventBackToSearch, addEventVisitSelection } from "./../events.js";
 import { conceptIds } from '../fieldToConceptIdMapping.js';
 
@@ -12,6 +12,7 @@ export const checkInTemplate = async (data, checkOutFlag) => {
     }
 
     const isCheckedIn = checkedIn(data);
+    const canCheckInOrOut = participantCanCheckIn(data);
     const visit = getCheckedInVisit(data);
 
     const response = await getParticipantCollections(data.token);
@@ -77,13 +78,16 @@ export const checkInTemplate = async (data, checkOutFlag) => {
 
     template += await participantStatus(data, collections);
 
-    template += `
-            <div class="col">
-                <button class="btn btn-outline-primary btn-block text-nowrap" ${!isCheckedIn ? `disabled` : visitCollections.length > 0 ? `` : `disabled`} type="submit" id="checkInComplete">${isCheckedIn ? `Check-Out` : `Check-In`}</button>
-            </div>
+    if(canCheckInOrOut) {
+        template += `
+                <div class="col">
+                    <button class="btn btn-outline-primary btn-block text-nowrap" ${!isCheckedIn ? `disabled` : visitCollections.length > 0 ? `` : `disabled`} type="submit" id="checkInComplete">${isCheckedIn ? `Check-Out` : `Check-In`}</button>
+                </div>
 
-        </form>
-    `;
+            </form>
+        `;
+    }
+    
 
     document.getElementById('contentBody').innerHTML = template;
     generateBarCode('connectIdBarCode', data.Connect_ID);

--- a/src/pages/checkIn.js
+++ b/src/pages/checkIn.js
@@ -79,7 +79,7 @@ export const checkInTemplate = async (data, checkOutFlag) => {
     template += await participantStatus(data, collections);
 
 
-    if(canCheckIn) {
+    if (canCheckIn) {
         template += `
             <div class="col">
                 <button class="btn btn-outline-primary btn-block text-nowrap" ${!isCheckedIn ? `disabled` : visitCollections.length > 0 ? `` : `disabled`} type="submit" id="checkInComplete">${isCheckedIn ? `Check-Out` : `Check-In`}</button>

--- a/src/pages/checkIn.js
+++ b/src/pages/checkIn.js
@@ -12,7 +12,7 @@ export const checkInTemplate = async (data, checkOutFlag) => {
     }
 
     const isCheckedIn = checkedIn(data);
-    const canCheckInOrOut = participantCanCheckIn(data);
+    const canCheckIn = participantCanCheckIn(data);
     const visit = getCheckedInVisit(data);
 
     const response = await getParticipantCollections(data.token);
@@ -78,14 +78,24 @@ export const checkInTemplate = async (data, checkOutFlag) => {
 
     template += await participantStatus(data, collections);
 
-    if(canCheckInOrOut) {
-        template += `
-                <div class="col">
-                    <button class="btn btn-outline-primary btn-block text-nowrap" ${!isCheckedIn ? `disabled` : visitCollections.length > 0 ? `` : `disabled`} type="submit" id="checkInComplete">${isCheckedIn ? `Check-Out` : `Check-In`}</button>
-                </div>
 
-            </form>
-        `;
+    if(canCheckIn) {
+        template += `
+            <div class="col">
+                <button class="btn btn-outline-primary btn-block text-nowrap" ${!isCheckedIn ? `disabled` : visitCollections.length > 0 ? `` : `disabled`} type="submit" id="checkInComplete">${isCheckedIn ? `Check-Out` : `Check-In`}</button>
+            </div>
+
+        </form>
+    `;
+    } else {
+        // Disable only the check-in button if the user has withdrawn consent
+        template += `
+            <div class="col">
+                <button class="btn btn-outline-primary btn-block text-nowrap" ${isCheckedIn ? `` : `disabled`} type="submit" id="checkInComplete">${isCheckedIn ? `Check-Out` : `Check-In`}</button>
+            </div>
+
+        </form>
+    `;
     }
     
 

--- a/src/pages/dashboard.js
+++ b/src/pages/dashboard.js
@@ -1,4 +1,4 @@
-import { userAuthorization, removeActiveClass, getWorkflow, checkedIn, verificationConversion, restrictNonBiospecimenUser } from "./../shared.js"
+import { userAuthorization, removeActiveClass, getWorkflow, checkedIn, participantCanCheckIn, verificationConversion, restrictNonBiospecimenUser } from "./../shared.js"
 import {  addGoToCheckInEvent, addGoToSpecimenLinkEvent, addEventSearchForm1, addEventBackToSearch, addEventSearchForm2, addEventSearchForm3, addEventSearchForm4, addEventSearchSpecimen, addEventNavBarSpecimenSearch, addEventClearAll } from "./../events.js";
 import { homeNavBar, bodyNavBar } from '../navbar.js';
 
@@ -184,15 +184,16 @@ export const searchResults = (result) => {
             <td>${data['912301837'] === 208325815 || data['912301837'] === 622008261 || data['912301837'] === 458508122 ? `<i class="fas fa-2x fa-check"></i>` :  `<i class="fas fa-2x fa-times"></i>`}</td>`;
 
         const isCheckedIn = checkedIn(data);
+        const canCheckIn = participantCanCheckIn(data);
         if (getWorkflow() === 'research') {
         template += `
             <tr>
                 ${tdTemplate}
                 <td>
-                    <button class="btn btn-outline-primary text-nowrap" data-check-in-btn-connect-id=${data.Connect_ID} data-check-in-btn-uid=${data.state.uid}>${!isCheckedIn ? `Go to Check-In` : `Go to Check-Out`}</button>
+                    ${canCheckIn ? `<button class="btn btn-outline-primary text-nowrap" data-check-in-btn-connect-id=${data.Connect_ID} data-check-in-btn-uid=${data.state.uid}>${!isCheckedIn ? `Go to Check-In` : `Go to Check-Out`}</button>` : ``}
                 </td>
                 <td>
-                    ${isCheckedIn ? `<button class="btn btn-outline-primary text-nowrap" data-specimen-link-connect-id=${data.Connect_ID}>Specimen Link</button>` : ``}
+                    ${isCheckedIn && canCheckIn ? `<button class="btn btn-outline-primary text-nowrap" data-specimen-link-connect-id=${data.Connect_ID}>Specimen Link</button>` : ``}
                 </td>
             </tr>
         `
@@ -201,7 +202,7 @@ export const searchResults = (result) => {
             <tr>
                 ${tdTemplate}
                 <td>
-                    <button class="btn btn-outline-primary text-nowrap" data-specimen-link-connect-id=${data.Connect_ID}>Specimen Link</button>
+                    ${canCheckIn ? `<button class="btn btn-outline-primary text-nowrap" data-specimen-link-connect-id=${data.Connect_ID}>Specimen Link</button>` : ``}
                 </td>
             </tr>
         ` 

--- a/src/pages/dashboard.js
+++ b/src/pages/dashboard.js
@@ -190,10 +190,10 @@ export const searchResults = (result) => {
             <tr>
                 ${tdTemplate}
                 <td>
-                    ${canCheckIn ? `<button class="btn btn-outline-primary text-nowrap" data-check-in-btn-connect-id=${data.Connect_ID} data-check-in-btn-uid=${data.state.uid}>${!isCheckedIn ? `Go to Check-In` : `Go to Check-Out`}</button>` : ``}
+                    <button class="btn btn-outline-primary text-nowrap" data-check-in-btn-connect-id=${data.Connect_ID} data-check-in-btn-uid=${data.state.uid}>${!isCheckedIn ? `Go to Check-In` : `Go to Check-Out`}</button>
                 </td>
                 <td>
-                    ${isCheckedIn && canCheckIn ? `<button class="btn btn-outline-primary text-nowrap" data-specimen-link-connect-id=${data.Connect_ID}>Specimen Link</button>` : ``}
+                    ${isCheckedIn ? `<button class="btn btn-outline-primary text-nowrap" data-specimen-link-connect-id=${data.Connect_ID}>Specimen Link</button>` : ``}
                 </td>
             </tr>
         `

--- a/src/pages/dashboard.js
+++ b/src/pages/dashboard.js
@@ -202,7 +202,7 @@ export const searchResults = (result) => {
             <tr>
                 ${tdTemplate}
                 <td>
-                    ${canCheckIn ? `<button class="btn btn-outline-primary text-nowrap" data-specimen-link-connect-id=${data.Connect_ID}>Specimen Link</button>` : ``}
+                <button ${!canCheckIn ? `disabled` : ``} class="btn btn-outline-primary text-nowrap" data-specimen-link-connect-id=${data.Connect_ID}>Specimen Link</button>
                 </td>
             </tr>
         ` 

--- a/src/shared.js
+++ b/src/shared.js
@@ -2750,11 +2750,12 @@ export const checkOutParticipant = async (data) => {
 };
 
 export const participantCanCheckIn = (data) => {
+    let yesString = conceptIds.yes + '';
     if(
-        data[conceptIds.withdrewConsent] === conceptIds.yes ||
-        data[conceptIds.revokedHIPAA] === conceptIds.yes ||
-        data[conceptIds.destroyData] === conceptIds.yes ||
-        data[conceptIds.dataDestroyed] === conceptIds.yes
+        (data[conceptIds.withdrewConsent] + '') === yesString ||
+        (data[conceptIds.revokedHIPAA] + '') === yesString ||
+        (data[conceptIds.destroyData] + '') === yesString ||
+        (data[conceptIds.dataDestroyed] + '') === yesString
     ) {
         return false;
     } else {

--- a/src/shared.js
+++ b/src/shared.js
@@ -2386,6 +2386,7 @@ export const participationConversion = {
     '872012139': 'Revoked HIPAA only',
     '854021266': 'Withdrew consent',
     '241236037': 'Destroy data',
+    '884452262': 'Data destroyed',
     '458508122': 'Refused all future activities',
     '618686157': 'Deceased'
 };
@@ -2746,6 +2747,24 @@ export const checkOutParticipant = async (data) => {
          
          await updateParticipant(checkOutData);
     }
+};
+
+export const participantCanCheckIn = (data) => {
+    let canCheckIn = false; // Default to false
+    let participationStatusCode = data[conceptIds.participationStatus];
+    if(participationStatusCode) {
+        // Do all comparisons with strings to be safe
+        canCheckIn = [
+            conceptIds.participationStatusCodes.revokedHIPAA.toString(),
+            conceptIds.participationStatusCodes.withdrewConsent.toString(),
+            conceptIds.participationStatusCodes.destroyData.toString(),
+            conceptIds.participationStatusCodes.dataDestroyed.toString(),
+            conceptIds.participationStatusCodes.refusedAllFutureActivities.toString(),
+            conceptIds.participationStatusCodes.deceased.toString()
+        ].indexOf(participationStatusCode.toString()) === -1;
+    }
+
+    return canCheckIn;
 };
 
 export const getCollectionsByVisit = async (data) => {

--- a/src/shared.js
+++ b/src/shared.js
@@ -2750,17 +2750,10 @@ export const checkOutParticipant = async (data) => {
 };
 
 export const participantCanCheckIn = (data) => {
-    if (
-        data[conceptIds.withdrewConsent] === conceptIds.yes ||
-        data[conceptIds.revokedHIPAA] === conceptIds.yes ||
-        data[conceptIds.destroyData] === conceptIds.yes ||
-        data[conceptIds.dataDestroyed] === conceptIds.yes
-    ) {
-        return false;
-    } 
-    
-    return true;
-    
+    return data[conceptIds.withdrewConsent] !== conceptIds.yes &&
+        data[conceptIds.revokedHIPAA] !== conceptIds.yes &&
+        data[conceptIds.destroyData] !== conceptIds.yes &&
+        data[conceptIds.dataDestroyed] !== conceptIds.yes;
 };
 
 export const getCollectionsByVisit = async (data) => {

--- a/src/shared.js
+++ b/src/shared.js
@@ -2750,12 +2750,11 @@ export const checkOutParticipant = async (data) => {
 };
 
 export const participantCanCheckIn = (data) => {
-    let yesString = conceptIds.yes + '';
     if (
-        (data[conceptIds.withdrewConsent] + '') === yesString ||
-        (data[conceptIds.revokedHIPAA] + '') === yesString ||
-        (data[conceptIds.destroyData] + '') === yesString ||
-        (data[conceptIds.dataDestroyed] + '') === yesString
+        data[conceptIds.withdrewConsent] === conceptIds.yes ||
+        data[conceptIds.revokedHIPAA] === conceptIds.yes ||
+        data[conceptIds.destroyData] === conceptIds.yes ||
+        data[conceptIds.dataDestroyed] === conceptIds.yes
     ) {
         return false;
     } 

--- a/src/shared.js
+++ b/src/shared.js
@@ -2750,21 +2750,16 @@ export const checkOutParticipant = async (data) => {
 };
 
 export const participantCanCheckIn = (data) => {
-    let canCheckIn = false; // Default to false
-    let participationStatusCode = data[conceptIds.participationStatus];
-    if(participationStatusCode) {
-        // Do all comparisons with strings to be safe
-        canCheckIn = [
-            conceptIds.participationStatusCodes.revokedHIPAA.toString(),
-            conceptIds.participationStatusCodes.withdrewConsent.toString(),
-            conceptIds.participationStatusCodes.destroyData.toString(),
-            conceptIds.participationStatusCodes.dataDestroyed.toString(),
-            conceptIds.participationStatusCodes.refusedAllFutureActivities.toString(),
-            conceptIds.participationStatusCodes.deceased.toString()
-        ].indexOf(participationStatusCode.toString()) === -1;
+    if(
+        data[conceptIds.withdrewConsent] === conceptIds.yes ||
+        data[conceptIds.revokedHIPAA] === conceptIds.yes ||
+        data[conceptIds.destroyData] === conceptIds.yes ||
+        data[conceptIds.dataDestroyed] === conceptIds.yes
+    ) {
+        return false;
+    } else {
+        return true;
     }
-
-    return canCheckIn;
 };
 
 export const getCollectionsByVisit = async (data) => {

--- a/src/shared.js
+++ b/src/shared.js
@@ -2751,16 +2751,17 @@ export const checkOutParticipant = async (data) => {
 
 export const participantCanCheckIn = (data) => {
     let yesString = conceptIds.yes + '';
-    if(
+    if (
         (data[conceptIds.withdrewConsent] + '') === yesString ||
         (data[conceptIds.revokedHIPAA] + '') === yesString ||
         (data[conceptIds.destroyData] + '') === yesString ||
         (data[conceptIds.dataDestroyed] + '') === yesString
     ) {
         return false;
-    } else {
-        return true;
-    }
+    } 
+    
+    return true;
+    
 };
 
 export const getCollectionsByVisit = async (data) => {


### PR DESCRIPTION
Addresses issue [905 (Disable check in button on Check in/Check out screen (Biospecimen Dashboard))](https://github.com/episphere/connect/issues/905) and [908 (Disable Specimen Link button on Participant Search Results screen (Clinical Biospecimen Dashboard))](https://github.com/episphere/connect/issues/908). 

Per discussion and specifications in the issues:
* The specimen link button on the participant search results has been disabled only for the clinical dashboard and is still present in the research dashboard
* The research dashboard version of the participant search results still has an enabled check in/check out button for users who have revoked consent
* The check in/out screen has the check in button disabled for participants who have withdrawn consent. The check out button has not been disabled for these participants.
* Consent withdrawal is determined by the individual withdrew consent, revoked HIPAA, Data Destruction Requested and Data Destroyed flags on the user and not by the value in the participant status flag.