### PR TITLE
Clinical CSV File Receipts now generate with requested dummy receipt …

### DIFF
--- a/src/pages/receipts/csvFileReceipt.js
+++ b/src/pages/receipts/csvFileReceipt.js
@@ -366,9 +366,12 @@ const updateResultMappings = (filteredResult, vialMappings, collectionId, tubeId
         ? (keyToNameCSVObj[filteredResult[fieldToConceptIdMapping.healthcareProvider]] || '')
         : (keyToLocationObj[filteredResult[fieldToConceptIdMapping.collectionLocation]] || '');
 
-    const dateReceived = filteredResult[fieldToConceptIdMapping.dateReceived]
-        ? formatISODateTimeDateOnly(filteredResult[fieldToConceptIdMapping.dateReceived])
-        : '';
+        // Dummy date for clinical files requested in issue 936
+        const dateReceived = (collectionTypeValue === fieldToConceptIdMapping.clinical) ?
+        '01/01/1999 12pm'
+        : ( filteredResult[fieldToConceptIdMapping.dateReceived]
+            ? formatISODateTimeDateOnly(filteredResult[fieldToConceptIdMapping.dateReceived])
+            : '');
 
     const dateDrawn = (collectionTypeValue === fieldToConceptIdMapping.clinical)
         ? (clinicalDateTime ? convertISODateTime(clinicalDateTime) : '')


### PR DESCRIPTION
Clinical CSV File Receipts now generate with requested dummy receipt time, as requested in [issue 936](https://github.com/episphere/connect/issues/936).