### PR TITLE
UChicago (UCM) now has access to both dashboards in non-prod environments. (949)

### DIFF
--- a/src/pages/welcome.js
+++ b/src/pages/welcome.js
@@ -21,7 +21,8 @@ export const welcomeScreen = async (auth, route) => {
 }
 
 const clinicalOnlySiteArray = ['KPNW', 'KPCO', 'KPHI', 'KPGA'];
-const researchOnlySiteArray = ['MFC', 'UCM'];
+// Allow UCM access to both dashboards in non-prod environments (949)
+const researchOnlySiteArray = location.host === urls.prod ? ['MFC', 'UCM'] : ['MFC'];
 
 const welcomeScreenTemplate = (name, data, auth, route) => {
     let template = '';


### PR DESCRIPTION
Grants UCM access to clinical dashboard in dev and stage, per (949)[https://github.com/episphere/connect/issues/949].