### PR TITLE
Scanned barcode error in Kit Shipment

### DIFF
--- a/src/fieldToConceptIdMapping.js
+++ b/src/fieldToConceptIdMapping.js
@@ -335,7 +335,7 @@ export const conceptIds = {
     returnKitId: 194252513,
     collectionCupId: 259846815,
     collectionCardId: 786397882,
-    UKID: 687158491,
+    uniqueKitID: 687158491,
     kitType: 379252329,
     mouthwashKitType: 976461859,
     mouthwashSurveyCompletionStatus: 547363263,

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -6,7 +6,7 @@ import { conceptIds } from '../../fieldToConceptIdMapping.js';
 
 const contentBody = document.getElementById("contentBody");
 localStorage.setItem('tmpKitData', JSON.stringify([]));
-appState.setState({UKID: ``});
+appState.setState({uniqueKitID: ``});
 
 export const kitAssemblyScreen = async (auth) => {
   const user = auth.currentUser;
@@ -208,9 +208,9 @@ const editAssembledKits = () => {
         document.getElementById('returnKitId').value = editKitObj[conceptIds.returnKitId]
         document.getElementById('cupId').value = editKitObj[conceptIds.collectionCupId].slice(0, -4) + " " + editKitObj[conceptIds.collectionCupId].slice(-4)
         document.getElementById('cardId').value = editKitObj[conceptIds.collectionCardId].slice(0, -4) + " " + editKitObj[conceptIds.collectionCardId].slice(-4)
-        appState.setState({UKID: editKitObj[conceptIds.UKID]})
+        appState.setState({uniqueKitID: editKitObj[conceptIds.uniqueKitID]})
       });
-    }); // state to indicate if its an edit & also pass the UKID
+    }); // state to indicate if its an edit & also pass the uniqueKitID
 }}
 
 const checkUniqueness = async (supplyKitId, collectionId) => {
@@ -227,16 +227,16 @@ const checkUniqueness = async (supplyKitId, collectionId) => {
 const storeAssembledKit = async (kitData) => {
   const idToken = await getIdToken();
   showAnimation();
-  const collectionUnique = appState.getState().UKID !== '' ? { data: true } : await checkUniqueness(kitData[conceptIds.supplyKitId], kitData?.[conceptIds.collectionCupId].replace(/\s/g, "\n"));
+  const collectionUnique = appState.getState().uniqueKitID !== '' ? { data: true } : await checkUniqueness(kitData[conceptIds.supplyKitId], kitData?.[conceptIds.collectionCupId].replace(/\s/g, "\n"));
   hideAnimation();
   if (collectionUnique.data === true) {
     kitData[conceptIds.kitStatus] = conceptIds.pending;
-    kitData[conceptIds.UKID] = "MW" + Math.random().toString(16).slice(2);
+    kitData[conceptIds.uniqueKitID] = "MW" + Math.random().toString(16).slice(2);
     kitData[conceptIds.pendingDateTimeStamp] = new Date().toISOString();
     let api = `addKitData`
-    if (appState.getState().UKID !== ``) { 
+    if (appState.getState().uniqueKitID !== ``) { 
       api = `updateKitData` 
-      kitData[conceptIds.UKID] = appState.getState().UKID
+      kitData[conceptIds.uniqueKitID] = appState.getState().uniqueKitID
     }
     const response = await fetch(`${baseAPI}api=${api}`, {
       method: "POST",
@@ -252,17 +252,17 @@ const storeAssembledKit = async (kitData) => {
       alertTemplate(`Kit saved successfully!`, `success`);
       const existingKitData = JSON.parse(localStorage.getItem('tmpKitData'));
       existingKitData.push(kitData);
-      if (appState.getState().UKID !== ``) {
+      if (appState.getState().uniqueKitID !== ``) {
         const filteredKitData = [];
         const seenValues = new Set();
         for (let i = existingKitData.length - 1; i >= 0; i--) { // removes previously assembled kit
-          const key = existingKitData[i][conceptIds.UKID];
+          const key = existingKitData[i][conceptIds.uniqueKitID];
           if (!seenValues.has(key)) {
               seenValues.add(key);
               filteredKitData.push(existingKitData[i]);
           }
       }
-        appState.setState({UKID: ``})
+        appState.setState({uniqueKitID: ``})
         localStorage.setItem('tmpKitData', JSON.stringify(filteredKitData))
       }
       else {

--- a/src/pages/homeCollection/kitShipment.js
+++ b/src/pages/homeCollection/kitShipment.js
@@ -47,13 +47,13 @@ const verifyScannedCode = async () => {
     scannedCodeInput.addEventListener("change", async () => {
       showAnimation();
       const isScannedCodeValid = await checkScannedCodeValid(scannedCodeInput.value)
-      isScannedCodeValid.data?.valid ? confirmPickupTemplate(isScannedCodeValid.data?.UKID) : tryAgainTemplate();
+      isScannedCodeValid.data?.valid ? confirmPickupTemplate(isScannedCodeValid.data?.uniqueKitID) : tryAgainTemplate();
       hideAnimation();
     });
   }
 };
 
-const confirmPickupTemplate = (UKID) => {
+const confirmPickupTemplate = (uniqueKitID) => {
   const cardBody = document.getElementById("cardBody");
   cardBody.innerHTML = `        
                   <div class="card-body">
@@ -68,7 +68,7 @@ const confirmPickupTemplate = (UKID) => {
                         <button type="submit" class="btn btn-danger" id="cancelResponse">Cancel</button>
                         <button type="submit" class="btn btn-primary" id="saveResponse">Save</button>
                       </div>`;
-  saveResponse(UKID);
+  saveResponse(uniqueKitID);
   cancelResponse();
 };
 
@@ -82,10 +82,10 @@ const tryAgainTemplate = () => {
   verifyScannedCode();
 };
 
-const saveResponse = (UKID) => {
+const saveResponse = (uniqueKitID) => {
   const saveResponseBtn = document.getElementById("saveResponse");
   let data = {};
-  data[conceptIds.UKID] = UKID;
+  data[conceptIds.uniqueKitID] = uniqueKitID;
   if (saveResponseBtn) {
     saveResponseBtn.addEventListener("click", (e) => {
       data[conceptIds.shippedDateTime] = convertDateReceivedinISO(document.getElementById("inputDate").value);
@@ -147,6 +147,15 @@ const setShippedResponse = async (data) => {
   }
 };
 
+/**
+ * Checks the validity of a scanned code.
+ * @param {string} scannedCode - The USPS/FedEx Tracking Number to verify.
+ * @returns {Promise<{valid: boolean, uniqueKitID: string} | boolean>} A promise that resolves to:
+ *   * An object containing: 
+ *      * valid: {boolean} - Indicates if the scanned code is valid.
+ *      * uniqueKitID: {string} - The unique identifier for the Supply Kit, if available.
+ *   * OR a false if the scanned code is not a supply kit tracking number or if the kit status is already assigned.
+ */
 const checkScannedCodeValid = async (scannedCode) => {
   const idToken = await getIdToken();
   const response = await fetch(`${baseAPI}api=verifyScannedCode&id=${scannedCode}`, {


### PR DESCRIPTION
This PR addresses the scanned barcode problem of this issue. 
- https://github.com/episphere/connect/issues/975#issue-2253220253

Problem: 

- I changed `UKID` to `uniqueKitID` in [connectFaas](https://github.com/episphere/connectFaas/pull/581/files#diff-be91e66430aa4dd2f61668d1bd17d3cb449f57947e13bfa2f6bc087919967282R2317) for one of the objects. The old front end code referenced the `UKID` instead of the `uniqueKitID`, `isScannedCodeValid.data?.UKID`. This resulted in the error.

Object Example:

`{ valid: true, uniqueKitID: "MWf2647b02c60e1" }`

Code Changes:
- Updated `UKID` to `uniqueKitID`
- Added JSDoc to `checkScannedCodeValid()`