### PR TITLE
Dev to Stage Sync - Add Collection ID Column

### DIFF
--- a/src/pages/homeCollection/kitStatusReportsShipped.js
+++ b/src/pages/homeCollection/kitStatusReportsShipped.js
@@ -47,7 +47,8 @@ const displayKitStatusShippedTable = (shippedKitStatusParticipantsArray) => {
                             <th class="sticky-row" style="background-color: #f7f7f7;" scope="col">Study Site </th>
                             <th class="sticky-row" style="background-color: #f7f7f7;" scope="col">Shipped Date</th>
                             <th class="sticky-row" style="background-color: #f7f7f7;" scope="col">Supply Kit ID</th>
-                            <th class="sticky-row" style="background-color: #f7f7f7;" scope="col">Supply Kit ID Tracking Number</th>
+                            <th class="sticky-row" style="background-color: #f7f7f7;" scope="col">Collection ID</th>
+                            <th class="sticky-row" style="background-color: #f7f7f7;" scope="col">Supply Kit Tracking Number</th>
                             <th class="sticky-row" style="background-color: #f7f7f7;" scope="col">Return Kit Tracking Number</th>
                             <th class="sticky-row" style="background-color: #f7f7f7;" scope="col">Mouthwash Survey Completion Status</th>
                         </tr>
@@ -72,6 +73,7 @@ const createShippedRows = (shippedKitStatusParticipantsArray) => {
     const healthcareProvider = keyToNameObj[particpantObj[conceptIds.healthcareProvider]];
     const mouthwashShippedDate = convertISODateTime(particpantObj[conceptIds.shippedDateTime]).split(/\s+/)[0];
     const supplyKitId = particpantObj[conceptIds.supplyKitId];
+    const collectionCardId = particpantObj[conceptIds.collectionCardId];
     const supplyKitTrackingNum = particpantObj[conceptIds.supplyKitTrackingNum];
     const returnKitTrackingNum = particpantObj[conceptIds.returnKitTrackingNum];
     const mouthwashSurveyStatus = convertSurveyCompletionStatus(particpantObj[conceptIds.mouthwashSurveyCompletionStatus]);
@@ -82,6 +84,7 @@ const createShippedRows = (shippedKitStatusParticipantsArray) => {
                     <td>${healthcareProvider}</td>
                     <td>${mouthwashShippedDate}</td>
                     <td>${supplyKitId}</td>
+                    <td>${collectionCardId}</td>
                     <td>${supplyKitTrackingNum}</td>
                     <td>${returnKitTrackingNum}</td>
                     <td>${mouthwashSurveyStatus}</td>

--- a/src/pages/receipts/csvFileReceipt.js
+++ b/src/pages/receipts/csvFileReceipt.js
@@ -387,15 +387,13 @@ const updateResultMappings = (filteredResult, vialMappings, collectionId, tubeId
         ? (keyToNameCSVObj[filteredResult[fieldToConceptIdMapping.healthcareProvider]] || '')
         : (keyToLocationObj[filteredResult[fieldToConceptIdMapping.collectionLocation]] || '');
 
-        // Dummy date for clinical files requested in issue 936
-        const dateReceived = (collectionTypeValue === fieldToConceptIdMapping.clinical) ?
-        '01/01/1999 12pm'
-        : ( filteredResult[fieldToConceptIdMapping.dateReceived]
-            ? formatISODateTimeDateOnly(filteredResult[fieldToConceptIdMapping.dateReceived])
-            : '');
+    const dateReceived = filteredResult[fieldToConceptIdMapping.dateReceived]
+        ? formatISODateTimeDateOnly(filteredResult[fieldToConceptIdMapping.dateReceived])
+        : '';
 
+    // Dummy date for clinical files requested in issue 936
     const dateDrawn = (collectionTypeValue === fieldToConceptIdMapping.clinical)
-        ? (clinicalDateTime ? convertISODateTime(clinicalDateTime) : '')
+        ? '01/01/1999 12pm'
         : (withdrawalDateTime ? convertISODateTime(withdrawalDateTime) : '');
 
     const vialType = vialMappings[0] || '';


### PR DESCRIPTION
This PR dev-stage sync is a follow up to [issue#955](https://github.com/episphere/connect/issues/955)
- https://github.com/episphere/biospecimen/pull/693

The update was tested in dev
- https://github.com/episphere/connect/issues/955#issuecomment-2074899105

Changes 
- Added `collection ID` column to Kits Shipped table and referenced `collection card Id` values 
- Remove the "ID" in Supply Kit ID Tracking Number table header

![Screenshot 2024-04-23 at 5 55 09 PM](https://github.com/episphere/biospecimen/assets/33293205/0f340b2f-829d-4885-9ff7-3071624590c6)