### PR TITLE
Requested changes for 987

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -1126,7 +1126,7 @@ const checkFormAndSave = async (participantData, biospecimenData, shouldNavigate
         const inputFields = Array.from(document.getElementsByClassName('input-barcode-id'));
         const isFormDataValid = inputFields.every(input => validateFormInputField(input, biospecimenData, true));
         
-        isFormDataValid ?
+        isFormDataValid || !shouldNavigateToReview ?
             await collectionSubmission(participantData, biospecimenData, shouldNavigateToReview) :
             showTimedNotifications({ title: 'Data Errors Exist!', body: 'Please correct data entry errors in red before saving.' });
     } catch (error) {
@@ -1342,7 +1342,7 @@ const validateFormInputField = (inputTube, biospecimenData) => {
         if (!isTubeIDEntryValid) {
             const errorMessageText = isBagID ?
                 `Invalid entry. Bag ID must be ${validationID}` :
-                `Invalid entry. Specimen ID must be ${validationID}. Replacement labels 0050-0054 are valid.`;
+                `Invalid entry. Specimen ID must be ${validationID}.`;
             errorMessage(inputTube.id, errorMessageText);
             return false;
         }


### PR DESCRIPTION
Collection data entry page may now be saved even if validation fails so long as the user does not progress to the next page.

Outdated replacement label validation text has been removed.

As requested in [987](https://github.com/episphere/connect/issues/987).