### PR TITLE
BPTL  home collection - return and supply kit tracking number persists

### DIFF
--- a/src/pages/homeCollection/assignKits.js
+++ b/src/pages/homeCollection/assignKits.js
@@ -89,7 +89,7 @@ const assignKitsTemplate = async (name) => {
     
     if(scannedBarcodeValue && scannedBarcode2Value && scannedBarcodeValue !== scannedBarcode2Value) {
       const msg = 'Supply Kit Tracking Number doesn\'t match';
-      errorMessage('scannedBarcode2', msg, true, false);
+      errorMessage('scannedBarcode2', msg, true, false, true);
     } else {
       removeAllErrors();
     }
@@ -176,6 +176,7 @@ const confirmAssignment = () => {
           document.getElementById('address').value = ``;
           document.getElementById('Connect_ID').value = ``;
           document.getElementById('scannedBarcode').value = ``;
+          document.getElementById('scannedBarcode2').value = ``;
           document.getElementById('scanSupplyKit').value = ``;
           document.getElementById("showMsg").innerHTML = ``;
 

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -54,7 +54,7 @@ const kitAssemblyTemplate = async (name) => {
                           <label for="returnKitId" class="col-md-4 col-form-label">Return Kit ID</label>
                           <div class="col-md-8">
                             <input type="text" class="form-control" id="returnKitId" placeholder="Enter Return Kit ID" required />
-                            <span id="showReturnKitErrorMsg" style="font-size: 14px;"></span>
+                            <span id="showReturnKitErrorMsg" style="font-size: 14px; color: red;"></span>
                             </div>
                         </div>
                         <div class="form-group row">
@@ -67,7 +67,7 @@ const kitAssemblyTemplate = async (name) => {
                           <label for="cardId" class="col-md-4 col-form-label">Card ID</label>
                           <div class="col-md-8">
                             <input type="text" class="form-control" id="cardId" placeholder="Enter Card ID" required />
-                            <span id="showCardIdErrorMsg" style="font-size: 14px;"></span>
+                            <span id="showCardIdErrorMsg" style="font-size: 14px; color: red;"></span>
                           </div>
                       </div>
                       <div class="form-group row">
@@ -107,7 +107,7 @@ const kitAssemblyTemplate = async (name) => {
   enableEnterKeystroke();
   dropdownTrigger('Select Kit Type');
   checkTrackingNumberSource();
-  performQCcheck('scannedBarcode2', 'scannedBarcode', 'showMsg', `Return Tracking Number doesn't match`);
+  performQCcheck('scannedBarcode2', 'scannedBarcode', 'showMsg', `Return Kit Tracking Number doesn't match`);
   performQCcheck('returnKitId', 'supplyKitId', 'showReturnKitErrorMsg', `Supply Kit & Return Kit need to be same`);
   performQCcheck('cardId', 'cupId', 'showCardIdErrorMsg', `Cup ID & Card ID need to be same`);
 };
@@ -125,50 +125,51 @@ const processAssembledKit = () => {
   const saveKitButton = document.getElementById('saveKit');
   if (saveKitButton) {
     saveKitButton.addEventListener('click', async () => { 
-      let kitObj = {};
-      const queryScannedBarcodeValue = document.getElementById('scannedBarcode')?.value?.trim();
-      const scannedBarcodeValue = (queryScannedBarcodeValue !== undefined) ? queryScannedBarcodeValue : 0;
+        let kitObj = {};
+        const queryScannedBarcodeValue = document.getElementById('scannedBarcode')?.value?.trim();
+        const scannedBarcodeValue = (queryScannedBarcodeValue !== undefined) ? queryScannedBarcodeValue : 0;
 
-      const confirmScannedBarcodeValue = document.getElementById('scannedBarcode2')?.value?.trim();
+        const confirmScannedBarcodeValue = document.getElementById('scannedBarcode2')?.value?.trim();
 
-      const querySupplyKitIdValue = document.getElementById('supplyKitId').value.trim();
-      const supplyKitIdValue = (querySupplyKitIdValue !== undefined) ? querySupplyKitIdValue: 0;
+        const querySupplyKitIdValue = document.getElementById('supplyKitId').value.trim();
+        const supplyKitIdValue = (querySupplyKitIdValue !== undefined) ? querySupplyKitIdValue: 0;
 
-      const queryReturnKitIdValue = document.getElementById('returnKitId')?.value?.trim();
-      const returnKitIdValue = (queryReturnKitIdValue !== undefined) ? queryReturnKitIdValue : 0;
+        const queryReturnKitIdValue = document.getElementById('returnKitId')?.value?.trim();
+        const returnKitIdValue = (queryReturnKitIdValue !== undefined) ? queryReturnKitIdValue : 0;
 
-      const queryCollectionCupIdValue = document.getElementById('cupId')?.value?.trim();
-      const collectionCupIdValue = (queryCollectionCupIdValue !== undefined) ? queryCollectionCupIdValue : 0;
+        const queryCollectionCupIdValue = document.getElementById('cupId')?.value?.trim();
+        const collectionCupIdValue = (queryCollectionCupIdValue !== undefined) ? queryCollectionCupIdValue : 0;
 
-      const queryCollectionCardIdValue = document.getElementById('cardId')?.value?.trim();
-      const collectionCardIdValue = (queryCollectionCardIdValue !== undefined) ? queryCollectionCardIdValue : 0;
+        const queryCollectionCardIdValue = document.getElementById('cardId')?.value?.trim();
+        const collectionCardIdValue = (queryCollectionCardIdValue !== undefined) ? queryCollectionCardIdValue : 0;
 
-      if (queryScannedBarcodeValue !== confirmScannedBarcodeValue) {
-        triggerErrorModal('Return tracking number doesn\'t match.');
-        return;
-      }
-      else if (scannedBarcodeValue.length === 0 || supplyKitIdValue.length === 0 ||  returnKitIdValue.length === 0 ||
-        collectionCupIdValue.length === 0 || collectionCardIdValue.length === 0 || document.getElementById('dropdownSites').innerHTML !== 'Mouthwash') {
-          triggerErrorModal('One or more fields are missing.');
-          return
+        if (queryScannedBarcodeValue !== confirmScannedBarcodeValue) {
+            triggerErrorModal('Return Kit tracking number doesn\'t match.');
+            return;
+        } else if (scannedBarcodeValue.length === 0 || supplyKitIdValue.length === 0 ||  returnKitIdValue.length === 0 ||
+            collectionCupIdValue.length === 0 || collectionCardIdValue.length === 0) {
+            triggerErrorModal('One or more fields are missing.');
+            return
+        } else if (document.getElementById('dropdownSites').innerHTML !== 'Mouthwash') {
+            triggerErrorModal('Please select a Kit Type.');
+        } else {
+            kitObj[conceptIds.returnKitTrackingNum] = scannedBarcodeValue;
+            kitObj[conceptIds.supplyKitId] = supplyKitIdValue;
+            kitObj[conceptIds.returnKitId] = returnKitIdValue;
+            kitObj[conceptIds.collectionCupId] = collectionCupIdValue
+            kitObj[conceptIds.collectionCardId] = collectionCardIdValue;
+            kitObj[conceptIds.kitType] = conceptIds.mouthwashKitType;
+            const responseStoredStatus = await storeAssembledKit(kitObj);
+            if (responseStoredStatus) {
+            document.getElementById('scannedBarcode').value = ``;
+            document.getElementById('scannedBarcode2').value = ``;
+            document.getElementById('supplyKitId').value = ``;
+            document.getElementById('returnKitId').value = ``;
+            document.getElementById('cupId').value = ``;
+            document.getElementById('cardId').value = ``;
+            document.getElementById("showMsg").innerHTML = ``;
+            }
         }
-      else {
-        kitObj[conceptIds.returnKitTrackingNum] = scannedBarcodeValue;
-        kitObj[conceptIds.supplyKitId] = supplyKitIdValue;
-        kitObj[conceptIds.returnKitId] = returnKitIdValue;
-        kitObj[conceptIds.collectionCupId] = collectionCupIdValue
-        kitObj[conceptIds.collectionCardId] = collectionCardIdValue;
-        kitObj[conceptIds.kitType] = conceptIds.mouthwashKitType;
-        const responseStoredStatus = await storeAssembledKit(kitObj);
-        if (responseStoredStatus) {
-          document.getElementById('scannedBarcode').value = ``;
-          document.getElementById('supplyKitId').value = ``;
-          document.getElementById('returnKitId').value = ``;
-          document.getElementById('cupId').value = ``;
-          document.getElementById('cardId').value = ``;
-          document.getElementById("showMsg").innerHTML = ``;
-        }
-      }
     })
   }
 }

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -147,11 +147,9 @@ const processAssembledKit = () => {
             triggerErrorModal('Return Kit tracking number doesn\'t match.');
             return;
         } else if (scannedBarcodeValue.length === 0 || supplyKitIdValue.length === 0 ||  returnKitIdValue.length === 0 ||
-            collectionCupIdValue.length === 0 || collectionCardIdValue.length === 0) {
+            collectionCupIdValue.length === 0 || collectionCardIdValue.length === 0 || document.getElementById('dropdownSites').innerHTML !== 'Mouthwash') {
             triggerErrorModal('One or more fields are missing.');
             return
-        } else if (document.getElementById('dropdownSites').innerHTML !== 'Mouthwash') {
-            triggerErrorModal('Please select a Kit Type.');
         } else {
             kitObj[conceptIds.returnKitTrackingNum] = scannedBarcodeValue;
             kitObj[conceptIds.supplyKitId] = supplyKitIdValue;

--- a/src/shared.js
+++ b/src/shared.js
@@ -531,22 +531,29 @@ const closeBiospecimenModal = () => {
     document.body.classList.remove('modal-open');
 };
 
-export const errorMessage = (id, msg, focus, offset) => {
+export const errorMessage = (id, msg, focus, offset, icon) => {
     const currentElement = document.getElementById(id);
     const parentElement = currentElement.parentNode;
-    if(Array.from(parentElement.querySelectorAll('.form-error')).length > 0) return;
-    if(msg){
+    if (Array.from(parentElement.querySelectorAll('.form-error')).length > 0) return;
+    if (msg){
         const div = document.createElement('div');
         div.classList = ['error-text'];
+        if (icon) { 
+            const iconElement = document.createElement('i');
+            iconElement.classList = ['fa fa-exclamation-circle'];
+            iconElement.style.color = 'red';
+            iconElement.style.marginRight = '.2rem';
+            div.appendChild(iconElement);
+        }
         const span = document.createElement('span');
         span.classList = ['form-error']
-        if(offset) span.classList.add('offset-4');
+        if (offset) span.classList.add('offset-4');
         span.innerHTML = msg;
         div.append(span);
         parentElement.appendChild(div);
     }
     currentElement.classList.add('invalid');
-    if(focus) currentElement.focus();
+    if (focus) currentElement.focus();
 }
 
 export const shippingPrintManifestReminder = (boxesToShip, userName, tempCheckStatus, currShippingLocationNumber) => {
@@ -3140,7 +3147,8 @@ export const performQCcheck = (inputBox2, inputBox1, errorTag, errorMsg) => {
         const checkInputBox2Value = e.target.value.trim();
         const checkInputBox1Value = document.getElementById(inputBox1).value.trim();
         if (checkInputBox2Value !== checkInputBox1Value) {
-          document.getElementById(errorTag).innerHTML = `<i class="fa fa-exclamation-circle" style="font-size: 14px; color: red;"></i> ${errorMsg}`
+          document.getElementById(errorTag).innerHTML = `<i class="fa fa-exclamation-circle" style="font-size: 14px; color: red;"></i>
+                                                        <span style="color:red;">${errorMsg}</span>`
         }
         else {
           document.getElementById(errorTag).innerHTML = ``
@@ -3295,16 +3303,16 @@ export const checkTrackingNumberSource = () => {
         return;
       }
       if (input.length === 22 || input.length === 20) {
-        showMsg.innerHTML = `<i class="fa fa-check-circle" style="font-size: 14px; color: blue;"></i>USPS`;
-      }
-      else if (input.length === 12) {
-        showMsg.innerHTML = `<i class="fa fa-check-circle" style="font-size: 14px; color: orange;"></i>FedEx`;
-      }
-      else if (input.length === 34) {
+        showMsg.innerHTML = `<i class="fa fa-check-circle" style="font-size: 14px; color: blue;"></i>
+                            <span style="color: black;">USPS</span>`;
+      } else if (input.length === 12) {
+        showMsg.innerHTML = `<i class="fa fa-check-circle" style="font-size: 14px; color: orange;"></i>
+                            <span style="color: black;">FedEx</span>`;
+      } else if (input.length === 34) {
         e.target.value = input.slice(-12);
-        showMsg.innerHTML = `<i class="fa fa-check-circle" style="font-size: 14px; color: orange;"></i>FedEx`;
-      }
-      else {
+        showMsg.innerHTML = `<i class="fa fa-check-circle" style="font-size: 14px; color: orange;"></i>
+                            <span style="color: black;">FedEx</span>`;
+      } else {
         showMsg.innerHTML = "";
       }
     


### PR DESCRIPTION
The pull request is related to the links:
- https://github.com/episphere/connect/issues/1018

Changes: 

- Made extra confirm input field for return and supply kit tracking numbers clearable on a successful kit assembly and on a successful kit assign
- Added "Kit" to "Return Tracking Number Error message" ("Return Kit Tracking Number Error message")
- Added icon to "Supply Kit Tracking Number" input error message
- Changed text color of error messages to red on home collection's kit assembly page
