### PR TITLE
1022 follow-up

### DIFF
--- a/src/pages/homeCollection/kitsReceipt.js
+++ b/src/pages/homeCollection/kitsReceipt.js
@@ -165,7 +165,10 @@ export const confirmKitReceipt = () => {
         kitObj[conceptIds.collectionCupId] = document.getElementById('collectionId').value;
         const dateCollectionCard = document.getElementById('dateCollectionCard').value;
         const timeCollectionCard = document.getElementById('timeCollectionCard').value;
-        kitObj[conceptIds.collectionDateTimeStamp] = dateCollectionCard + 'T' + timeCollectionCard
+        if(dateCollectionCard && timeCollectionCard) {
+          kitObj[conceptIds.collectionDateTimeStamp] = dateCollectionCard + 'T' + timeCollectionCard
+        }
+        
         document.getElementById('collectionCheckBox').checked === true ? 
         kitObj[conceptIds.collectionCardFlag] = true : kitObj[conceptIds.collectionCardFlag] = false
         kitObj[conceptIds.collectionAddtnlNotes] = document.getElementById('collectionComments').value;

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -733,7 +733,7 @@ export const validatePackageInformation = () => {
   const dateReceived = document.getElementById("dateReceived").value;
   const collectionId = document.getElementById("collectionId").value;
   const dateCollectionCard = document.getElementById("dateCollectionCard").value;
-  const timeCollectionCard = document.getElementById("timeCollectionCard");
+  const timeCollectionCard = document.getElementById("timeCollectionCard").value;
 
   return (parseSelectPackageConditionsList.length !== 0) &&
     !!scannedBarcode && !!dateReceived && !!collectionId && !!dateCollectionCard && !!timeCollectionCard;


### PR DESCRIPTION
Resolved an issue where the new validation for kits receipt would still allow receipt time to be missing; added an additional check to prevent NaN issues if invalid date formats entered. (Feedback on [1022](https://github.com/episphere/connect/issues/1022#issuecomment-2166638445))