### PR TITLE
Add modal to restrict research dashboard check in

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -539,6 +539,7 @@ export const addGoToCheckInEvent = () => {
 
 export const addGoToSpecimenLinkEvent = () => {
     const specimenLinkButtons = document.querySelectorAll('button[data-specimen-link-connect-id]');
+
     for (const btn of specimenLinkButtons) {
         btn.addEventListener('click', async () => {
         let query = `connectId=${parseInt(btn.dataset.specimenLinkConnectId)}`;
@@ -562,7 +563,6 @@ export const addEventCheckInCompleteForm = (isCheckedIn, checkOutFlag) => {
             
             const response = await findParticipant(query);
             const data = response.data[0];
-            console.log("🚀 ~ addEventCheckInCompleteForm ~ data:", data)
 
             if (isCheckedIn) {
                 showAnimation();
@@ -579,8 +579,7 @@ export const addEventCheckInCompleteForm = (isCheckedIn, checkOutFlag) => {
             } else {
                 const visitConcept = document.getElementById('visit-select').value;
                 
-                const isClinicalUrineOrBloodCollected = checkClinicalBloodOrUrineCollected(data)
-
+                const isClinicalUrineOrBloodCollected = checkClinicalBloodOrUrineCollected(data);
                 if (isClinicalUrineOrBloodCollected) return;
 
 
@@ -590,7 +589,6 @@ export const addEventCheckInCompleteForm = (isCheckedIn, checkOutFlag) => {
                         const now = new Date();
                         if (now.getYear() == visitTime.getYear() && now.getMonth() == visitTime.getMonth() && now.getDate() == visitTime.getDate()) {
                             const response = await getParticipantCollections(data.token);
-                            console.log("🚀 ~ addEventCheckInCompleteForm ~ response:", response)
                             let collection = response.data.filter(res => res[conceptIds.collection.selectedVisit] == visit.concept);
                             if (collection.length === 0) continue;
                             const confirmContinueCheckIn = await handleCheckInWarning(visit, data, collection);
@@ -599,7 +597,7 @@ export const addEventCheckInCompleteForm = (isCheckedIn, checkOutFlag) => {
                     }
                 }
     
-                // await handleCheckInModal(data, visitConcept, query);
+                await handleCheckInModal(data, visitConcept, query);
             }
         } catch (error) {
             const bodyMessage = isCheckedIn ? 'There was an error checking out the participant. Please try again.' : 'There was an error checking in the participant. Please try again.';
@@ -609,15 +607,14 @@ export const addEventCheckInCompleteForm = (isCheckedIn, checkOutFlag) => {
 };
 
 /**
- * Checks if the participant has a clinical blood or urine collected and any specimen collected at Regional. If participant has clinical blood or urine collected, show a notification and return true.
+ * Checks if the participant has a clinical blood or urine collected variable under baseline. If participant has clinical blood or urine collected, show a notification and return true.
  * @param {Object} data - participant data
  * @returns {Boolean} - true if participant has any clinical blood or urine collected, false otherwise
 */
 const checkClinicalBloodOrUrineCollected = (data) => {
     const isBloodOrUrineCollected = data?.[conceptIds.collectionDetails]?.[conceptIds.baseline.visitId]?.[conceptIds.clinicalBloodOrUrineCollected];
-    const anySpecimenCollectedRRL = data?.[conceptIds.collectionDetails]?.[conceptIds.baseline.visitId]?.[conceptIds.anySpecimenCollected];
 
-    if (isBloodOrUrineCollected === conceptIds.yes && anySpecimenCollectedRRL === conceptIds.yes) { 
+    if (isBloodOrUrineCollected === conceptIds.yes) { 
         const bodyMessage = 'Check In not allowed, participant already has clinical collection for this timepoint.'
         showNotifications({ title: 'Check In Error', body: bodyMessage });
         return true;
@@ -706,7 +703,7 @@ export const addEventSpecimenLinkForm = (formData) => {
     form.addEventListener('click', async (e) => {
         e.preventDefault();
         const collections = await getCollectionsByVisit(formData);
-        console.log("🚀 ~ form.addEventListener ~ collections:", collections, "--", "formData:", formData)
+
         if (collections.length) {
             existingCollectionAlert(collections, connectId, formData);
         } else {
@@ -758,8 +755,7 @@ const existingCollectionAlert = async (collections, connectId, formData) => {
  * @param {string} connectId 
  * @param {*} formData 
  */
-const btnsClicked = async (connectId, formData) => { 
-    console.log("🚀 ~ btnsClicked ~ connectId, formData:", connectId, formData)
+const btnsClicked = async (connectId, formData) => {
     removeAllErrors();
 
     let scanSpecimenID = document.getElementById('scanSpecimenID')?.value && document.getElementById('scanSpecimenID')?.value.toUpperCase();
@@ -824,18 +820,15 @@ const btnsClicked = async (connectId, formData) => {
         
     }
     hideAnimation();
-    console.log("🚀 ~ btnsClicked ~ specimenData:", specimenData)
+
     if (specimenData?.Connect_ID && parseInt(specimenData.Connect_ID) !== particpantData.Connect_ID) {
         showNotifications({ title: 'Collection ID Duplication', body: 'Entered Collection ID is already associated with a different Connect ID.' })
         return;
     }
 
     showAnimation();
+
     formData[conceptIds.collection.selectedVisit] = formData?.[conceptIds.collection.selectedVisit] || parseInt(getCheckedInVisit(particpantData));
-    console.log("🚀 ~ btnsClicked ~ parseInt(getCheckedInVisit(particpantData)):", parseInt(getCheckedInVisit(particpantData)))
-    console.log("____")
-    console.log("🚀 ~ btnsClicked ~ formData?.[conceptIds.collection.selectedVisit]:", formData?.[conceptIds.collection.selectedVisit])
-    
     
     if (!formData?.collectionId) {
         console.log("Form data to be added:", formData);

--- a/src/events.js
+++ b/src/events.js
@@ -578,10 +578,9 @@ export const addEventCheckInCompleteForm = (isCheckedIn, checkOutFlag) => {
                 }, 1500);
             } else {
                 const visitConcept = document.getElementById('visit-select').value;
-                
                 const isClinicalUrineOrBloodCollected = checkClinicalBloodOrUrineCollected(data);
-                if (isClinicalUrineOrBloodCollected) return;
 
+                if (isClinicalUrineOrBloodCollected) return;
 
                 for (const visit of visitType) {
                     if (data[conceptIds.collection.selectedVisit] && data[conceptIds.collection.selectedVisit][visit.concept]) {
@@ -696,7 +695,6 @@ export const goToParticipantSearch = () => {
 export const addEventSpecimenLinkForm = (formData) => {
     const form = document.getElementById('researchSpecimenContinue');
     const connectId = document.getElementById('researchSpecimenContinue').dataset.connectId;
-    // Note: Can use this connectId value to get related biospecimen documents
 
     if (document.getElementById('navBarParticipantCheckIn')) document.getElementById('navBarParticipantCheckIn').dataset.connectId = connectId;
 

--- a/src/events.js
+++ b/src/events.js
@@ -6,7 +6,8 @@ import {
     convertConceptIdToPackageCondition, checkFedexShipDuplicate, shippingDuplicateMessage, checkInParticipant, checkOutParticipant, getCheckedInVisit, participantCanCheckIn, shippingPrintManifestReminder,
     checkNonAlphanumericStr, shippingNonAlphaNumericStrMessage, visitType, getParticipantCollections, updateBaselineData,
     siteSpecificLocationToConceptId, conceptIdToSiteSpecificLocation, locationConceptIDToLocationMap, updateCollectionSettingData, convertToOldBox, translateNumToType,
-    getCollectionsByVisit, getSpecimenAndParticipant, getUserProfile, checkDuplicateTrackingIdFromDb, checkAccessionId, checkSurveyEmailTrigger, checkDerivedVariables, isDeviceMobile, replaceDateInputWithMaskedInput, bagConceptIdList, showModalNotification, showTimedNotifications, showNotificationsCancelOrContinue, validateSpecimenAndParticipantResponse, findReplacementTubeLabels,
+    getCollectionsByVisit, getSpecimenAndParticipant, getUserProfile, checkDuplicateTrackingIdFromDb, checkAccessionId, checkSurveyEmailTrigger, checkDerivedVariables, isDeviceMobile, replaceDateInputWithMaskedInput, bagConceptIdList, showModalNotification, showTimedNotifications, showNotificationsCancelOrContinue, validateSpecimenAndParticipantResponse, findReplacementTubeLabels, 
+    showConfirmationModal,
 } from './shared.js';
 import { searchTemplate, searchBiospecimenTemplate } from './pages/dashboard.js';
 import { showReportsManifest } from './pages/reportsQuery.js';
@@ -818,7 +819,6 @@ const btnsClicked = async (connectId, formData) => {
         
     }
     hideAnimation();
-
     if (specimenData?.Connect_ID && parseInt(specimenData.Connect_ID) !== particpantData.Connect_ID) {
         showNotifications({ title: 'Collection ID Duplication', body: 'Entered Collection ID is already associated with a different Connect ID.' })
         return;
@@ -854,57 +854,6 @@ const btnsClicked = async (connectId, formData) => {
         searchTemplate();
     }
 }
-    
-
-const showConfirmationModal = async (collectionID, firstName) => {
-    return new Promise((resolve) => {
-        const modalContainer = document.createElement('div');
-        modalContainer.classList.add('modal', 'fade');
-        modalContainer.id = 'confirmationModal';
-        modalContainer.tabIndex = '-1';
-        modalContainer.role = 'dialog';
-        modalContainer.setAttribute('aria-labelledby', 'exampleModalCenterTitle');
-        modalContainer.setAttribute('aria-hidden', 'true');
-        const modalContent = document.createElement('div');
-        modalContent.classList.add('modal-dialog', 'modal-dialog-centered');
-        modalContent.setAttribute('role', 'document');
-
-        const modalBody = `
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">Confirm Collection ID</h5>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
-                </div>
-                <div class="modal-body">
-                    <p>Collection ID: ${collectionID}</p>
-                    <p>Confirm ID is correct for participant: ${firstName}</p>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-default" data-dismiss="modal" data-result="cancel">Cancel</button>
-                    <button type="button" class="btn btn-info" data-result="back" data-dismiss="modal">Confirm and Exit</button>
-                    <button type="button" class="btn btn-success" data-result="confirmed" data-dismiss="modal">Confirm and Continue</button>
-                </div>
-            </div>
-        `;
-
-        modalContent.innerHTML = modalBody;
-        modalContainer.appendChild(modalContent);
-        document.body.appendChild(modalContainer);
-
-        modalContainer.classList.add('show');
-        modalContainer.style.display = 'block';
-        modalContainer.addEventListener('click', (event) => {
-            const result = event.target.getAttribute('data-result');
-            if (result) 
-            {
-                document.body.removeChild(modalContainer);
-                resolve(result);
-            }
-        });
-    });
-};
 
 
 /**

--- a/src/fieldToConceptIdMapping.js
+++ b/src/fieldToConceptIdMapping.js
@@ -140,6 +140,7 @@ export const conceptIds = {
     checkOutDateTime: 343048998,
     checkInDateTime: 840048338,
     checkInComplete: 135591601,
+    clinicalBloodOrUrineCollected: 156605577,
 
     // not shipped specimen deviation id
     brokenSpecimenDeviation: 472864016,

--- a/src/pages/checkIn.js
+++ b/src/pages/checkIn.js
@@ -12,11 +12,8 @@ export const checkInTemplate = async (data, checkOutFlag) => {
     }
 
     const isCheckedIn = checkedIn(data);
-    console.log("Check In template data", data)
-    console.log("🚀 ~ checkInTemplate ~ isCheckedIn:", isCheckedIn)
     const canCheckIn = participantCanCheckIn(data);
     const visit = getCheckedInVisit(data);
-    console.log("🚀 ~ checkInTemplate ~ visit:", visit)
 
     const response = await getParticipantCollections(data.token);
     let collections = [];
@@ -79,7 +76,6 @@ export const checkInTemplate = async (data, checkOutFlag) => {
             <hr/>
     `;
     
-    console.log("collections", collections)
     template += await participantStatus(data, collections);
 
 
@@ -135,11 +131,9 @@ const participantStatus = (data, collections) => {
     let siteTubesList = getSiteTubesLists({'951355211': conceptIds.research});
 
     const bloodTubes = siteTubesList?.filter(tube => tube.tubeType === "Blood tube");
-    console.log("🚀 ~ participantStatus ~ bloodTubes:", bloodTubes)
     const urineTubes = siteTubesList?.filter(tube => tube.tubeType === "Urine");
-    console.log("🚀 ~ participantStatus ~ urineTubes:", urineTubes)
     const mouthwashTubes = siteTubesList?.filter(tube => tube.tubeType === "Mouthwash");
-    console.log("🚀 ~ participantStatus ~ mouthwashTubes:", mouthwashTubes)
+
 
     collections = collections.filter(collection => collection[conceptIds.collection.selectedVisit] == conceptIds.baseline.visitId);
 

--- a/src/pages/checkIn.js
+++ b/src/pages/checkIn.js
@@ -12,8 +12,11 @@ export const checkInTemplate = async (data, checkOutFlag) => {
     }
 
     const isCheckedIn = checkedIn(data);
+    console.log("Check In template data", data)
+    console.log("🚀 ~ checkInTemplate ~ isCheckedIn:", isCheckedIn)
     const canCheckIn = participantCanCheckIn(data);
     const visit = getCheckedInVisit(data);
+    console.log("🚀 ~ checkInTemplate ~ visit:", visit)
 
     const response = await getParticipantCollections(data.token);
     let collections = [];
@@ -75,7 +78,8 @@ export const checkInTemplate = async (data, checkOutFlag) => {
             
             <hr/>
     `;
-
+    
+    console.log("collections", collections)
     template += await participantStatus(data, collections);
 
 
@@ -131,8 +135,11 @@ const participantStatus = (data, collections) => {
     let siteTubesList = getSiteTubesLists({'951355211': conceptIds.research});
 
     const bloodTubes = siteTubesList?.filter(tube => tube.tubeType === "Blood tube");
+    console.log("🚀 ~ participantStatus ~ bloodTubes:", bloodTubes)
     const urineTubes = siteTubesList?.filter(tube => tube.tubeType === "Urine");
+    console.log("🚀 ~ participantStatus ~ urineTubes:", urineTubes)
     const mouthwashTubes = siteTubesList?.filter(tube => tube.tubeType === "Mouthwash");
+    console.log("🚀 ~ participantStatus ~ mouthwashTubes:", mouthwashTubes)
 
     collections = collections.filter(collection => collection[conceptIds.collection.selectedVisit] == conceptIds.baseline.visitId);
 

--- a/src/shared.js
+++ b/src/shared.js
@@ -2801,9 +2801,8 @@ export const checkInParticipant = async (data, visitConcept) => {
   const uid = data.state.uid;
   let shouldSendBioEmail = false;
 
-  if (data[conceptIds.selectedVisit]) {
-    visits = data[conceptIds.selectedVisit];
-
+  if (data[conceptIds.collection.selectedVisit]) {
+    visits = data[conceptIds.collection.selectedVisit];
     if (!visits[visitConcept]) {
       if (visitConcept === conceptIds.baseline.visitId.toString()) shouldSendBioEmail = true;
 

--- a/src/shared.js
+++ b/src/shared.js
@@ -489,8 +489,64 @@ export const showNotificationsSelectableList = (message, items, onCancel, onCont
             errorMessageDiv.style.display = 'block';
         }
     });
-
     document.getElementById('root').removeChild(button);
+};
+
+/**
+ * Display confirmation modal to the user and returns a promise with the user's choice.
+ *  
+ * @param {string} collectionID - the collection ID to display in the modal.
+ * @param {string} firstName - the participant's first name to display in the modal.
+ * @returns {Promise<string>} - the user's choice on button click: 'cancel', 'back', or 'confirmed'.
+*/
+export const showConfirmationModal =  (collectionID, firstName) => {
+    return new Promise((resolve) => {
+        const modalContainer = document.createElement('div');
+        modalContainer.classList.add('modal', 'fade');
+        modalContainer.id = 'confirmationModal';
+        modalContainer.tabIndex = '-1';
+        modalContainer.role = 'dialog';
+        modalContainer.setAttribute('aria-labelledby', 'exampleModalCenterTitle');
+        modalContainer.setAttribute('aria-hidden', 'true');
+        const modalContent = document.createElement('div');
+        modalContent.classList.add('modal-dialog', 'modal-dialog-centered');
+        modalContent.setAttribute('role', 'document');
+
+        const modalBody = `
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Confirm Collection ID</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <p>Collection ID: ${collectionID}</p>
+                    <p>Confirm ID is correct for participant: ${firstName}</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal" data-result="cancel">Cancel</button>
+                    <button type="button" class="btn btn-info" data-result="back" data-dismiss="modal">Confirm and Exit</button>
+                    <button type="button" class="btn btn-success" data-result="confirmed" data-dismiss="modal">Confirm and Continue</button>
+                </div>
+            </div>
+        `;
+
+        modalContent.innerHTML = modalBody;
+        modalContainer.appendChild(modalContent);
+        document.body.appendChild(modalContainer);
+
+        modalContainer.classList.add('show');
+        modalContainer.style.display = 'block';
+        modalContainer.addEventListener('click', (event) => {
+            const result = event.target.getAttribute('data-result');
+            if (result) 
+            {
+                document.body.removeChild(modalContainer);
+                resolve(result);
+            }
+        });
+    });
 };
 
 export const showTimedNotifications = (data, zIndex, timeInMilliseconds = 2600) => {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -468,3 +468,8 @@ box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
     max-height: 200px;
     overflow-x: hidden;
 }
+
+#checkInComplete:disabled {
+    cursor: not-allowed;
+    background-color: #e0e0e0;
+}


### PR DESCRIPTION
This pull request is related to 
- https://github.com/episphere/connect/issues/1004
- https://github.com/episphere/connect/issues/1004#issuecomment-2195180020

Issue: Add logic to prevent a check in for a participant with a clinical collection (blood or urine) in baseline. 

Code Changes:

- Added `clinicalBloodOrUrineCollected` to `fieldMapping.js` file to reference concept Id 156605577 used for the conditional logic.
- Created a function `checkClinicalBloodOrUrineCollected` in `events.js` file to check participant data for `clinicalBloodOrUrineCollected` (156605577) in the Collection Details baseline. If the clinicalBloodOrUrineCollected exists and is yes then display a Error Check In modal. This will create an early exit within the `addEventCheckInCompleteForm` function.

- Moved `showConfirmationModal` function out of `btnsClicked` function in `events.js` file. Add `showConfirmationModal` to `shared.js` file  to be exported and `import` in `event.js` file

- Added to `#checkInComplete:disabled` selector to `style.css` file to improve user experience. Previously, the disabled button had a transparent background color and the cursor was a pointer when hovered. The selector will add a grey background-color and not-allowed cursor when hovering over the disabled button.

disabled button
![Screenshot 2024-07-03 at 11 04 04 AM](https://github.com/episphere/biospecimen/assets/33293205/64aa0972-3d53-457a-b222-4e91e2d35271)

Check In Error Modal
![Screenshot 2024-07-03 at 11 04 24 AM](https://github.com/episphere/biospecimen/assets/33293205/c7b83d08-9c77-4e7c-89d5-0cafde6950a6)
