### PR TITLE
BPTL - kits receipt page, clear the collection date and the collection time input fields 

### DIFF
--- a/src/pages/homeCollection/kitsReceipt.js
+++ b/src/pages/homeCollection/kitsReceipt.js
@@ -202,7 +202,7 @@ const storePackageReceipt = async (data) => {
     document.getElementById("receivePackageComments").value = "";
     document.getElementById("dateReceived").value = getCurrentDate();
     document.getElementById("collectionComments").value = "";
-    document.getElementById("collectionId").value = "";
+    
     enableCollectionCardFields();
     enableCollectionCheckBox();
     document.getElementById("packageCondition").setAttribute("data-selected", "[]");

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -369,12 +369,6 @@ const clearPackageReceiptForm = (isSuccess) => {
     
     const dateReceived = document.getElementById("dateReceived");
     if (dateReceived) dateReceived.value = getCurrentDate();
-
-    const dateCollectionCard = document.getElementById("dateCollectionCard");
-    if (dateCollectionCard) dateCollectionCard.value = '';
-
-    const timeCollectionCard = document.getElementById("timeCollectionCard");
-    if (timeCollectionCard) timeCollectionCard.value = '';
     
     const collectionComments = document.getElementById("collectionComments");
     if (collectionComments) collectionComments.value = '';

--- a/src/pages/receipts/packageReceipt.js
+++ b/src/pages/receipts/packageReceipt.js
@@ -369,6 +369,12 @@ const clearPackageReceiptForm = (isSuccess) => {
     
     const dateReceived = document.getElementById("dateReceived");
     if (dateReceived) dateReceived.value = getCurrentDate();
+
+    const dateCollectionCard = document.getElementById("dateCollectionCard");
+    if (dateCollectionCard) dateCollectionCard.value = '';
+
+    const timeCollectionCard = document.getElementById("timeCollectionCard");
+    if (timeCollectionCard) timeCollectionCard.value = '';
     
     const collectionComments = document.getElementById("collectionComments");
     if (collectionComments) collectionComments.value = '';


### PR DESCRIPTION
This issue is related to the following:
- https://github.com/episphere/connect/issues/1043

Problem: 
- Home mouthwash collection date and time persisting from previous entry in Kit Receipt after successfully receiving a kit.

Code Change
- Removed early emptying of Collection ID input element's value so conditional check `if(document.getElementById("collectionId").value) {...}` after is run 
- [Reference conditional](https://github.com/episphere/biospecimen/compare/dev...issue%231043-clear-collection-date-and-collection-time-inputs?expand=1#diff-c67dc6fae2d4b8cad75f7004c5dc56c09be49a0589a6bfcc2b891d83bc522cbdL209) 