### PR TITLE
Update research dashboard check-in blocking logic

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -607,14 +607,23 @@ export const addEventCheckInCompleteForm = (isCheckedIn, checkOutFlag) => {
 };
 
 /**
- * Checks if the participant has a clinical blood or urine collected variable under baseline. If participant has clinical blood or urine collected, show a notification and return true.
+ * Checks if the participant has any specimen collected (clinical blood or a clinical urine) under baseline from the dashboard or collected clinical/blood derivations from the site EMR API. If participant has either a clinical blood or urine dashboard variable or other blood/urine derived variables from the site EMR API, show a notification and return true.
  * @param {Object} data - participant data
- * @returns {Boolean} - true if participant has any clinical blood or urine collected, false otherwise
+ * @returns {Boolean} - true if participant has any clinical blood or urine collected derivations, false otherwise
 */
 const checkClinicalBloodOrUrineCollected = (data) => {
-    const isBloodOrUrineCollected = data?.[conceptIds.collectionDetails]?.[conceptIds.baseline.visitId]?.[conceptIds.clinicalBloodOrUrineCollected];
+    const collectionDetailsBaseline = data?.[conceptIds.collectionDetails]?.[conceptIds.baseline.visitId];
+    if (!collectionDetailsBaseline) return false;
 
-    if (isBloodOrUrineCollected === conceptIds.yes) { 
+    const collectedBaselineStatuses = [
+        collectionDetailsBaseline?.[conceptIds.anySpecimenCollected],
+        collectionDetailsBaseline?.[conceptIds.clinicalSiteBloodCollected],
+        collectionDetailsBaseline?.[conceptIds.clinicalSiteUrineCollected],
+        collectionDetailsBaseline?.[conceptIds.clinicalSiteBloodRRLReceived],
+        collectionDetailsBaseline?.[conceptIds.clinicalSiteUrineRRLReceived]
+    ]
+
+    if (collectedBaselineStatuses.includes(conceptIds.yes)) { 
         const bodyMessage = 'Check In not allowed, participant already has clinical collection for this timepoint.'
         showNotifications({ title: 'Check In Error', body: bodyMessage });
         return true;

--- a/src/events.js
+++ b/src/events.js
@@ -624,8 +624,9 @@ const checkClinicalBloodOrUrineCollected = (data) => {
     ]
 
     if (collectedBaselineStatuses.includes(conceptIds.yes)) { 
-        const bodyMessage = 'Check In not allowed, participant already has clinical collection for this timepoint.'
-        showNotifications({ title: 'Check In Error', body: bodyMessage });
+        const modalIcon = `<i class="fas fa-exclamation-circle" style="color: red; font-size: 1.4rem;"></i>`
+        const bodyMessage = `Check In not allowed, participant already has clinical collection for this timepoint. If you have questions, contact the Connect Biospeicmen Team: <a href="mailto:connectbioteam@nih.gov">connectbioteam@nih.gov</a>.`
+        showNotifications({ title: `${modalIcon} WARNING`, body: bodyMessage });
         return true;
     }
     return false;

--- a/src/events.js
+++ b/src/events.js
@@ -607,7 +607,7 @@ export const addEventCheckInCompleteForm = (isCheckedIn, checkOutFlag) => {
 };
 
 /**
- * Checks if the participant has any specimen collected (clinical blood or a clinical urine) under baseline from the dashboard or collected clinical/blood derivations from the site EMR API. If participant has either a clinical blood or urine dashboard variable or other blood/urine derived variables from the site EMR API, show a notification and return true.
+ * Checks if the participant has any specimen collected (clinical blood or clinical urine) under baseline from the dashboard or collected clinical blood or urine derivations from the site EMR API. If participant has either a clinical blood or urine dashboard variable or other blood/urine derived variables from the site EMR API, show a notification and return true.
  * @param {Object} data - participant data
  * @returns {Boolean} - true if participant has any clinical blood or urine collected derivations, false otherwise
 */

--- a/src/events.js
+++ b/src/events.js
@@ -608,11 +608,11 @@ export const addEventCheckInCompleteForm = (isCheckedIn, checkOutFlag) => {
 
 /**
  * Checks if the participant has any specimen collected (clinical blood or clinical urine) under baseline from the dashboard or collected clinical blood or urine derivations from the site EMR API. If participant has either a clinical blood or urine dashboard variable or other blood/urine derived variables from the site EMR API, show a notification and return true.
- * @param {Object} data - participant data
+ * @param {Object} participantData - participant document data from find participant query
  * @returns {Boolean} - true if participant has any clinical blood or urine collected derivations, false otherwise
 */
-const checkClinicalBloodOrUrineCollected = (data) => {
-    const collectionDetailsBaseline = data?.[conceptIds.collectionDetails]?.[conceptIds.baseline.visitId];
+const checkClinicalBloodOrUrineCollected = (participantData) => {
+    const collectionDetailsBaseline = participantData?.[conceptIds.collectionDetails]?.[conceptIds.baseline.visitId];
     if (!collectionDetailsBaseline) return false;
 
     const collectedBaselineStatuses = [
@@ -621,7 +621,7 @@ const checkClinicalBloodOrUrineCollected = (data) => {
         collectionDetailsBaseline?.[conceptIds.clinicalSiteUrineCollected],
         collectionDetailsBaseline?.[conceptIds.clinicalSiteBloodRRLReceived],
         collectionDetailsBaseline?.[conceptIds.clinicalSiteUrineRRLReceived]
-    ]
+    ];
 
     if (collectedBaselineStatuses.includes(conceptIds.yes)) { 
         const modalIcon = `<i class="fas fa-exclamation-circle" style="color: red; font-size: 1.4rem;"></i>`

--- a/src/fieldToConceptIdMapping.js
+++ b/src/fieldToConceptIdMapping.js
@@ -142,6 +142,12 @@ export const conceptIds = {
     checkInComplete: 135591601,
     clinicalBloodOrUrineCollected: 156605577,
 
+    // Site EMR API Clinical baseline derivations
+    clinicalSiteBloodCollected: 693370086,
+    clinicalSiteUrineCollected: 786930107,
+    clinicalSiteBloodRRLReceived: 728696253,
+    clinicalSiteUrineRRLReceived: 453452655,
+
     // not shipped specimen deviation id
     brokenSpecimenDeviation: 472864016,
     discardSpecimenDeviation: 810960823,


### PR DESCRIPTION
This PR is related to the following:
- https://github.com/episphere/connect/issues/1004

- https://github.com/episphere/connect/issues/1004#issuecomment-2228781199 (Updated comment)

- https://github.com/episphere/biospecimen/pull/723 (Previous PR)

Problem:
- Previous logic does not check for the EMR site derived variables
- Previous variable clinicalBloodOrUrineCollected ([156605577](https://episphere.github.io/conceptGithubActions/web/#156605577)) is static when either a clinical blood or urine tube is saved prior to finalizing and remains static when all clinical blood or urine tubes are unchecked and saved. 
- Find another existing variable that is dynamic for the save button functionality. The variable to be used is "Any specimen collected at RRL" [(316824786)](https://episphere.github.io/conceptGithubActions/web/#316824786)

Code Changes:
- Added more conditional OR checks to block the check-in button in research dashboard
- Added 4 EMR site API concept id references in `fieldToConceptIdMapping.js` file: `anySpecimenCollected: 693370086`; `clinicalSiteUrineCollected: 786930107`; `clinicalSiteBloodRRLReceived: 728696253`; `clinicalSiteUrineRRLReceived: 453452655`
- Added the 4 EMR site references and replaced concept id `156605577` to concept Id `316824786` reference in `checkClinicalBloodOrUrineCollected` function in `events.js` file
- Updated the jsdocs comments for `checkClinicalBloodOrUrineCollected` function
- Changed error modal wording text ([Reference](https://github.com/episphere/connect/issues/1004#issuecomment-2229272123)) and add modal icon

New Error Modal Wording:
![Screenshot 2024-07-15 at 5 13 20 PM](https://github.com/user-attachments/assets/85e57ba2-3af1-435b-9016-ca2c60bad196)


