### PR TITLE
Fix biospecimen check-in modal buttons

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -571,7 +571,6 @@ export const addEventCheckInCompleteForm = (isCheckedIn, checkOutFlag) => {
                 hideAnimation();
                 showTimedNotifications({ title: 'Success', body: 'Participant is checked out.' }, 100000, 1500);
                 setTimeout(() => {
-                    dismissBiospecimenModal();
                     checkOutFlag === true ? location.reload() : goToParticipantSearch(); 
                 }, 1500);
             } else {
@@ -626,7 +625,6 @@ const checkClinicalBloodOrUrineCollected = (participantData) => {
         const bodyMessage = `Check In not allowed, participant already has clinical collection for this timepoint. If you have questions, contact the Connect Biospeicmen Team: <a href="mailto:connectbioteam@nih.gov">connectbioteam@nih.gov</a>.`
 
         showNotifications({ title: `${modalIcon} WARNING`, body: bodyMessage });
-        const biospecimenModal = document.getElementById('biospecimenModal');
         return true;
     }
     return false;

--- a/src/events.js
+++ b/src/events.js
@@ -7,7 +7,7 @@ import {
     checkNonAlphanumericStr, shippingNonAlphaNumericStrMessage, visitType, getParticipantCollections, updateBaselineData,
     siteSpecificLocationToConceptId, conceptIdToSiteSpecificLocation, locationConceptIDToLocationMap, updateCollectionSettingData, convertToOldBox, translateNumToType,
     getCollectionsByVisit, getSpecimenAndParticipant, getUserProfile, checkDuplicateTrackingIdFromDb, checkAccessionId, checkSurveyEmailTrigger, checkDerivedVariables, isDeviceMobile, replaceDateInputWithMaskedInput, bagConceptIdList, showModalNotification, showTimedNotifications, showNotificationsCancelOrContinue, validateSpecimenAndParticipantResponse, findReplacementTubeLabels, 
-    showConfirmationModal,
+    showConfirmationModal, dismissBiospecimenModal
 } from './shared.js';
 import { searchTemplate, searchBiospecimenTemplate } from './pages/dashboard.js';
 import { showReportsManifest } from './pages/reportsQuery.js';
@@ -571,10 +571,7 @@ export const addEventCheckInCompleteForm = (isCheckedIn, checkOutFlag) => {
                 hideAnimation();
                 showTimedNotifications({ title: 'Success', body: 'Participant is checked out.' }, 100000, 1500);
                 setTimeout(() => {
-                    const closeButton = document.querySelector('#biospecimenModal .btn[data-dismiss="modal"]');
-                    if (closeButton) {
-                        closeButton.click();
-                    }
+                    dismissBiospecimenModal();
                     checkOutFlag === true ? location.reload() : goToParticipantSearch(); 
                 }, 1500);
             } else {
@@ -611,8 +608,9 @@ export const addEventCheckInCompleteForm = (isCheckedIn, checkOutFlag) => {
  * @param {Object} participantData - participant document data from find participant query
  * @returns {Boolean} - true if participant has any clinical blood or urine collected derivations, false otherwise
 */
-const checkClinicalBloodOrUrineCollected = (participantData) => {
+const checkClinicalBloodOrUrineCollected = (participantData) => {    
     const collectionDetailsBaseline = participantData?.[conceptIds.collectionDetails]?.[conceptIds.baseline.visitId];
+    
     if (!collectionDetailsBaseline) return false;
 
     const collectedBaselineStatuses = [
@@ -623,10 +621,12 @@ const checkClinicalBloodOrUrineCollected = (participantData) => {
         collectionDetailsBaseline?.[conceptIds.clinicalSiteUrineRRLReceived]
     ];
 
-    if (collectedBaselineStatuses.includes(conceptIds.yes)) { 
+    if (collectedBaselineStatuses.includes(conceptIds.yes)) {
         const modalIcon = `<i class="fas fa-exclamation-circle" style="color: red; font-size: 1.4rem;"></i>`
         const bodyMessage = `Check In not allowed, participant already has clinical collection for this timepoint. If you have questions, contact the Connect Biospeicmen Team: <a href="mailto:connectbioteam@nih.gov">connectbioteam@nih.gov</a>.`
+
         showNotifications({ title: `${modalIcon} WARNING`, body: bodyMessage });
+        const biospecimenModal = document.getElementById('biospecimenModal');
         return true;
     }
     return false;
@@ -662,12 +662,15 @@ const handleCheckInModal = async (data, visitConcept, query) => {
         continueButtonText: "Continue to Specimen Link",
     };
 
-    const checkInOnCancel = () => {  };
+    const checkInOnCancel = () => {
+        dismissBiospecimenModal();
+      };
     const checkInOnContinue = async () => {
         try {
             const updatedResponse = await findParticipant(query);
             const updatedData = updatedResponse.data[0];
-    
+
+            dismissBiospecimenModal();
             specimenTemplate(updatedData);
         } catch (error) {
             showNotifications({ title: 'Error', body: 'There was an error checking in the participant. Please try again.' });
@@ -839,7 +842,6 @@ const btnsClicked = async (connectId, formData) => {
     formData[conceptIds.collection.selectedVisit] = formData?.[conceptIds.collection.selectedVisit] || parseInt(getCheckedInVisit(particpantData));
     
     if (!formData?.collectionId) {
-        console.log("Form data to be added:", formData);
         const storeResponse = await storeSpecimen([formData]);  
         if (storeResponse.code === 400) {
             hideAnimation();

--- a/src/events.js
+++ b/src/events.js
@@ -608,7 +608,7 @@ export const addEventCheckInCompleteForm = (isCheckedIn, checkOutFlag) => {
  * @param {Object} participantData - participant document data from find participant query
  * @returns {Boolean} - true if participant has any clinical blood or urine collected derivations, false otherwise
 */
-const checkClinicalBloodOrUrineCollected = (participantData) => {    
+const checkClinicalBloodOrUrineCollected = (participantData) => {
     const collectionDetailsBaseline = participantData?.[conceptIds.collectionDetails]?.[conceptIds.baseline.visitId];
     
     if (!collectionDetailsBaseline) return false;

--- a/src/shared.js
+++ b/src/shared.js
@@ -603,11 +603,11 @@ const closeBiospecimenModal = () => {
 /**
  * Targets close button on biospecimen bootstrap modal and closes it. Can be used to close and dismiss modal for other buttons on the modal.
  * */  
-    export const dismissBiospecimenModal = () => { 
-        const closeButton = document.querySelector('#biospecimenModal .btn[data-dismiss="modal"]');
+export const dismissBiospecimenModal = () => { 
+    const closeButton = document.querySelector('#biospecimenModal .btn[data-dismiss="modal"]');
 
-        if (closeButton) closeButton.click();
-    }
+    if (closeButton) closeButton.click();
+}
 
 export const errorMessage = (id, msg, focus, offset, icon) => {
     const currentElement = document.getElementById(id);

--- a/src/shared.js
+++ b/src/shared.js
@@ -578,10 +578,7 @@ export const showTimedNotifications = (data, zIndex, timeInMilliseconds = 2600) 
 
     // Programmatically close the modal on a timer.
     setTimeout(() => {
-        const closeButton = document.querySelector('#biospecimenModal .btn[data-dismiss="modal"]');
-        if (closeButton) {
-            closeButton.click();
-        }
+        dismissBiospecimenModal()
     }, timeInMilliseconds);
 };
 
@@ -602,6 +599,15 @@ const closeBiospecimenModal = () => {
 
     document.body.classList.remove('modal-open');
 };
+
+/**
+ * Targets close button on biospecimen bootstrap modal and closes it. Can be used to close and dismiss modal for other buttons on the modal.
+ * */  
+    export const dismissBiospecimenModal = () => { 
+        const closeButton = document.querySelector('#biospecimenModal .btn[data-dismiss="modal"]');
+
+        if (closeButton) closeButton.click();
+    }
 
 export const errorMessage = (id, msg, focus, offset, icon) => {
     const currentElement = document.getElementById(id);


### PR DESCRIPTION
This pull request is related to the links below:
- https://github.com/episphere/connect/issues/1004
- https://github.com/episphere/biospecimen/pull/723
- https://github.com/episphere/biospecimen/pull/726


Problem
The Workflow to create the problem. A research user is successfully checked in after clicking on the check-in modal. A user then clicks either the `cancel` button or `continue` button. This does not reset or dismiss the bootstrap modal's class attributes and styling. After clicking either "cancel" or "continue", search a participant that has recorded clinical specimens collected. The check-in block does not appear when the clinical participant searched in the research dashboard workflow. The close button or "X" button properly dismisses/resets the biospecimen modal class attributes and styling.

Code Changes:
- created new function `dismissBiospecimenModal` to target biospecimen modal "close button" to dismiss/reset the modal's class attributes/ styling
- call `dismissBiospecimenModal` when either cancel or continue button is clicked
- replace areas of code with function `dismissBiospecimenModal`

![Screenshot 2024-07-17 at 9 31 41 AM](https://github.com/user-attachments/assets/00f78107-b792-4088-90f9-32df4f9e3119)
