### PR TITLE
Adjust disabled timing of check-in button

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -558,7 +558,6 @@ export const addEventCheckInCompleteForm = (isCheckedIn, checkOutFlag) => {
         e.preventDefault();
         try {
             const btnCheckIn = document.getElementById('checkInComplete');
-            btnCheckIn.disabled = true;
             
             let query = `connectId=${parseInt(form.dataset.connectId)}`;
             
@@ -599,6 +598,8 @@ export const addEventCheckInCompleteForm = (isCheckedIn, checkOutFlag) => {
     
                 await handleCheckInModal(data, visitConcept, query);
             }
+            btnCheckIn.disabled = true;
+            
         } catch (error) {
             const bodyMessage = isCheckedIn ? 'There was an error checking out the participant. Please try again.' : 'There was an error checking in the participant. Please try again.';
             showNotifications({ title: 'Error', body: bodyMessage });

--- a/src/events.js
+++ b/src/events.js
@@ -597,9 +597,8 @@ export const addEventCheckInCompleteForm = (isCheckedIn, checkOutFlag) => {
                 }
     
                 await handleCheckInModal(data, visitConcept, query);
+                btnCheckIn.disabled = true;
             }
-            btnCheckIn.disabled = true;
-            
         } catch (error) {
             const bodyMessage = isCheckedIn ? 'There was an error checking out the participant. Please try again.' : 'There was an error checking in the participant. Please try again.';
             showNotifications({ title: 'Error', body: bodyMessage });


### PR DESCRIPTION
This pull request is related to:
- https://github.com/episphere/connect/issues/1004
- https://github.com/episphere/connect/issues/1004#issuecomment-2237246655

Problem:
The not-allowed cursor on hover appears before the check-in modal appears.

Code change:
- moved `btnCheckIn.disabled = true;` into else block 

