### PR TITLE
Display app version

### DIFF
--- a/appVersion.js
+++ b/appVersion.js
@@ -1,5 +1,3 @@
 const appVersion = {
-    "versionNumber": "v1.4.0"
+    "versionNumber": "v24.7.0"
 }
-
-export default appVersion;

--- a/appVersion.js
+++ b/appVersion.js
@@ -1,0 +1,5 @@
+const appVersion = {
+    "versionNumber": "v1.4.0"
+}
+
+export default appVersion;

--- a/appVersion.js
+++ b/appVersion.js
@@ -1,3 +1,0 @@
-const appVersion = {
-    "versionNumber": "v24.7.0"
-}

--- a/index.html
+++ b/index.html
@@ -100,18 +100,6 @@
             </div>
         </div>
     </footer>
-    <script>
-        if(location.host !== 'biospecimen-myconnect.cancer.gov') {
-            (function () {
-                const sentryScript = document.createElement('script');
-                sentryScript.src = 'https://browser.sentry-cdn.com/6.13.3/bundle.tracing.min.js';
-                document.head.appendChild(sentryScript);
-                sentryScript.addEventListener('load', () => {
-                    Sentry.init({ dsn: 'https://113d31d0985947ae9f1876b0e31209cd@o1088108.ingest.sentry.io/6139072' });
-                })
-            })();
-        }
-    </script> 
     <script src="index.js" type="module"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.3/jquery.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -95,6 +95,7 @@
                         <li class="menu-item"><a class="footer-links" href="http://www.usa.gov/">USA.gov</a></li>
                     </ul>
                     <p class="menu footer-tagline">NIH…Turning Discovery Into Health<sup>®</sup></p>
+                    <p id="appVersion"></p>
                 </div>
             </div>
         </div>

--- a/index.js
+++ b/index.js
@@ -138,26 +138,6 @@ const userLoggedIn = () => {
     });
 };
 
-
-const fetchAppVersionFromCache = async () => {
-    try {
-      const cache = await caches.open('app-version-cache');
-      const response = await cache.match('./appVersion.js');
-  
-      if (!response) return;
-  
-      const appVersionText = await response.text();
-      const versionMatch = appVersionText.match(/"versionNumber":\s*"(.+?)"/);       
-
-      if (!versionMatch) return;
-  
-      return versionMatch[1];
-    } catch (error) {
-      console.error('Error fetching app version:', error);
-      return 'Error fetching version';
-    }
-  }
-
 /**
  * This function is an async function that checks if the service worker is supported by the browser
  * If it is supported, it registers the service worker
@@ -204,3 +184,22 @@ const updateVersionDisplay = async () => {
         versionElement.textContent = versionNumber;
     }
 };
+
+const fetchAppVersionFromCache = async () => {
+    try {
+        const cache = await caches.open('app-version-cache');
+        const response = await cache.match('./appVersion.js');
+
+        if (!response) return;
+
+        const appVersionText = await response.text();
+        const versionMatch = appVersionText.match(/"versionNumber"\s*:\s*"(v\d+\.\d+\.\d+)"/);       
+
+        if (!versionMatch) return;
+
+        return versionMatch[1];
+    } catch (error) {
+        console.error('Error fetching app version:', error);
+        return 'Error fetching version';
+    }
+}

--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ const registerServiceWorker = async () => {
     if ("serviceWorker" in navigator) {
         try {
         const registration = await navigator.serviceWorker.register("./serviceWorker.js");
-        // console.log('Service Worker registered');
+        console.log('Service Worker registered with scope:', registration.scope);
 
         registration.addEventListener('updatefound', () => { // This event fires when a new service worker is found
             const newWorker = registration.installing;

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ const datadogConfig = {
 
 const isLocalDev = location.hostname === 'localhost' || location.hostname === '127.0.0.1';
 
-window.onload = async () => {
+window.onload = () => {
     if(location.host === urls.prod) {
         !firebase.apps.length ? firebase.initializeApp(prodFirebaseConfig()) : firebase.app();
         window.DD_RUM && window.DD_RUM.init({ ...datadogConfig, env: 'prod' });

--- a/index.js
+++ b/index.js
@@ -170,20 +170,11 @@ const registerServiceWorker = async () => {
 */
 const updateVersionDisplay = async () => {
     const versionNumber = await fetchAppVersionFromCache();
-    if (!versionNumber) return;
+    const versionElement = document.getElementById('appVersion');
 
-    let versionElement = document.getElementById('appVersion');
-
-    if (!versionElement) { 
-        const contentWrapper = document.querySelector('.footer-content .content-wrapper');
-        if (!contentWrapper || !versionNumber) return;
-
-        versionElement = document.createElement('p');
-        versionElement.id = 'appVersion';
-        contentWrapper.appendChild(versionElement);
-        versionElement.textContent = versionNumber;
-    }
-};
+    if (!versionNumber || !versionElement) return;
+    versionElement.textContent = `${versionNumber}`;
+    };
 
 const fetchAppVersionFromCache = async () => {
     try {

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ import { collectionIdSearchScreen } from "./src/pages/reports/collectionIdSearch
 import { bptlShipReportsScreen } from "./src/pages/reports/shippingReport.js";
 import { checkOutReportTemplate } from "./src/pages/checkOutReport.js";
 import { dailyReportTemplate } from "./src/pages/dailyReport.js";
+import appVersion from "./appVersion.js";
 
 //test
 
@@ -136,3 +137,13 @@ const userLoggedIn = () => {
         });
     });
 };
+
+(function displayAppVersion() {
+    document.addEventListener('DOMContentLoaded', function() {
+        const contentWrapper = document.querySelector('.footer-content .content-wrapper');
+
+        const newElement = document.createElement('div');
+        newElement.innerHTML = `<p id="appVersion">${appVersion.versionNumber}</p>`;
+        contentWrapper.appendChild(newElement);
+    });
+})();

--- a/index.js
+++ b/index.js
@@ -112,7 +112,6 @@ const manageRoutes = async () => {
         else if (route === "#allParticipants") allParticipantsScreen(auth, route);
         else if (route === "#addressPrinted") addressesPrintedScreen(auth, route);
         else if (route === "#assigned") assignedScreen(auth, route);
-        // else if (route === "#status_shipped") kitStatusReportsShipped(auth, route);
         else if (route === "#received") receivedKitsScreen(auth,route);
         else if (route === "#kitshipment") kitShipmentScreen(auth, route);
         else if (route === "#packagesintransit") packagesInTransitScreen(auth, route);

--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -72,7 +72,7 @@ self.addEventListener('install', (event) => {
                 return cache.keys()
                     .then((keys) => {
                         const deletionPromises = keys
-                            .filter(key => key.url.includes('app-version-cache')) //
+                            .filter(key => key.url.includes('app-version-cache'))
                             .map(key => cache.delete(key));
                             return Promise.all(deletionPromises);
             })

--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -1,19 +1,22 @@
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/5.1.2/workbox-sw.js');
-importScripts('./appVersion.js');
 
+const appVersion = "v24.7.0";
 workbox.setConfig({debug: false});
 const { registerRoute } = workbox.routing;
-const { CacheFirst, NetworkFirst, StaleWhileRevalidate, NetworkOnly } = workbox.strategies;
-const { CacheableResponse, CacheableResponsePlugin } = workbox.cacheableResponse;
+const { CacheFirst, NetworkFirst } = workbox.strategies;
 const { ExpirationPlugin } = workbox.expiration;
-const { BackgroundSyncPlugin } = workbox.backgroundSync
 const googleAnalytics = workbox.googleAnalytics;
+const cacheNameMapper = {
+  "static-cache": `static-cache-${appVersion}`,
+  "images-cache": `images-cache-${appVersion}`,
+};
+const currCacheNameArray = Object.values(cacheNameMapper);
 
 googleAnalytics.initialize();
-registerRoute(/\.(?:js|css)$/, new NetworkFirst({cacheName: 'static-cache'}));
+registerRoute(/\.(?:js|css|html)$/, new NetworkFirst({ cacheName: cacheNameMapper["static-cache"] }));
 registerRoute(/\.(?:png|jpg|jpeg|svg|gif|ico)$/,
     new CacheFirst({
-        cacheName: 'images-cache',
+        cacheName: cacheNameMapper["images-cache"],
         plugins: [
             new ExpirationPlugin({
                 maxEntries: 30,
@@ -23,66 +26,26 @@ registerRoute(/\.(?:png|jpg|jpeg|svg|gif|ico)$/,
     })
 );
 
-registerRoute(
-    new RegExp('https://us-central1-nih-nci-dceg-connect-dev.cloudfunctions.net/.+'),
-    new NetworkFirst({
-        cacheName: 'api-cache',
-        plugins: [
-            new CacheableResponsePlugin({
-                statuses: [200],
-            })
-        ]
-    }),
-    'GET'
-);
-
-
-const bgSyncPlugin = new BackgroundSyncPlugin('connectBiospecimen', {
-    maxRetentionTime: 24 * 60 // Retry for max of 24 Hours (specified in minutes)
+self.addEventListener("install", () => {
+  self.skipWaiting();
 });
 
-registerRoute(
-    new RegExp('https://us-central1-nih-nci-dceg-connect-dev.cloudfunctions.net/.+'),
-    new NetworkOnly({
-      plugins: [bgSyncPlugin]
-    }),
-    'POST'
-);
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((cacheNames) => {
+      return Promise.all(
+        cacheNames.map((cacheName) => {
+          if (!currCacheNameArray.includes(cacheName)) {
+            return caches.delete(cacheName);
+          }
+        })
+      );
+    })
+  );
+});
 
-registerRoute(
-  /index\.html$/,
-  new NetworkFirst({
-    cacheName: 'index-html-cache',
-    networkTimeoutSeconds: 3,
-    plugins: [
-      new CacheableResponsePlugin({
-        statuses: [0, 200],
-      }),
-    ],
-  })
-);
-
-const cacheVersionName = `app-version-cache`;
-const precacheVersionAssets = ['/appVersion.js'];
-
-self.addEventListener('install', (event) => {
-    event.waitUntil(
-        caches.open(cacheVersionName)
-            .then((cache) => {
-                return cache.keys()
-                    .then((keys) => {
-                        const deletionPromises = keys
-                            .filter(key => key.url.includes('app-version-cache'))
-                            .map(key => cache.delete(key));
-                            return Promise.all(deletionPromises);
-            })
-            .then(() => cache.addAll(precacheVersionAssets));
-            })
-            .then(() => {
-                self.skipWaiting(); // Forces the waiting service worker to become the active service worker
-            })
-            .catch(error => {
-                console.error('Cache update failed:', error);
-            })
-    );
+self.addEventListener("message", (event) => {
+  if (event.data.action === "getAppVersion") {
+    event.source.postMessage({ action: "sendAppVersion", payload: appVersion });
+  }
 });

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -473,3 +473,7 @@ box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
     cursor: not-allowed;
     background-color: #e0e0e0;
 }
+
+#appVersion {
+    font-size: 0.8rem;
+}


### PR DESCRIPTION
This pull request is related to the following:
- https://github.com/episphere/connect/issues/621
 
Related pull requests:
- https://github.com/episphere/studyManagerDashboard/pull/3
- https://github.com/episphere/connectApp/pull/813

Problem: Display the app version number

Code changes ([from Warren's push and other small fixes](https://github.com/episphere/biospecimen/pull/730/commits/5ef27c3175a0c44d0ab129e0c44a1a47b58d5034)):
- In `index.html`, script for using sentry removed
- In `index.js`, service worker conditional with listeners to check if service worker is registered and to have main thread and service worker to communicate to get the app version
- In `serviceWorkers.js`, add version number be in a constant; add cache version number in register route for `NetworkFirst` and `CacheFirst` Strategy; include listener to install a new service worker immediately skipping waiting phase , listener to remove old cache when new service worker activates, and event listener to respond to the main thread asking for "getAppVersion" to display version number to footer