### PR TITLE
bptl package form remove event listener from body

### DIFF
--- a/src/pages/siteCollection/packageReceipt.js
+++ b/src/pages/siteCollection/packageReceipt.js
@@ -348,6 +348,7 @@ const unsavedChangesRoutingMessage = (e) => {
         e.preventDefault();
     } else {
         window.removeEventListener("beforeunload", handleBeforeUnload);
+        document.body.removeEventListener('click', checkLinkNavigation);
     }
 };
 
@@ -356,7 +357,7 @@ const unsavedChangesRoutingMessage = (e) => {
  * @param {boolean} isKitReceipt - If true, add event listeners to only kit receipt inputs. If false, add event listeners to all inputs.
 */
 export const addFormInputListenersOnLoad = (isKitReceipt = false) => {
-    let inputChangeCheckList = inputChangeList.filter((input) => isKitReceipt || !input.onlyKitsReceipt);
+    const inputChangeCheckList = inputChangeList.filter((input) => isKitReceipt || !input.onlyKitsReceipt);
 
     inputChangeCheckList.forEach(({ selector, listenerType, customHandler }) => {
         const inputEl = document.getElementById(selector);
@@ -471,12 +472,9 @@ const cancelConfirm = () => {
         const collectionComments = document.getElementById("collectionComments");
         if (collectionComments) collectionComments.value = "";
 
-        
-        const clearButtonEl = document.getElementById("clearForm");
         clearButtonEl.removeEventListener("click", cancelConfirm);
         packageCondition.setAttribute("data-selected","[]")
         
-        window.removeEventListener("beforeunload", handleBeforeUnload);
         window.removeEventListener("beforeunload", handleBeforeUnload);
         setupLeavingPageMessage()
     }
@@ -487,10 +485,9 @@ const cancelConfirm = () => {
  * @param {boolean} hasUnsavedChanges - If true, add event listener to window object. If false, remove event listener from window object.
 */
 const toggleBeforeUnloadListener = (hasUnsavedChanges) => {
+    window.removeEventListener("beforeunload", handleBeforeUnload);
     if (hasUnsavedChanges) {
         window.addEventListener("beforeunload", handleBeforeUnload);
-    } else {
-        window.removeEventListener("beforeunload", handleBeforeUnload);
     }
 };
 


### PR DESCRIPTION
This PR is related to the following links:
- https://github.com/episphere/connect/issues/853

Problem:
When user has unsaved inputs and confirms to navigate away from form page, dialog box persist after navigating page again 

Changes (fix): 
- Remove event listener from body element after user chooses to confirm browser dialog and navigates to another route
- added the remove event listener in `unsavedChangesRoutingMessage` function
- other code cleanup