### PR TITLE
Kit CSV now handles kit level lookup information coming from API (1302)

### DIFF
--- a/src/fieldToConceptIdMapping.js
+++ b/src/fieldToConceptIdMapping.js
@@ -146,6 +146,11 @@ export const conceptIds = {
     bioKitMouthwashBL1: 541483796,
     bioKitMouthwashBL2: 641006239,
 
+    kitLevel: 426588510,
+    initialKit: 663273321,
+    replacementKit1: 389478821,
+    replacementKit2: 772116457,
+
     // Site EMR API Clinical baseline derivations
     clinicalSiteBloodCollected: 693370086,
     clinicalSiteUrineCollected: 786930107,

--- a/src/pages/homeCollection/kitCSV.js
+++ b/src/pages/homeCollection/kitCSV.js
@@ -69,6 +69,11 @@ const getKitsByReceivedDate = async (dateString) => {
 }
 
 const modifyKitQueryResults = (kitsData) => {
+  const kitLevelLookup = {
+    [conceptIds.initialKit]: 'BL',
+    [conceptIds.replacementKit1]: 'BL_1',
+    [conceptIds.replacementKit2]: 'BL_2'
+  }
   const csvKitArray = [];
   kitsData.forEach(kitData => {
     const sampleCollectionCenter = keyToNameCSVObj[kitData[conceptIds.healthcareProvider]];
@@ -83,6 +88,7 @@ const modifyKitQueryResults = (kitsData) => {
     const additivePreservative = vialMappings[1] || '';
     const materialType = vialMappings[2] || '';
     const volume = vialMappings[3] || '';
+    const visit = kitLevelLookup[kitData[conceptIds.kitLevel]] || 'BL';
     const updatedKitResults = {
       'Study ID': 'Connect Study',
       'Sample Collection Center': sampleCollectionCenter,
@@ -101,7 +107,7 @@ const modifyKitQueryResults = (kitsData) => {
       'Vial Warnings': '',
       'Hemolyzed': '',
       'Label Status': 'Barcoded',
-      'Visit': 'BL'
+      'Visit': visit
     }
     csvKitArray.push(updatedKitResults);
   });


### PR DESCRIPTION
Front end work for [1302](https://github.com/episphere/connect/issues/1302). When generating the CSV for kits shipped on a given date, the CSV now can process information from the back end indicating whether it is an initial, first replacement or second replacement kit and appropriately displaying the visit as BL, BL_1 or BL_2.