### PR TITLE
BPTL Receipt CSV File - Add Default to Hemolyzed column

### DIFF
--- a/src/pages/siteCollection/csvFileReceipt.js
+++ b/src/pages/siteCollection/csvFileReceipt.js
@@ -532,7 +532,7 @@ const generateFileToDownload = (blob, title, fileType) => {
  * @param {string} materialType - Material type of the specimen (e.g., "Serum", "Plasma")
  * @returns {string} Corresponding hemolyzed status, or an empty string if not found in the map
 */
-const  getHemolyzedStatus = (materialType) => {
+const getHemolyzedStatus = (materialType) => {
   const statusMap = {
     'Serum': 'not hem (1)',
     'Plasma': 'not hem (1)',


### PR DESCRIPTION
This pull request is related to [issue#1141](https://github.com/episphere/connect/issues/1141):
- https://github.com/episphere/connect/issues/1141

**Requested Changes:**

- In the BPTL CSV file receipt, add "not hem (1)" to the "Hemolyzed" column cells for samples with a "Material Type" value of either "Serum" or "Plasma".

**Code Changes:** 
- Created a `getHemolyzedStatus` function to grab the correct Hemolyzed string value. The function includes a predefined mapping for future material type to hemolyzed status associations.

**Created File using 5/1/2025 date:**

<img width="400" alt="Screenshot 2025-05-30 at 11 49 16 AM" src="https://github.com/user-attachments/assets/a73b1656-4801-4fc3-831b-bf526963bb1b" />
<br>

<img width="300" alt="Screenshot 2025-05-30 at 11 49 16 AM" src="https://github.com/user-attachments/assets/b13c6f89-b6e7-4d28-842a-5b3199a56238" />
