### PR TITLE
Issue#1098 hotfix

### DIFF
--- a/src/pages/homeCollection/kitStatusReports.js
+++ b/src/pages/homeCollection/kitStatusReports.js
@@ -38,7 +38,7 @@ const kitStatusReportsTemplate = async (name) => {
             : ''
         }
 
-        <div id="root root-margin">
+        <div id="tableContainer">
             <div class="table">
                 ${createTableContent(reportsData)}
             </div>
@@ -256,7 +256,7 @@ function filterKitsHandler () {
                 const response = await getParticipantsByKitStatus(kitStatusConceptId, filters);
                 const responseData = response.data;
 
-                document.querySelector("#root .table").innerHTML = createTableContent(responseData);
+                document.querySelector("#tableContainer > .table").innerHTML = createTableContent(responseData);
             } catch (error) {
                 console.error("Error filtering kits:", error);
             } finally { 
@@ -302,7 +302,7 @@ function clearFiltersHandler() {
                 const response = await getParticipantsByKitStatus(kitStatusConceptId);
                 const responseData = response.data;
 
-                document.querySelector("#root .table").innerHTML = createTableContent(responseData);
+                document.querySelector("#tableContainer > .table").innerHTML = createTableContent(responseData);
             } catch (error) {
                 console.error("Error clearing filters:", error);
             } finally {


### PR DESCRIPTION
This pull request is a hotfix for [issue#1098](https://github.com/episphere/connect/issues/1098):

Problem: 
The received kit status report page's filter functionality will break if there is no fetched data. Here is the case scenario of the breaking process. The received kit status page loads for the first time. There is no fetched data (no received kits in the last 7 days). The text "The selected kit status report has no data to display. Please select a different kit status report from the dropdown." will be displayed. The user tries to apply filters to fetch received kits. The apply filter button does not work because the previous `document.querySelector("#kitStatusReportsTable tbody")` is null.

Code Changes:
- Added div with an id `tableContianer` and also a nested div with a class `table` to `kitStatusReportsTemplate` function.
- Created function called `createTableContent` to return a string or the table contents on initial load, apply filters button and clear filters button
- Added `try...catch` to initial fetch for kit status