### PR TITLE
diff - version override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "chai": "^6.0.1",
         "esbuild": "^0.27.2",
-        "esbuild-register": "3.6",
+        "esbuild-register": "^3.6.0",
         "jsdom": "^24.1.3",
         "mocha": "^11.7.2"
       }
@@ -921,9 +921,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
       "dev": true,
       "engines": {
         "node": ">=0.3.1"

--- a/package.json
+++ b/package.json
@@ -20,5 +20,11 @@
     "esbuild-register": "^3.6.0",
     "jsdom": "^24.1.3",
     "mocha": "^11.7.2"
+  },
+  "overridesNote": {
+    "diff": "8.0.3 for GHSA-73rr-hh4g-fpgx"
+  },
+  "overrides": {
+    "diff": "8.0.3"
   }
 }


### PR DESCRIPTION
Alert Addressed: https://github.com/NCI-C4CP/biospecimen/security/dependabot/1

This pull request introduces a security-related dependency override in the `package.json` file to address a known vulnerability. The most important changes are:

Dependency management and security:

* Added an `overrides` section to force the `diff` package to version `8.0.3`, addressing the GHSA-73rr-hh4g-fpgx security advisory.
* Included an `overridesNote` field to document the reason for the override, specifying that it is due to GHSA-73rr-hh4g-fpgx.