### PR TITLE
Issue#1575 duplicate track numbers

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -6,7 +6,7 @@ import {
     convertConceptIdToPackageCondition, checkFedexShipDuplicate, shippingDuplicateMessage, checkInParticipant, checkOutParticipant, getCheckedInVisit, participantCanCheckIn, shippingPrintManifestReminder,
     checkNonAlphanumericStr, shippingNonAlphaNumericStrMessage, visitType, getParticipantCollections, updateBaselineData,
     siteSpecificLocationToConceptId, conceptIdToSiteSpecificLocation, locationConceptIDToLocationMap, translateNumToType,
-    getCollectionsByVisit, getSpecimenAndParticipant, getUserProfile, checkDuplicateTrackingIdFromDb, checkAccessionId, checkSurveyEmailTrigger, checkDerivedVariables, isDeviceMobile, replaceDateInputWithMaskedInput, bagConceptIdList, showModalNotification, showTimedNotifications, showNotificationsCancelOrContinue, validateSpecimenAndParticipantResponse, findReplacementTubeLabels, 
+    getCollectionsByVisit, getSpecimenAndParticipant, getUserProfile, checkDuplicateTrackingIdsFromDb, checkAccessionId, checkSurveyEmailTrigger, checkDerivedVariables, isDeviceMobile, replaceDateInputWithMaskedInput, bagConceptIdList, showModalNotification, showTimedNotifications, showNotificationsCancelOrContinue, validateSpecimenAndParticipantResponse, findReplacementTubeLabels, 
     showConfirmationModal, dismissBiospecimenModal, submitSpecimen, escapeHTML,
     getBagList, getBagConceptId, getBagId
 } from './shared.js';
@@ -1932,20 +1932,34 @@ export const addEventSaveAndContinueButton = async (boxIdAndBagsObj, userName, b
             };
         }
 
-        const isDuplicateTrackingIdInDb = await checkDuplicateTrackingIdFromDb(boxIdArray);
-        if (isDuplicateTrackingIdInDb || (checkFedexShipDuplicate(boxIdArray) && boxIdArray.length > 1)) {
+        if ((checkFedexShipDuplicate(boxIdArray) && boxIdArray.length > 1)) {
             shippingDuplicateMessage();
             return;
-          }
-
-        if (checkNonAlphanumericStr(boxIdArray)) {
-          shippingNonAlphaNumericStrMessage();
-          return;
         }
 
-        localforage.setItem("shipData", shippingData);
-        const shipmentCourier = escapeHTML(document.getElementById('courierSelect').value);
-        finalShipmentTracking({boxIdAndBagsObj, boxIdAndTrackingObj, userName, boxWithTempMonitor, shipmentCourier});
+        if (checkNonAlphanumericStr(boxIdArray)) {
+            shippingNonAlphaNumericStrMessage();
+            return;
+        }
+
+        showAnimation();
+        const getDuplicateTrackingIdsInDb = await checkDuplicateTrackingIdsFromDb(boxIdArray);
+        console.log("🚀 ~ addEventSaveButton ~ getDuplicateTrackingIdsInDb:", getDuplicateTrackingIdsInDb)
+        hideAnimation();
+
+        // extract data 
+        // save immediately if nothing is found 
+        if (getDuplicateTrackingIdsInDb.length === 0) {
+            localforage.setItem("shipData", shippingData); // Save shipping data locally
+            showTimedNotifications({ title: 'Reminder', body: 'Tracking input saved.' });
+            localforage.setItem("shipData", shippingData);
+            const shipmentCourier = escapeHTML(document.getElementById('courierSelect').value);
+            finalShipmentTracking({boxIdAndBagsObj, boxIdAndTrackingObj, userName, boxWithTempMonitor, shipmentCourier});
+        } else {
+            // extract all duplicate tracking IDs
+            const extractDuplicateTrackingIds = getDuplicateTrackingIdsInDb.map(item => item.trackingId);
+            shippingDuplicateMessage(extractDuplicateTrackingIds);
+        }
     })
 
 }
@@ -1956,6 +1970,7 @@ export const addEventSaveButton = async (boxIdAndBagsObj) => {
         let shippingData = [];
         let boxIdAndTrackingObj = {};
         const boxIdArray = Object.keys(boxIdAndBagsObj);
+        console.log("🚀 ~ addEventSaveButton ~ boxIdArray:", boxIdArray)
 
         for (const boxId of boxIdArray) {
             const trackingId = document.getElementById(boxId + "trackingId").value.toUpperCase();
@@ -1978,14 +1993,30 @@ export const addEventSaveButton = async (boxIdAndBagsObj) => {
             return;
         }
 
-        let isDuplicateTrackingIdInDb = await checkDuplicateTrackingIdFromDb(boxIdArray);
-        if(isDuplicateTrackingIdInDb || (checkFedexShipDuplicate(boxIdArray) && boxIdArray.length > 1)){
-            shippingDuplicateMessage(isDuplicateTrackingIdInDb)
-            return
-          }
-          
-        localforage.setItem("shipData", shippingData);
-        showTimedNotifications({ title: 'Reminder', body: 'Tracking input saved.' });
+        // 
+        if ((checkFedexShipDuplicate(boxIdArray) && boxIdArray.length > 1)){
+            // generic message without duplicates from frontend
+            shippingDuplicateMessage();
+            return;
+        }
+
+        // This will need a loading spinner 
+        showAnimation();
+        const getDuplicateTrackingIdsInDb = await checkDuplicateTrackingIdsFromDb(boxIdArray);
+        console.log("🚀 ~ addEventSaveButton ~ getDuplicateTrackingIdsInDb:", getDuplicateTrackingIdsInDb)
+        hideAnimation();
+        
+        // extract data 
+        // save immediately if nothing is found 
+        if (getDuplicateTrackingIdsInDb.length === 0) {
+            localforage.setItem("shipData", shippingData); // Save shipping data locally
+            showTimedNotifications({ title: 'Reminder', body: 'Tracking input saved.' });
+        } else {
+            // extract all duplicate tracking IDs
+            const extractDuplicateTrackingIds = getDuplicateTrackingIdsInDb.map(item => item.trackingId);
+            shippingDuplicateMessage(extractDuplicateTrackingIds);
+            return;
+        }
     })
 }
 

--- a/src/events.js
+++ b/src/events.js
@@ -3,7 +3,7 @@ import {
     errorMessage, removeAllErrors, storeSpecimen, updateSpecimen, searchSpecimen, generateBarCode, updateBox,
     ship, disableInput, updateNewTempDate, getSiteTubesLists, getWorkflow, fixMissingTubeData,
     getSiteCouriers, getPage, getNumPages, removeSingleError, displayManifestContactInfo, checkShipForage, checkAlertState, retrieveDateFromIsoString,
-    convertConceptIdToPackageCondition, checkFedexShipDuplicate, shippingDuplicateMessage, checkInParticipant, checkOutParticipant, getCheckedInVisit, participantCanCheckIn, shippingPrintManifestReminder,
+    convertConceptIdToPackageCondition, checkFedexShipDuplicate, shippingDatabaseDuplicateMessage, shippingInputDuplicateMessage, checkInParticipant, checkOutParticipant, getCheckedInVisit, participantCanCheckIn, shippingPrintManifestReminder,
     checkNonAlphanumericStr, shippingNonAlphaNumericStrMessage, visitType, getParticipantCollections, updateBaselineData,
     siteSpecificLocationToConceptId, conceptIdToSiteSpecificLocation, locationConceptIDToLocationMap, translateNumToType,
     getCollectionsByVisit, getSpecimenAndParticipant, getUserProfile, checkDuplicateTrackingIdsFromDb, checkAccessionId, checkSurveyEmailTrigger, checkDerivedVariables, isDeviceMobile, replaceDateInputWithMaskedInput, bagConceptIdList, showModalNotification, showTimedNotifications, showNotificationsCancelOrContinue, validateSpecimenAndParticipantResponse, findReplacementTubeLabels, 
@@ -1933,7 +1933,7 @@ export const addEventSaveAndContinueButton = async (boxIdAndBagsObj, userName, b
         }
 
         if ((checkFedexShipDuplicate(boxIdArray) && boxIdArray.length > 1)) {
-            shippingDuplicateMessage([]);
+            shippingInputDuplicateMessage();
             return;
         }
 
@@ -1959,7 +1959,7 @@ export const addEventSaveAndContinueButton = async (boxIdAndBagsObj, userName, b
         } else {
             // extract all duplicate tracking IDs
             const extractDuplicateTrackingIds = getDuplicateTrackingIdsInDb.map(item => item.trackingId);
-            shippingDuplicateMessage(extractDuplicateTrackingIds);
+            shippingDatabaseDuplicateMessage(extractDuplicateTrackingIds);
         }
     })
 
@@ -1999,8 +1999,7 @@ export const addEventSaveButton = async (boxIdAndBagsObj) => {
         }
 
         if ((checkFedexShipDuplicate(boxIdArray) && boxIdArray.length > 1)){
-            // generic message without duplicates from frontend
-            shippingDuplicateMessage([]);
+            shippingInputDuplicateMessage();
             return;
         }
 
@@ -2018,7 +2017,7 @@ export const addEventSaveButton = async (boxIdAndBagsObj) => {
             showTimedNotifications({ title: 'Reminder', body: 'Tracking input saved.' });
         } else {
             const extractDuplicateTrackingIds = getDuplicateTrackingIdsInDb.map(item => item.trackingId);
-            shippingDuplicateMessage(extractDuplicateTrackingIds);
+            shippingDatabaseDuplicateMessage(extractDuplicateTrackingIds);
             return;
         }
     })

--- a/src/events.js
+++ b/src/events.js
@@ -1944,13 +1944,10 @@ export const addEventSaveAndContinueButton = async (boxIdAndBagsObj, userName, b
 
         showAnimation();
         const getDuplicateTrackingIdsInDb = await checkDuplicateTrackingIdsFromDb(boxIdArray);
-        console.log("🚀 ~ addEventSaveButton ~ getDuplicateTrackingIdsInDb:", getDuplicateTrackingIdsInDb)
         hideAnimation();
 
-        // extract data 
-        // save immediately if nothing is found 
         if (getDuplicateTrackingIdsInDb.length === 0) {
-            localforage.setItem("shipData", shippingData); // Save shipping data locally
+            localforage.setItem("shipData", shippingData);
             showTimedNotifications({ title: 'Reminder', body: 'Tracking input saved.' });
             localforage.setItem("shipData", shippingData);
             const shipmentCourier = escapeHTML(document.getElementById('courierSelect').value);
@@ -1970,7 +1967,6 @@ export const addEventSaveButton = async (boxIdAndBagsObj) => {
         let shippingData = [];
         let boxIdAndTrackingObj = {};
         const boxIdArray = Object.keys(boxIdAndBagsObj);
-        console.log("🚀 ~ addEventSaveButton ~ boxIdArray:", boxIdArray)
 
         for (const boxId of boxIdArray) {
             const trackingId = document.getElementById(boxId + "trackingId").value.toUpperCase();
@@ -2000,19 +1996,14 @@ export const addEventSaveButton = async (boxIdAndBagsObj) => {
             return;
         }
 
-        // This will need a loading spinner 
         showAnimation();
         const getDuplicateTrackingIdsInDb = await checkDuplicateTrackingIdsFromDb(boxIdArray);
-        console.log("🚀 ~ addEventSaveButton ~ getDuplicateTrackingIdsInDb:", getDuplicateTrackingIdsInDb)
         hideAnimation();
         
-        // extract data 
-        // save immediately if nothing is found 
         if (getDuplicateTrackingIdsInDb.length === 0) {
-            localforage.setItem("shipData", shippingData); // Save shipping data locally
+            localforage.setItem("shipData", shippingData);
             showTimedNotifications({ title: 'Reminder', body: 'Tracking input saved.' });
         } else {
-            // extract all duplicate tracking IDs
             const extractDuplicateTrackingIds = getDuplicateTrackingIdsInDb.map(item => item.trackingId);
             shippingDuplicateMessage(extractDuplicateTrackingIds);
             return;

--- a/src/events.js
+++ b/src/events.js
@@ -1933,7 +1933,7 @@ export const addEventSaveAndContinueButton = async (boxIdAndBagsObj, userName, b
         }
 
         if ((checkFedexShipDuplicate(boxIdArray) && boxIdArray.length > 1)) {
-            shippingDuplicateMessage();
+            shippingDuplicateMessage([]);
             return;
         }
 
@@ -1946,10 +1946,14 @@ export const addEventSaveAndContinueButton = async (boxIdAndBagsObj, userName, b
         const getDuplicateTrackingIdsInDb = await checkDuplicateTrackingIdsFromDb(boxIdArray);
         hideAnimation();
 
+        if (!Array.isArray(getDuplicateTrackingIdsInDb)) {
+            showTimedNotifications({ title: 'Error', body: 'Unable to validate tracking IDs right now. Please try again.' });
+            return;
+        }
+
         if (getDuplicateTrackingIdsInDb.length === 0) {
             localforage.setItem("shipData", shippingData);
             showTimedNotifications({ title: 'Reminder', body: 'Tracking input saved.' });
-            localforage.setItem("shipData", shippingData);
             const shipmentCourier = escapeHTML(document.getElementById('courierSelect').value);
             finalShipmentTracking({boxIdAndBagsObj, boxIdAndTrackingObj, userName, boxWithTempMonitor, shipmentCourier});
         } else {
@@ -1971,6 +1975,11 @@ export const addEventSaveButton = async (boxIdAndBagsObj) => {
         for (const boxId of boxIdArray) {
             const trackingId = document.getElementById(boxId + "trackingId").value.toUpperCase();
             const trackingIdConfirm = document.getElementById(boxId + "trackingIdConfirm").value.toUpperCase();
+
+            if (trackingId === '' || trackingIdConfirm === '') {
+                showNotifications({ title: 'Missing Fields', body: 'Please enter in shipment tracking numbers'});
+                return;
+            }
     
             if (trackingId !== trackingIdConfirm) {
               isMismatch = true;
@@ -1989,10 +1998,9 @@ export const addEventSaveButton = async (boxIdAndBagsObj) => {
             return;
         }
 
-        // 
         if ((checkFedexShipDuplicate(boxIdArray) && boxIdArray.length > 1)){
             // generic message without duplicates from frontend
-            shippingDuplicateMessage();
+            shippingDuplicateMessage([]);
             return;
         }
 
@@ -2000,6 +2008,11 @@ export const addEventSaveButton = async (boxIdAndBagsObj) => {
         const getDuplicateTrackingIdsInDb = await checkDuplicateTrackingIdsFromDb(boxIdArray);
         hideAnimation();
         
+        if (!Array.isArray(getDuplicateTrackingIdsInDb)) {
+            showTimedNotifications({ title: 'Error', body: 'Unable to validate tracking IDs right now. Please try again.' });
+            return;
+        }
+
         if (getDuplicateTrackingIdsInDb.length === 0) {
             localforage.setItem("shipData", shippingData);
             showTimedNotifications({ title: 'Reminder', body: 'Tracking input saved.' });

--- a/src/pages/homeCollection/kitAssembly.js
+++ b/src/pages/homeCollection/kitAssembly.js
@@ -316,6 +316,10 @@ const storeAssembledKit = async (kitData) => {
       alertTemplate('This tracking number has already been used.');
       return false;
     }
+    else if (responseStatus === 'duplicate box tracking number'){
+      alertTemplate('This tracking number has already been used.');
+      return false;
+    }
     else {
       console.error('Response error', responseStatus);
       alertTemplate(`Failed to save the kit.`);

--- a/src/shared.js
+++ b/src/shared.js
@@ -40,8 +40,6 @@ let api = '';
 
 if(location.host === urls.prod) api = 'https://api-myconnect.cancer.gov/biospecimen?';
 else if(location.host === urls.stage) api = 'https://api-myconnect-stage.cancer.gov/biospecimen?';
-//TODO: remove this!! This is for local dev only.
-else if(location.host.startsWith('localhost')) api = 'http://localhost:5001/nih-nci-dceg-connect-dev/us-central1/biospecimen?';
 else api = 'https://us-central1-nih-nci-dceg-connect-dev.cloudfunctions.net/biospecimen?';
 export const baseAPI = api;
 

--- a/src/shared.js
+++ b/src/shared.js
@@ -40,6 +40,8 @@ let api = '';
 
 if(location.host === urls.prod) api = 'https://api-myconnect.cancer.gov/biospecimen?';
 else if(location.host === urls.stage) api = 'https://api-myconnect-stage.cancer.gov/biospecimen?';
+//TODO: remove this!! This is for local dev only.
+else if(location.host.startsWith('localhost')) api = 'http://localhost:5001/nih-nci-dceg-connect-dev/us-central1/biospecimen?';
 else api = 'https://us-central1-nih-nci-dceg-connect-dev.cloudfunctions.net/biospecimen?';
 export const baseAPI = api;
 
@@ -638,7 +640,7 @@ export const shippingPrintManifestReminder = (boxesToShip, userName, tempCheckSt
   })
 }
 
-export const shippingDuplicateMessage = (duplicateIdNumber) => {
+export const shippingDuplicateMessage = (duplicateIdNumbers) => {
   const button = document.createElement('button');
     button.dataset.bsTarget = '#biospecimenModal';
     button.dataset.bsToggle = 'modal';
@@ -648,6 +650,11 @@ export const shippingDuplicateMessage = (duplicateIdNumber) => {
     document.getElementById('root').removeChild(button);
     const header = document.getElementById('biospecimenModalHeader');
     const body = document.getElementById('biospecimenModalBody');
+    const duplicateNumbersText = `
+            <ul>
+            ${duplicateIdNumbers.map(id => `<li>${id}</li>`).join('')}
+            </ul>
+        `;
     header.style.borderBottom = 0;
     header.innerHTML = `<h5 class="modal-title"></h5>
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" style="font-size:2rem;">
@@ -658,7 +665,13 @@ export const shippingDuplicateMessage = (duplicateIdNumber) => {
                 <div style="display:flex; justify-content:center; margin-bottom:1rem;">
                   <i class="fas fa-exclamation-triangle fa-5x" style="color:#ffc107"></i>
                 </div>
-                <p style="text-align:center; font-size:1.4rem; margin-bottom:1.2rem; "><span style="display:block; font-weight:600;font-size:1.8rem; margin-bottom: 0.5rem;">Duplicate Tracking Numbers${duplicateIdNumber ? `[${duplicateIdNumber}]` : ''}</span> Please enter unique Fedex tracking numbers</p>
+                <p style="text-align:center; font-size:1.4rem; margin-bottom:1.2rem; ">
+                    <span style="display:block; font-weight:600;font-size:1.8rem; margin-bottom: 0.5rem;">
+                    Duplicate Tracking Numbers
+                    </span>
+                </p>
+                ${duplicateNumbersText}
+                <p>This tracking number has already been used. Discard the shipping label(s) and use a new one.</p>
             </div>
         </div>
         <div class="row" style="display:flex; justify-content:center;">
@@ -3491,21 +3504,63 @@ export const checkFedexShipDuplicate = (boxes) => {
   let filteredArr = new Set(arr)
   return arr.length !== filteredArr.size
 }
-  
-export const checkDuplicateTrackingIdFromDb = async (boxes) => {
+
+// ORIGINAL COPY
+// export const checkDuplicateTrackingIdFromDb = async (boxes) => {
+//     let isExistingTrackingId = false;
+    
+//     for (const boxId of boxes) {
+    
+//         let trackingId = document.getElementById(`${boxId}trackingId`).value;
+//         let numBoxesShipped = await getNumPages(5, {trackingId});
+//         if (numBoxesShipped > 0) {
+//             isExistingTrackingId = escapeHTML(trackingId);
+//             break;
+//         }
+//     }
+//     return isExistingTrackingId;
+// }
+
+// might be better to rename to getDuplicateTrackingIdFromDb
+export const checkDuplicateTrackingIdsFromDb = async (boxes) => {
+    // create an object to hold trackingIds and is duplicate or not
+    // tracking id variable
     let isExistingTrackingId = false;
-    
-    for (const boxId of boxes) {
-    
-        let trackingId = document.getElementById(`${boxId}trackingId`).value;
-        let numBoxesShipped = await getNumPages(5, {trackingId});
-        if (numBoxesShipped > 0) {
-            isExistingTrackingId = escapeHTML(trackingId);
-            break;
-        }
+    let trackingIdsArray = []
+    let duplicateTrackingIdsArray = []
+
+    console.log(boxes);
+
+    // rewrite above
+
+    const trackingIds = boxes.map(boxId => 
+        document.getElementById(`${boxId}trackingId`).value
+    );
+    console.log("🚀 ~ checkDuplicateTrackingIdFromDb ~ trackingIds:", trackingIds)
+
+    // send all tracking ids to backend and check if they exist in db
+
+    // Create request to send to backend
+    // 'checkDuplicateTrackingId rename?'
+    try {
+        const idToken = await getIdToken();
+        const response = await fetch(`${api}api=checkDuplicateTrackingId`, {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${idToken}`,
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ trackingIds })
+        });
+        const result = await response.json();
+        console.log("🚀 ~ checkDuplicateTrackingIdFromDb ~ result:", result);
+        return result.data;
+    } catch (error) {
+        console.error("Error checking duplicate tracking IDs:", error);
     }
-    return isExistingTrackingId;
-}
+};
+
+
 
 export const checkNonAlphanumericStr = (boxes) => {
   let regExp = /^[a-z0-9]+$/i

--- a/src/shared.js
+++ b/src/shared.js
@@ -3506,7 +3506,7 @@ export const convertConceptIdToPackageCondition = (packagedCondition, packageCon
 
 export const checkFedexShipDuplicate = (boxes) => {
   let arr = []
-  boxes.forEach(boxId => arr.push(document.getElementById(`${boxId}trackingId`).value))
+  boxes.forEach(boxId => arr.push(document.getElementById(`${boxId}trackingId`).value.trim()))
   let filteredArr = new Set(arr)
   return arr.length !== filteredArr.size
 }

--- a/src/shared.js
+++ b/src/shared.js
@@ -3505,43 +3505,11 @@ export const checkFedexShipDuplicate = (boxes) => {
   return arr.length !== filteredArr.size
 }
 
-// ORIGINAL COPY
-// export const checkDuplicateTrackingIdFromDb = async (boxes) => {
-//     let isExistingTrackingId = false;
-    
-//     for (const boxId of boxes) {
-    
-//         let trackingId = document.getElementById(`${boxId}trackingId`).value;
-//         let numBoxesShipped = await getNumPages(5, {trackingId});
-//         if (numBoxesShipped > 0) {
-//             isExistingTrackingId = escapeHTML(trackingId);
-//             break;
-//         }
-//     }
-//     return isExistingTrackingId;
-// }
 
-// might be better to rename to getDuplicateTrackingIdFromDb
 export const checkDuplicateTrackingIdsFromDb = async (boxes) => {
-    // create an object to hold trackingIds and is duplicate or not
-    // tracking id variable
-    let isExistingTrackingId = false;
-    let trackingIdsArray = []
-    let duplicateTrackingIdsArray = []
-
-    console.log(boxes);
-
-    // rewrite above
-
     const trackingIds = boxes.map(boxId => 
         document.getElementById(`${boxId}trackingId`).value
     );
-    console.log("🚀 ~ checkDuplicateTrackingIdFromDb ~ trackingIds:", trackingIds)
-
-    // send all tracking ids to backend and check if they exist in db
-
-    // Create request to send to backend
-    // 'checkDuplicateTrackingId rename?'
     try {
         const idToken = await getIdToken();
         const response = await fetch(`${api}api=checkDuplicateTrackingId`, {
@@ -3553,7 +3521,6 @@ export const checkDuplicateTrackingIdsFromDb = async (boxes) => {
             body: JSON.stringify({ trackingIds })
         });
         const result = await response.json();
-        console.log("🚀 ~ checkDuplicateTrackingIdFromDb ~ result:", result);
         return result.data;
     } catch (error) {
         console.error("Error checking duplicate tracking IDs:", error);

--- a/src/shared.js
+++ b/src/shared.js
@@ -638,7 +638,12 @@ export const shippingPrintManifestReminder = (boxesToShip, userName, tempCheckSt
   })
 }
 
-export const shippingDuplicateMessage = (duplicateIdNumbers) => {
+/**
+ * Displays a modal warning for backend-confirmed duplicate tracking IDs.
+ * @param {Array<string>} duplicateIdNumbers - Duplicate tracking IDs returned from the database validation check.
+ * @returns {void}
+ */
+export const shippingDatabaseDuplicateMessage = (duplicateIdNumbers) => {
     const button = document.createElement('button');
     button.dataset.bsTarget = '#biospecimenModal';
     button.dataset.bsToggle = 'modal';
@@ -684,6 +689,43 @@ export const shippingDuplicateMessage = (duplicateIdNumbers) => {
         </div>
         `;
 }
+
+/**
+ * Prior to database duplicate validation, displays a modal warning for duplicate tracking numbers in the input.
+ * @returns {void}
+*/
+export const shippingInputDuplicateMessage = () => {
+    const button = document.createElement('button');
+    button.dataset.bsTarget = '#biospecimenModal';
+    button.dataset.bsToggle = 'modal';
+
+    document.getElementById('root').appendChild(button);
+    button.click();
+    document.getElementById('root').removeChild(button);
+    const header = document.getElementById('biospecimenModalHeader');
+    const body = document.getElementById('biospecimenModalBody');
+    header.innerHTML = `<h5 class="modal-title"></h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" style="font-size:2rem;">
+                        </button>`;
+    body.innerHTML = `
+        <div class="row">
+            <div class="col">
+                <div style="display:flex; justify-content:center; margin-bottom:1rem;">
+                    <i class="fas fa-exclamation-triangle fa-5x" style="color:#ffc107"></i>
+                </div>
+                <p style="text-align:center; font-size:1.4rem; margin-bottom:1.2rem; ">
+                    <span style="display:block; font-weight:600;font-size:1.8rem; margin-bottom: 0.5rem;">
+                        Duplicate Tracking Numbers
+                    </span>
+                </p>
+                <p>There are duplicate tracking numbers in the input. Please correct them before proceeding.</p>
+            </div>
+        </div>
+        <div class="row" style="display:flex; justify-content:center;">
+            <button id="shipManifestConfirm" type="button" class="btn btn-secondary col-auto" data-bs-dismiss="modal" aria-label="Close" style="margin-right:4%; padding:6px 25px;">Close</button>
+        </div>
+        `;
+};
 
 export const shippingNonAlphaNumericStrMessage = () => {
   const button = document.createElement('button');

--- a/src/shared.js
+++ b/src/shared.js
@@ -639,7 +639,7 @@ export const shippingPrintManifestReminder = (boxesToShip, userName, tempCheckSt
 }
 
 export const shippingDuplicateMessage = (duplicateIdNumbers) => {
-  const button = document.createElement('button');
+    const button = document.createElement('button');
     button.dataset.bsTarget = '#biospecimenModal';
     button.dataset.bsToggle = 'modal';
 
@@ -650,9 +650,16 @@ export const shippingDuplicateMessage = (duplicateIdNumbers) => {
     const body = document.getElementById('biospecimenModalBody');
     const duplicateNumbersText = `
             <ul>
-            ${duplicateIdNumbers.map(id => `<li>${id}</li>`).join('')}
+            ${duplicateIdNumbers.map(id => `<li>${escapeHTML(id)}</li>`).join('')}
             </ul>
         `;
+    let message = '';
+    const duplicateCount = duplicateIdNumbers.length;
+    if (duplicateCount === 1) {
+        message = `This tracking number has already been used. Discard the shipping label and use a new one.`;
+    } else {
+        message = `These tracking numbers have already been used. Discard the shipping labels and use new ones.`;
+    }
     header.style.borderBottom = 0;
     header.innerHTML = `<h5 class="modal-title"></h5>
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" style="font-size:2rem;">
@@ -661,20 +668,21 @@ export const shippingDuplicateMessage = (duplicateIdNumbers) => {
         <div class="row">
             <div class="col">
                 <div style="display:flex; justify-content:center; margin-bottom:1rem;">
-                  <i class="fas fa-exclamation-triangle fa-5x" style="color:#ffc107"></i>
+                    <i class="fas fa-exclamation-triangle fa-5x" style="color:#ffc107"></i>
                 </div>
                 <p style="text-align:center; font-size:1.4rem; margin-bottom:1.2rem; ">
                     <span style="display:block; font-weight:600;font-size:1.8rem; margin-bottom: 0.5rem;">
-                    Duplicate Tracking Numbers
+                        ${duplicateCount === 1 ? `Duplicate Tracking Number` : `Duplicate Tracking Numbers`}
                     </span>
                 </p>
                 ${duplicateNumbersText}
-                <p>This tracking number has already been used. Discard the shipping label(s) and use a new one.</p>
+                <p>${message}</p>
             </div>
         </div>
         <div class="row" style="display:flex; justify-content:center;">
-          <button id="shipManifestConfirm" type="button" class="btn btn-secondary col-auto" data-bs-dismiss="modal" aria-label="Close" style="margin-right:4%; padding:6px 25px;">Close</button>
-        </div>`;
+            <button id="shipManifestConfirm" type="button" class="btn btn-secondary col-auto" data-bs-dismiss="modal" aria-label="Close" style="margin-right:4%; padding:6px 25px;">Close</button>
+        </div>
+        `;
 }
 
 export const shippingNonAlphaNumericStrMessage = () => {
@@ -3518,6 +3526,10 @@ export const checkDuplicateTrackingIdsFromDb = async (boxes) => {
             },
             body: JSON.stringify({ trackingIds })
         });
+        if (!response.ok) {
+            throw new Error(`Failed to check duplicate tracking IDs: ${response.status} ${response.statusText}`);
+        }
+
         const result = await response.json();
         return result.data;
     } catch (error) {


### PR DESCRIPTION
A PR for [issue#1575](https://github.com/episphere/connect/issues/1575).
- https://github.com/episphere/connect/issues/1575

Requested Changes:
- Prevent duplicate tracking numbers from getting saved
- In Shipping dashboard have box tracking "save" check existing "tracking numbers" for all sites in `(959708259) BioPack_TrackScan1_v1r0`, `(531858099) BioKit_SupplyKitTrack_v1r0 (Supply Kit USPS/FedEx Tracking Number for outbound mouthwash supply kit)`, and `<972453354> BioKit_ReturnKitTrack_v1r0 (Return Kit Tracking Number)`
- In BPTL's Kit Assembly have the form prevent already existing return kit tracking number, supply kit tracking number, and boxes's tracking
- In BPTL's Assign Kits have the form prevent already existing return kit tracking number, supply kit tracking number, and boxes's tracking