### PR TITLE
Issue#1620 Add package condition to received kit reports

### DIFF
--- a/src/pages/homeCollection/kitStatusReports.js
+++ b/src/pages/homeCollection/kitStatusReports.js
@@ -452,49 +452,50 @@ export const kitStatusSelectionOptions = {
         queryParam: 'status=received',
         columns: [
             {
-            header: 'Connect ID',
-            key: 'Connect_ID'
+                header: 'Connect ID',
+                key: 'Connect_ID'
             },
             {
-            header: 'Collection ID',
-            key: conceptIds.collectionCardId
+                header: 'Collection ID',
+                key: conceptIds.collectionCardId
             },
             {
-            header: 'Date Received',
-            key: conceptIds.receivedDateTime,
-            renderer: (dataRow) => {
-                const isoDate = dataRow[conceptIds.receivedDateTime];
-                if (!isoDate) return '';
-                return convertISODateTime(isoDate).split(/\s+/)[0]
-                }
-            },
-            {
-            header: 'Return Kit Tracking Number',
-            key: conceptIds.returnKitTrackingNum
-            },
-            {
-            header: 'Kit Type (Initial, 2nd, 3rd)',
-            key: conceptIds.kitLevel,
-            renderer: (dataRow) => {
-                    const kitLevelMap = {
-                        [conceptIds.initialKit]: 'Initial',
-                        [conceptIds.replacementKit1]: '2nd',
-                        [conceptIds.replacementKit2]: '3rd'
+                header: 'Date Received',
+                key: conceptIds.receivedDateTime,
+                renderer: (dataRow) => {
+                    const isoDate = dataRow[conceptIds.receivedDateTime];
+                    if (!isoDate) return '';
+                    return convertISODateTime(isoDate).split(/\s+/)[0]
                     }
-                    return kitLevelMap[dataRow[conceptIds.kitLevel]] || '';
-                }
+            },
+            {
+                header: 'Return Kit Tracking Number',
+                key: conceptIds.returnKitTrackingNum
+            },
+            {
+                header: 'Kit Type (Initial, 2nd, 3rd)',
+                key: conceptIds.kitLevel,
+                renderer: (dataRow) => {
+                        const kitLevelMap = {
+                            [conceptIds.initialKit]: 'Initial',
+                            [conceptIds.replacementKit1]: '2nd',
+                            [conceptIds.replacementKit2]: '3rd'
+                        }
+                        return kitLevelMap[dataRow[conceptIds.kitLevel]] || '';
+                    }
             },
             {
                 header: 'Package Condition',
                 key: conceptIds.pkgReceiptConditions,
                 renderer: (dataRow) => {
-                    const packageConditions = dataRow[conceptIds.pkgReceiptConditions];
-                    let fullString  = ''
-                    for (const condition of packageConditions) {
-                        // loop through each condition and add to fullString
-                        fullString += `${packageConditionConversion[condition]}, ` || '';
-                    }
-                    return fullString.slice(0, -2); // remove the trailing comma and space on last condition
+                    const packageConditions = Array.isArray(dataRow[conceptIds.pkgReceiptConditions])
+                        ? dataRow[conceptIds.pkgReceiptConditions]
+                        : [];
+
+                    return packageConditions
+                        .map((condition) => packageConditionConversion[condition] || '')
+                        .filter(Boolean)
+                        .join(', ');
                 }
             }
         ]

--- a/src/pages/homeCollection/kitStatusReports.js
+++ b/src/pages/homeCollection/kitStatusReports.js
@@ -497,9 +497,6 @@ export const kitStatusSelectionOptions = {
                     return fullString.slice(0, -2); // remove the trailing comma and space on last condition
                 }
             }
-
         ]
     }
 };
-
-// packageConditionConversion

--- a/src/pages/homeCollection/kitStatusReports.js
+++ b/src/pages/homeCollection/kitStatusReports.js
@@ -2,7 +2,7 @@ import { showAnimation, hideAnimation, getParticipantsByKitStatus, convertISODat
 import { displayKitStatusReportsHeader } from "./participantSelectionHeaders.js";
 import { nonUserNavBar } from "../../navbar.js";
 import { activeHomeCollectionNavbar } from "./homeCollectionNavbar.js";
-import { conceptIds } from "../../fieldToConceptIdMapping.js";
+import { conceptIds, packageConditionConversion } from "../../fieldToConceptIdMapping.js";
 
 export const displayKitStatusReportsScreen = async (auth) => {
     const user = auth.currentUser;
@@ -483,7 +483,23 @@ export const kitStatusSelectionOptions = {
                     }
                     return kitLevelMap[dataRow[conceptIds.kitLevel]] || '';
                 }
+            },
+            {
+                header: 'Package Condition',
+                key: conceptIds.pkgReceiptConditions,
+                renderer: (dataRow) => {
+                    const packageConditions = dataRow[conceptIds.pkgReceiptConditions];
+                    let fullString  = ''
+                    for (const condition of packageConditions) {
+                        // loop through each condition and add to fullString
+                        fullString += `${packageConditionConversion[condition]}, ` || '';
+                    }
+                    return fullString.slice(0, -2); // remove the trailing comma and space on last condition
+                }
             }
+
         ]
     }
 };
+
+// packageConditionConversion


### PR DESCRIPTION
PR for issue#1620
- https://github.com/episphere/connect/issues/1620

Code Changes:
- Added to the `kitStatusSelectionOptions ` object to display a new column to the Received Kit Reports page


NOTE: This is for May release cycle (05/2026) and will be assigned when May cycle begins