### PR TITLE
Issue#1735

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ import { collectionIdSearchScreen } from "./src/pages/siteCollection/collectionI
 import { bptlShipReportsScreen } from "./src/pages/siteCollection/shippingReport.js";
 import { checkOutReportTemplate } from "./src/pages/checkOutReport.js";
 import { dailyReportTemplate } from "./src/pages/dailyReport.js";
+import { unfinalizedBoxesReportTemplate } from "./src/pages/unfinalizedBoxesReport.js";
 
 if ("serviceWorker" in navigator) {
     navigator.serviceWorker
@@ -130,6 +131,7 @@ const manageRoutes = async () => {
         else if (route === "#reports") reportsQuery(auth, route);
         else if (route === "#checkoutReport") checkOutReportTemplate(auth, route);
         else if (route === "#dailyReport") dailyReportTemplate(auth, route);
+        else if (route === "#unfinalizedBoxesReport") unfinalizedBoxesReportTemplate(auth, route);
         else if (route === "#bptlShipReports") bptlShipReportsScreen(auth, route);
         else if (route === "#sign_out") signOut();
         else window.location.hash = "#welcome";

--- a/src/navbar.js
+++ b/src/navbar.js
@@ -127,6 +127,9 @@ export const reportSideNavBar = () => {
             <li class="nav-item">
                 <a class="nav-link" href="#dailyReport" id="navBarDailyReport">Daily Review Report</a>
             </li>
+            <li class="nav-item">
+                <a class="nav-link" href="#unfinalizedBoxesReport" id="navBarUnfinalizedBoxesReport">Unfinalized Boxes Report</a>
+            </li>
         </ul>`;
 }
 

--- a/src/pages/unfinalizedBoxesReport.js
+++ b/src/pages/unfinalizedBoxesReport.js
@@ -1,0 +1,111 @@
+import { 
+    userAuthorization, 
+    removeActiveClass, 
+    hideAnimation, 
+    showAnimation, 
+    findParticipant, 
+    convertISODateTimeToLocal, 
+    restrictNonBiospecimenUser, 
+    showNotifications,
+    locationConceptIDToLocationMap,
+    getBoxes } from "./../shared.js"
+import { homeNavBar, reportSideNavBar } from '../navbar.js';
+import { conceptIds } from "../fieldToConceptIdMapping.js";
+
+export const unfinalizedBoxesReportTemplate = (auth, route) => {
+    auth.onAuthStateChanged(async user => {
+        if (user){
+            const response = await userAuthorization(route, user.displayName ? user.displayName : user.email);
+            if (response.isBiospecimenUser === false ) {
+                restrictNonBiospecimenUser();
+                return;
+            }
+            document.getElementById('contentBody').innerHTML = await createUnfinalizedBoxesReport(); // Creates entire page for unfinalized boxes report
+        
+        // Remove active class from nav link and add active class to unfinalized boxes report nav link
+        removeActiveClass('nav-link', 'active');
+        const navBarBtn = document.getElementById('navBarUnfinalizedBoxesReport');
+        navBarBtn.classList.add('active');
+        } else {
+            window.location.hash = '#';
+        }
+    });
+}
+
+export const createUnfinalizedBoxesReport = async () => {
+    // Data fetching function
+    try {
+        const boxesResponse = await getBoxes();
+        console.log("🚀 ~ createUnfinalizedBoxesReport ~ boxesResponse:", boxesResponse)
+        const boxes = boxesResponse.data;
+
+        // Add main container here
+        return `
+            <div class="container">
+                <div class="row">
+                    <div class="col-2">
+                        <h2>Reports</h2>
+                        ${reportSideNavBar()}
+                    </div>
+                    <div class="col-10">
+                        <!-- Table for unfinalized boxes report -->
+                        <table class="table table-bordered" id="unfinalizedBoxesReportTable">
+                            ${createBoxReportHeaders(boxReportHeaders)}
+                            ${createBoxReportRows(boxes)}
+                        </table>
+                    </div>
+                </div>
+            </div>
+        `;
+    } catch (error) {
+        console.error("Error creating unfinalized boxes report:", error);
+        showNotifications("Error creating unfinalized boxes report", "danger");
+    } finally {
+        hideAnimation();
+    }
+};
+
+const boxReportHeaders = [
+    "Shipping Location",
+    "Box ID",
+    "Started",
+    "Go to Shipping"
+];
+
+const createBoxReportHeaders = (boxReportHeaders) => { 
+    // Create table headers for the unfinalized boxes report
+    return `
+        <thead>
+            <tr>
+                ${boxReportHeaders.map(header => `<th scope="col">${header}</th>`).join('')}
+            </tr>
+        </thead>
+    `
+};
+
+const createBoxReportRows = (boxes) => {
+    const shippingRoute = "#shipping";
+
+    return `
+        <tbody>
+            ${boxes.map(box => {
+                const shippingLocation = locationConceptIDToLocationMap[box[conceptIds.shippingLocation]];
+                const boxId = box[conceptIds.shippingBoxId];
+                const startedTimestamp = convertISODateTimeToLocal(box[conceptIds.firstBagAddedToBoxTimestamp]).split(/\s+/, 1)[0] ?? '';
+
+                console.log("🚀 ~ createBoxReportRows ~ shippingLocation:", shippingLocation)
+                console.log("🚀 ~ createBoxReportRows ~ boxId:", boxId)
+                console.log("🚀 ~ createBoxReportRows ~ startedTimestamp:", startedTimestamp)
+
+                return `
+                    <tr>
+                        <td>${shippingLocation}</td>
+                        <td>${boxId}</td>
+                        <td>${startedTimestamp}</td>
+                        <td><a href="${shippingRoute}" class="btn btn-primary">Go to Shipping</a></td>
+                    </tr>
+                ` 
+            }).join('')}
+        </tbody>
+    `
+};


### PR DESCRIPTION
PR for issue#1735
- https://github.com/episphere/connect/issues/1735

Requirements: 
- Add new Unfinalized Box Reports to Biospecimen's report page to display boxes not yet finalized in the shipping dashboard.
- Make not yet finalized boxes viewable to their respective sites

Edit: Make unfinalized boxes with added bag(s) **only**, created boxes with no bags/ tubes collected should be **excluded**

Code Changes:

- Added `Unfinalized Box Reports` to side navbar
- Added new route `#unfinalizedBoxesReport` 
- Created new Unfinalized Box Reports page and table
- Added test coverage for Unfinalized Box Reports page